### PR TITLE
Add gh-index field to stats

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "jest": "^26.1.0"
   },
   "dependencies": {
-    "dotenv": "^8.2.0"
+    "dotenv": "^8.2.0",
+    "h-index": "^1.1.0"
   }
 }

--- a/src/calculateRank.js
+++ b/src/calculateRank.js
@@ -17,6 +17,7 @@ function normalcdf(mean, sigma, to) {
 }
 
 function calculateRank({
+  ghIndex,
   totalRepos,
   totalCommits,
   contributions,
@@ -25,6 +26,7 @@ function calculateRank({
   issues,
   stargazers,
 }) {
+  const GHINDEX_OFFSET = 12;
   const COMMITS_OFFSET = 1.65;
   const CONTRIBS_OFFSET = 1.65;
   const ISSUES_OFFSET = 1;
@@ -34,6 +36,7 @@ function calculateRank({
   const REPO_OFFSET = 1;
 
   const ALL_OFFSETS =
+    GHINDEX_OFFSET +
     CONTRIBS_OFFSET +
     ISSUES_OFFSET +
     STARS_OFFSET +
@@ -52,6 +55,7 @@ function calculateRank({
 
   // prettier-ignore
   const score = (
+    ghIndex * ghIndex * GHINDEX_OFFSET +
     totalCommits * COMMITS_OFFSET +
     contributions * CONTRIBS_OFFSET +
     issues * ISSUES_OFFSET +

--- a/src/fetchStats.js
+++ b/src/fetchStats.js
@@ -2,6 +2,7 @@ const { request } = require("./utils");
 const retryer = require("./retryer");
 const calculateRank = require("./calculateRank");
 require("dotenv").config();
+const hIndex = require("h-index");
 
 const fetcher = (variables, token) => {
   return request(
@@ -50,6 +51,7 @@ async function fetchStats(username) {
 
   const stats = {
     name: "",
+    ghIndex: 0,
     totalPRs: 0,
     totalCommits: 0,
     totalIssues: 0,
@@ -68,6 +70,7 @@ async function fetchStats(username) {
   const user = res.data.data.user;
 
   stats.name = user.name || user.login;
+  stats.ghIndex = hIndex(user.repositories.nodes.map((n) => n.stargazers.totalCount)).h;
   stats.totalIssues = user.issues.totalCount;
   stats.totalCommits = user.contributionsCollection.totalCommitContributions;
   stats.totalPRs = user.pullRequests.totalCount;

--- a/src/fetchStats.js
+++ b/src/fetchStats.js
@@ -81,6 +81,7 @@ async function fetchStats(username) {
   }, 0);
 
   stats.rank = calculateRank({
+    ghIndex: stats.ghIndex,
     totalCommits: stats.totalCommits,
     totalRepos: user.repositories.totalCount,
     followers: user.followers.totalCount,

--- a/src/renderStatsCard.js
+++ b/src/renderStatsCard.js
@@ -22,6 +22,7 @@ const createTextNode = ({ icon, label, value, id, index, lineHeight }) => {
 const renderStatsCard = (stats = {}, options = { hide: [] }) => {
   const {
     name,
+    ghIndex,
     totalStars,
     totalCommits,
     totalIssues,
@@ -49,6 +50,12 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
   const bgColor = fallbackColor(bg_color, "#FFFEFE");
 
   const STATS = {
+    index: {
+      icon: "ｈ",
+      label: "h-index",
+      value: ghIndex,
+      id: "index",
+    },
     stars: {
       icon: "★",
       label: "Total Stars",

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -8,6 +8,7 @@ const calculateRank = require("../src/calculateRank");
 
 const stats = {
   name: "Anurag Hazra",
+  ghIndex: 1,
   totalStars: 100,
   totalCommits: 200,
   totalIssues: 300,

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -17,6 +17,7 @@ const stats = {
   rank: null,
 };
 stats.rank = calculateRank({
+  ghIndex: stats.ghIndex,
   totalCommits: stats.totalCommits,
   totalRepos: 1,
   followers: 0,

--- a/tests/calculateRank.test.js
+++ b/tests/calculateRank.test.js
@@ -5,6 +5,7 @@ describe("Test calculateRank", () => {
   it("should calculate rank correctly", () => {
     expect(
       calculateRank({
+        ghIndex: 4,
         totalCommits: 100,
         totalRepos: 5,
         followers: 100,
@@ -13,6 +14,6 @@ describe("Test calculateRank", () => {
         prs: 300,
         issues: 200,
       })
-    ).toStrictEqual({ level: "A+", score: 49.16605417270399 });
+    ).toStrictEqual({ level: "A+", score: 51.11796226386711 });
   });
 });

--- a/tests/fetchStats.test.js
+++ b/tests/fetchStats.test.js
@@ -16,11 +16,11 @@ const data = {
       repositories: {
         totalCount: 5,
         nodes: [
-          { stargazers: { totalCount: 100 } },
+          { stargazers: { totalCount: 146 } },
           { stargazers: { totalCount: 100 } },
           { stargazers: { totalCount: 100 } },
           { stargazers: { totalCount: 50 } },
-          { stargazers: { totalCount: 50 } },
+          { stargazers: { totalCount: 4 } },
         ],
       },
     },
@@ -62,6 +62,7 @@ describe("Test fetchStats", () => {
     expect(stats).toStrictEqual({
       contributedTo: 61,
       name: "Anurag Hazra",
+      ghIndex: 4,
       totalCommits: 100,
       totalIssues: 200,
       totalPRs: 300,

--- a/tests/fetchStats.test.js
+++ b/tests/fetchStats.test.js
@@ -50,6 +50,7 @@ describe("Test fetchStats", () => {
 
     let stats = await fetchStats("anuraghazra");
     const rank = calculateRank({
+      ghIndex: 4,
       totalCommits: 100,
       totalRepos: 5,
       followers: 100,

--- a/tests/renderStatsCard.test.js
+++ b/tests/renderStatsCard.test.js
@@ -24,7 +24,7 @@ describe("Test renderStatsCard", () => {
 
     expect(
       document.body.getElementsByTagName("svg")[0].getAttribute("height")
-    ).toBe("195");
+    ).toBe("220");
     expect(getByTestId(document.body, "stars").textContent).toBe("100");
     expect(getByTestId(document.body, "commits").textContent).toBe("200");
     expect(getByTestId(document.body, "issues").textContent).toBe("300");


### PR DESCRIPTION
gh-index is defined by the h-index of the stargazer count of each of the repo of a GitHub user, i.e. the maximum `h` where there are at least `h` repos with stargazer counts greater than or equal to `h`. This is a good metric of a GitHub user's reputation.

There are tools to calculate this:
- [gh-index](https://github.com/b1f6c1c4/gh-index) on npm
- [github-index](https://github.com/flowmemo/github-index)

TODO:
- [x] Adjust rank based on h-index