### PR TITLE
Changed hex colors to be copy/paste workable

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,10 +77,10 @@ Customization Options:
 
 | Option      | type      | Stats Card (default)   | Repo Card (default)    |
 | ----------- | --------- | ---------------------- | ---------------------- |
-| title_color | hex color | 2f80ed                 | 2f80ed                 |
+| title_color | hex color | 2F80ED                 | 2F80ED                 |
 | text_color  | hex color | 333                    | 333                    |
-| icon_color  | hex color | 4c71f2                 | 586069                 |
-| bg_color    | hex color | ffffff                 | ffffff                 |
+| icon_color  | hex color | 4C71F2                 | 586069                 |
+| bg_color    | hex color | FFFEFE                 | FFFEFE                 |
 | show_owner  | boolean   | not applicable         | false                  |
 
 - You can also customize the cards to be compatible with dark mode

--- a/readme.md
+++ b/readme.md
@@ -77,10 +77,10 @@ Customization Options:
 
 | Option      | type      | Stats Card (default)   | Repo Card (default)    |
 | ----------- | --------- | ---------------------- | ---------------------- |
-| title_color | hex color | #2f80ed                | #2f80ed                |
-| text_color  | hex color | #333                   | #333                   |
-| icon_color  | hex color | #4c71f2                | #586069                |
-| bg_color    | hex color | rgba(255, 255, 255, 0) | rgba(255, 255, 255, 0) |
+| title_color | hex color | 2f80ed                 | 2f80ed                 |
+| text_color  | hex color | 333                    | 333                    |
+| icon_color  | hex color | 4c71f2                 | 586069                 |
+| bg_color    | hex color | ffffff                 | ffffff                 |
 | show_owner  | boolean   | not applicable         | false                  |
 
 - You can also customize the cards to be compatible with dark mode


### PR DESCRIPTION
I was a little confused at first setting the bg_color, since it said `hex color` but had `rgba(...)` so I copied the title color which of course didn't work since it started with `#` I think this makes it a bit clearer how to use it!