### PR TITLE
fix: fixed total stars count stat

### DIFF
--- a/src/fetchStats.js
+++ b/src/fetchStats.js
@@ -21,7 +21,7 @@ async function fetchStats(username) {
           issues(first: 100) {
             totalCount
           }
-          repositories(first: 100) {
+          repositories(first: 100, orderBy: { direction: DESC, field: STARGAZERS }) {
             nodes {
               stargazers {
                 totalCount
@@ -31,7 +31,7 @@ async function fetchStats(username) {
         }
       }
     `,
-    variables: { login: username }
+    variables: { login: username },
   });
 
   const stats = {


### PR DESCRIPTION
Total stars count was missing lot of repos because github's limitation to fetch 100max repos but i solved it by sorting the repos by `STARGAZER` count