### PR TITLE
Added "prussian" theme to themes/README preview

### DIFF
--- a/themes/README.md
+++ b/themes/README.md
@@ -17,7 +17,8 @@ Use `?theme=THEME_NAME` parameter like so :-
 | `default` ![default][default] |     `radical` ![radical][radical]      |           `merko` ![merko][merko]            |
 | `gruvbox` ![gruvbox][gruvbox] | `tokyonight` ![tokyonight][tokyonight] |        `onedark` ![onedark][onedark]         |
 |  `cobalt` ![cobalt][cobalt]   |  `synthwave` ![synthwave][synthwave]   | `highcontrast` ![highcontrast][highcontrast] |
-| `dracula` ![dracula][dracula] |          `dark` ![dark][dark]          |         [Add your theme][add-theme]          |
+| `dracula` ![dracula][dracula] |          `dark` ![dark][dark]          |      `prussian` ![prussian][prussian]        |
+| [Add your theme][add-theme]   |||
 
 ## Repo Card
 
@@ -28,7 +29,9 @@ Use `?theme=THEME_NAME` parameter like so :-
 | `default_repocard` ![default_repocard][default_repocard] |     `radical` ![radical][radical_repocard]      |           `merko` ![merko][merko_repocard]            |
 |          `gruvbox` ![gruvbox][gruvbox_repocard]          | `tokyonight` ![tokyonight][tokyonight_repocard] |        `onedark` ![onedark][onedark_repocard]         |
 |           `cobalt` ![cobalt][cobalt_repocard]            |  `synthwave` ![synthwave][synthwave_repocard]   | `highcontrast` ![highcontrast][highcontrast_repocard] |
-|          `dracula` ![dracula][dracula_repocard]          |     `dark` ![dark_repocard][dark_repocard]      |              [Add your theme][add-theme]              |
+|          `dracula` ![dracula][dracula_repocard]          |     `dark` ![dark_repocard][dark_repocard]      |  `prussian` ![prussian_repocard][prussian_repocard]         |
+| [Add your theme][add-theme]   |||
+
 
 <!-- Repo Card Theme previews -->
 
@@ -44,6 +47,7 @@ Use `?theme=THEME_NAME` parameter like so :-
 [synthwave_repocard]: https://github-readme-stats.vercel.app/api/pin/?username=anuraghazra&repo=github-readme-stats&cache_seconds=86400&theme=synthwave
 [onedark_repocard]: https://github-readme-stats.vercel.app/api/pin/?username=anuraghazra&repo=github-readme-stats&cache_seconds=86400&theme=onedark
 [highcontrast_repocard]: https://github-readme-stats.vercel.app/api/pin/?username=anuraghazra&repo=github-readme-stats&cache_seconds=86400&theme=highcontrast
+[prussian_repocard]: https://github-readme-stats.vercel.app/api/pin/?username=anuraghazra&repo=github-readme-stats&cache_seconds=86400&theme=prussian
 
 <!-- Stats Theme previews -->
 
@@ -58,5 +62,7 @@ Use `?theme=THEME_NAME` parameter like so :-
 [synthwave]: https://github-readme-stats.vercel.app/api?username=anuraghazra&theme=synthwave&hide=["contribs","prs"]&cache_seconds=86400
 [highcontrast]: https://github-readme-stats.vercel.app/api?username=anuraghazra&theme=highcontrast&hide=["contribs","prs"]&cache_seconds=86400
 [dracula]: https://github-readme-stats.vercel.app/api?username=anuraghazra&theme=dracula&hide=["contribs","prs"]&cache_seconds=86400
+[prussian]: https://github-readme-stats.vercel.app/api?username=anuraghazra&theme=prussian&hide=["contribs","prs"]&cache_seconds=86400
+
 
 [add-theme]: https://github.com/anuraghazra/github-readme-stats/edit/master/themes/index.js


### PR DESCRIPTION
Added prussian theme to themes preview. https://github.com/anuraghazra/github-readme-stats/pull/123


PD: As the cache is 86400 it will take some time until it is updated, I can't think of any good solution at the moment. Apart from making it 0 and then update it to 86400 again.