### PR TITLE
Change A++ to A+ and A+ to A

### DIFF
--- a/src/calculateRank.js
+++ b/src/calculateRank.js
@@ -78,10 +78,10 @@ function calculateRank({
     normalizedScore >= RANK_DOUBLE_A_VALUE &&
     normalizedScore < RANK_A2_VALUE
   ) {
-    level = "A++";
+    level = "A+";
   }
   if (normalizedScore >= RANK_A2_VALUE && normalizedScore < RANK_A3_VALUE) {
-    level = "A+";
+    level = "A";
   }
   if (normalizedScore >= RANK_A3_VALUE && normalizedScore < RANK_B_VALUE) {
     level = "B+";

--- a/tests/calculateRank.test.js
+++ b/tests/calculateRank.test.js
@@ -13,6 +13,6 @@ describe("Test calculateRank", () => {
         prs: 300,
         issues: 200,
       })
-    ).toStrictEqual({ level: "A+", score: 49.16605417270399 });
+    ).toStrictEqual({ level: "A", score: 49.16605417270399 });
   });
 });


### PR DESCRIPTION
A and S rank should be aligned. So it should either be S++, S+ and A++, A+ or S+, S and A+, A. Is there a reason that this is done in a different way?