### PR TITLE
fix: filter out private repos

### DIFF
--- a/src/fetchRepo.js
+++ b/src/fetchRepo.js
@@ -8,6 +8,7 @@ const fetcher = (variables, token) => {
       fragment RepoInfo on Repository {
         name
         nameWithOwner
+        isPrivate
         stargazers {
           totalCount
         }
@@ -53,15 +54,21 @@ async function fetchRepo(username, reponame) {
     throw new Error("Not found");
   }
 
-  if (data.organization === null && data.user) {
-    if (!data.user.repository) {
+  const isUser = data.organization === null && data.user;
+  const isOrg = data.user === null && data.organization;
+
+  if (isUser) {
+    if (!data.user.repository || data.user.repository.isPrivate) {
       throw new Error("User Repository Not found");
     }
     return data.user.repository;
   }
 
-  if (data.user === null && data.organization) {
-    if (!data.organization.repository) {
+  if (isOrg) {
+    if (
+      !data.organization.repository ||
+      data.organization.repository.isPrivate
+    ) {
       throw new Error("Organization Repository Not found");
     }
     return data.organization.repository;

--- a/tests/fetchRepo.test.js
+++ b/tests/fetchRepo.test.js
@@ -80,4 +80,17 @@ describe("Test fetchRepo", () => {
       "Not found"
     );
   });
+
+  it("should throw error if repository is private", async () => {
+    mock.onPost("https://api.github.com/graphql").reply(200, {
+      data: {
+        user: { repository: { ...data_repo, isPrivate: true } },
+        organization: null,
+      },
+    });
+
+    await expect(fetchRepo("anuraghazra", "convoychat")).rejects.toThrow(
+      "User Repository Not found"
+    );
+  });
 });


### PR DESCRIPTION
filtering out private repos just in case, otherwise if a user somehow found out the name of any of the PAT owner's private 
*(assuming they created the PAT with private repo access)* repos's name then the user could see the repo in github extra pins.