### PR TITLE
Added proper apostrophe in stats card's header

### DIFF
--- a/src/renderStatsCard.js
+++ b/src/renderStatsCard.js
@@ -124,9 +124,11 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
   });
 
   // Conditionally rendered elements
+
+  const apostrophe = ["x", "s"].includes(name.slice(-1)) ? "" : "s";
   const title = hide_title
     ? ""
-    : `<text x="25" y="35" class="header">${name}'s GitHub Stats</text>`;
+    : `<text x="25" y="35" class="header">${name}'${apostrophe} GitHub Stats</text>`;
 
   const border = hide_border
     ? ""

--- a/tests/renderStatsCard.test.js
+++ b/tests/renderStatsCard.test.js
@@ -39,6 +39,20 @@ describe("Test renderStatsCard", () => {
     expect(queryByTestId(document.body, "rank-circle")).toBeInTheDocument();
   });
 
+  it("should have proper name apostrophe", () => {
+    document.body.innerHTML = renderStatsCard({ ...stats, name: "Anil Das" });
+
+    expect(document.getElementsByClassName("header")[0].textContent).toBe(
+      "Anil Das' GitHub Stats"
+    );
+
+    document.body.innerHTML = renderStatsCard({ ...stats, name: "Felix" });
+
+    expect(document.getElementsByClassName("header")[0].textContent).toBe(
+      "Felix' GitHub Stats"
+    );
+  });
+
   it("should hide individual stats", () => {
     document.body.innerHTML = renderStatsCard(stats, {
       hide: "['issues', 'prs', 'contribs']",


### PR DESCRIPTION
this PR focuses on two things:

- if the user's name ends with an `s`, no longer add `'s` at the end
- fix an issue where `GITHUB_TOKEN` from the env variables would no longer be respected, instead attempting to use ``process.env[`PAT_${retries + 1}`]`` &mdash; #58 