### PR TITLE
Fetch total contributions count, similar to contributions count on Profile page | Add Fix for new tests

### DIFF
--- a/src/fetchStats.js
+++ b/src/fetchStats.js
@@ -77,8 +77,6 @@ async function fetchStats(username) {
   stats.name = user.name || user.login;
   stats.totalIssues = user.issues.totalCount;
   stats.totalCommits = user.contributionsCollection.contributionCalendar.totalContributions;
-
-  user.contributionsCollection.contributionCalendar.totalContributions;
   stats.totalPRs = user.pullRequests.totalCount;
   stats.contributedTo = user.repositoriesContributedTo.totalCount;
 


### PR DESCRIPTION
### Tests have not been updated for it, it was tested on https://developer.github.com/v4/explorer/
## Correct Contribution Count (```fix/contributions-count``` branch)
```
query userInfo($login: String!,$startDate: DateTime!,$endDate: DateTime!) {
    ...
    contributionsCollection(from: $startDate, to: $endDate) {
        contributionCalendar {
            totalContributions
        }
    }
    ...
}
```
The above code will give the accurate contributions count (for people who are not using env ```PAT``` token), as shown on https://github.com/users/anuraghazra/contributions or profile page from ```"startdate": "2019-07-17T06:37:41.324Z"``` to ```"enddate": "2020-07-17T06:37:41.324Z"```.
#### The dynamic code to get startdate and enddate and process it, is also included in this fix.
![correct](https://user-images.githubusercontent.com/25902527/87757731-bdfddf00-c828-11ea-969f-5a0ffeabea70.png)

---
## Incorrect Contribution Count (```master``` branch)
```
query userInfo($login: String!) {
    ...
    contributionsCollection {
        totalCommitContributions
    }
    ...
}
```
#### gives a wrong contributions count.
![wrong](https://user-images.githubusercontent.com/25902527/87757592-87c05f80-c828-11ea-9d08-4e17752f56fa.png)

---
*It is a very cool repo😍*
**Great work Sir!** 👍


