### PR TITLE
fix style collapses on stats card by css font config

### DIFF
--- a/src/getStyles.js
+++ b/src/getStyles.js
@@ -52,7 +52,7 @@ const getStyles = ({
       animation: fadeIn 0.8s ease-in-out forwards;
     }
     .stat { 
-      font: 600 14px 'Segoe UI', Ubuntu, Sans-Serif; fill: ${textColor};
+      font: 600 14px 'Segoe UI', Ubuntu, "Helvetica Neue", Sans-Serif; fill: ${textColor};
     }
     .stagger { 
       opacity: 0;


### PR DESCRIPTION
issue #104 

add css font config `Helvetica Neue` to `.stat`.

Fix style collapse in Japanese MacOS.