### PR TITLE
Add cache to function response

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -189,7 +189,7 @@ module.exports = async (req, res) => {
 
   const stats = await fetchStats(username);
 
-  res.setHeader('Cache-Control', 's-maxage=300');
+  res.setHeader('Cache-Control', 'public, max-age=300');
   res.setHeader("Content-Type", "image/svg+xml");
   res.send(
     renderSVG(stats, {

--- a/api/index.js
+++ b/api/index.js
@@ -189,7 +189,7 @@ module.exports = async (req, res) => {
 
   const stats = await fetchStats(username);
 
-  res.setHeader('Cache-Control', 's-maxage=3600');
+  res.setHeader('Cache-Control', 's-maxage=300');
   res.setHeader("Content-Type", "image/svg+xml");
   res.send(
     renderSVG(stats, {

--- a/api/index.js
+++ b/api/index.js
@@ -189,6 +189,7 @@ module.exports = async (req, res) => {
 
   const stats = await fetchStats(username);
 
+  res.setHeader('Cache-Control', 's-maxage=3600');
   res.setHeader("Content-Type", "image/svg+xml");
   res.send(
     renderSVG(stats, {

--- a/api/pin.js
+++ b/api/pin.js
@@ -120,6 +120,7 @@ module.exports = async (req, res) => {
 
   const repoData = await fetchRepo(username, repo);
 
+  res.setHeader('Cache-Control', 'public, max-age=300');
   res.setHeader("Content-Type", "image/svg+xml");
   res.send(renderRepoCard(repoData));
 };


### PR DESCRIPTION
I tried adding a cache (1h, but can be changed) to help with the commit count problem. It reduced Anshuman Verma's request from 4.5s avg to 185s avg in subsequent requests. The first request took a bit longer. 
This approach has a problem, though. The stats will only refresh once the cache max-age has expired, I guess it's not that big of a deal, shield.io and similar tend to have cache in place.