### PR TITLE
fix: total commits count

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -189,6 +189,7 @@ module.exports = async (req, res) => {
 
   const stats = await fetchStats(username);
 
+  res.setHeader('Cache-Control', 'public, max-age=300');
   res.setHeader("Content-Type", "image/svg+xml");
   res.send(
     renderSVG(stats, {

--- a/api/pin.js
+++ b/api/pin.js
@@ -120,6 +120,7 @@ module.exports = async (req, res) => {
 
   const repoData = await fetchRepo(username, repo);
 
+  res.setHeader('Cache-Control', 'public, max-age=300');
   res.setHeader("Content-Type", "image/svg+xml");
   res.send(renderRepoCard(repoData));
 };


### PR DESCRIPTION
So as i mentioned in #14 that github api only return commits of 1 year max. what i did is that fetched all user years and then looped through that and made a graphql request for each year 

```gql
    data: {
          query: `
          query userInfo($login: String!, $from: DateTime!, $to: DateTime!) {
            user(login: $login) {
              contributionsCollection(from: $from, to: $to) {
                totalCommitContributions
              }
            }
          }
        `,
          variables: {
            login: username,
            from: currentDate.toISOString(), // current year
            to: nextDate.toISOString(), // next year
          },
        },
```

TODO: perf improvement?