### PR TITLE
Add private contributors to totalContributions

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -31,7 +31,7 @@ module.exports = async (req, res) => {
   res.setHeader("Content-Type", "image/svg+xml");
 
   try {
-    stats = await fetchStats(username, count_private);
+    stats = await fetchStats(username, parseBoolean(count_private));
   } catch (err) {
     return res.send(renderError(err.message));
   }

--- a/api/index.js
+++ b/api/index.js
@@ -17,6 +17,7 @@ module.exports = async (req, res) => {
     hide_border,
     hide_rank,
     show_icons,
+    count_private,
     line_height,
     title_color,
     icon_color,
@@ -30,7 +31,7 @@ module.exports = async (req, res) => {
   res.setHeader("Content-Type", "image/svg+xml");
 
   try {
-    stats = await fetchStats(username);
+    stats = await fetchStats(username, count_private);
   } catch (err) {
     return res.send(renderError(err.message));
   }

--- a/readme.md
+++ b/readme.md
@@ -65,6 +65,18 @@ To hide any specific stats, you can pass a query parameter `?hide=` with comma s
 ![Anurag's github stats](https://github-readme-stats.vercel.app/api?username=anuraghazra&hide=contribs,prs])
 ```
 
+### Adding private contributions count to total commits count
+
+You can add the count of all your private contributions to the total commits count by using the query parameter `?count_private=true`.
+
+_Note: If you are deploying this project yourself, the private contributions will be counted by default otherwise you need to chose to share your private contribution counts._
+
+> Options: `&count_private=true`
+
+```md
+![Anurag's github stats](https://github-readme-stats.vercel.app/api?username=anuraghazra&count_private=true)
+```
+
 ### Showing icons
 
 To enable icons, you can pass `show_icons=true` in the query param, like so:

--- a/readme.md
+++ b/readme.md
@@ -109,21 +109,22 @@ You can customize the appearance of your `Stats Card` or `Repo Card` however you
 
 Customization Options:
 
-| Option        | type      | description                          | Stats Card (default) | Repo Card (default) | Top Lang Card (default) |
-| ------------- | --------- | ------------------------------------ | -------------------- | ------------------- | ----------------------- |
-| title_color   | hex color | title color                          | 2f80ed               | 2f80ed              | 2f80ed                  |
-| text_color    | hex color | body color                           | 333                  | 333                 | 333                     |
-| icon_color    | hex color | icon color                           | 4c71f2               | 586069              | 586069                  |
-| bg_color      | hex color | card bg color                        | FFFEFE               | FFFEFE              | FFFEFE                  |
-| line_height   | number    | control the line-height between text | 30                   | N/A                 | N/A                     |
-| hide          | CSV       | hides the items specified            | undefined            | N/A                 | undefined               |
-| hide_rank     | boolean   | hides the ranking                    | false                | N/A                 | N/A                     |
-| hide_title    | boolean   | hides the stats title                | false                | N/A                 | false                   |
-| hide_border   | boolean   | hides the stats card border          | false                | N/A                 | N/A                     |
-| show_owner    | boolean   | shows owner name in repo card        | N/A                  | false               | N/A                     |
-| show_icons    | boolean   | shows icons                          | false                | N/A                 | N/A                     |
-| theme         | string    | sets inbuilt theme                   | 'default'            | 'default_repocard'  | 'default                |
-| cache_seconds | number    | manually set custom cache control    | 1800                 | 1800                | '1800'                  |
+| Option        | type      | description                                 | Stats Card (default) | Repo Card (default) | Top Lang Card (default) |
+| ------------- | --------- | ------------------------------------------- | -------------------- | ------------------- | ----------------------- |
+| title_color   | hex color | title color                                 | 2f80ed               | 2f80ed              | 2f80ed                  |
+| text_color    | hex color | body color                                  | 333                  | 333                 | 333                     |
+| icon_color    | hex color | icon color                                  | 4c71f2               | 586069              | 586069                  |
+| bg_color      | hex color | card bg color                               | FFFEFE               | FFFEFE              | FFFEFE                  |
+| line_height   | number    | control the line-height between text        | 30                   | N/A                 | N/A                     |
+| hide          | CSV       | hides the items specified                   | undefined            | N/A                 | undefined               |
+| hide_rank     | boolean   | hides the ranking                           | false                | N/A                 | N/A                     |
+| hide_title    | boolean   | hides the stats title                       | false                | N/A                 | false                   |
+| hide_border   | boolean   | hides the stats card border                 | false                | N/A                 | N/A                     |
+| show_owner    | boolean   | shows owner name in repo card               | N/A                  | false               | N/A                     |
+| show_icons    | boolean   | shows icons                                 | false                | N/A                 | N/A                     |
+| theme         | string    | sets inbuilt theme                          | 'default'            | 'default_repocard'  | 'default                |
+| cache_seconds | number    | manually set custom cache control           | 1800                 | 1800                | '1800'                  |
+| count_private | boolean   | counts private contributions too if enabled | false                | N/A                 | N/A                     |
 
 > Note on cache: Repo cards have default cache of 30mins (1800 seconds) if the fork count & star count is less than 1k otherwise it's 2hours (7200). Also note that cache is clamped to minimum of 30min and maximum of 24hours
 

--- a/src/fetchStats.js
+++ b/src/fetchStats.js
@@ -46,7 +46,7 @@ const fetcher = (variables, token) => {
   );
 };
 
-async function fetchStats(username, count_private=false) {
+async function fetchStats(username, count_private = false) {
   if (!username) throw Error("Invalid username");
 
   const stats = {
@@ -71,7 +71,14 @@ async function fetchStats(username, count_private=false) {
 
   stats.name = user.name || user.login;
   stats.totalIssues = user.issues.totalCount;
-  stats.totalCommits = count_private ? contributionCount.totalCommitContributions + contributionCount.restrictedContributionsCount : contributionCount.totalCommitContributions;
+
+  stats.totalCommits = contributionCount.totalCommitContributions;
+  if (count_private) {
+    stats.totalCommits =
+      contributionCount.totalCommitContributions +
+      contributionCount.restrictedContributionsCount;
+  }
+
   stats.totalPRs = user.pullRequests.totalCount;
   stats.contributedTo = user.repositoriesContributedTo.totalCount;
 

--- a/src/fetchStats.js
+++ b/src/fetchStats.js
@@ -13,6 +13,7 @@ const fetcher = (variables, token) => {
           login
           contributionsCollection {
             totalCommitContributions
+            restrictedContributionsCount
           }
           repositoriesContributedTo(first: 1, contributionTypes: [COMMIT, ISSUE, PULL_REQUEST, REPOSITORY]) {
             totalCount
@@ -45,7 +46,7 @@ const fetcher = (variables, token) => {
   );
 };
 
-async function fetchStats(username) {
+async function fetchStats(username, count_private=false) {
   if (!username) throw Error("Invalid username");
 
   const stats = {
@@ -66,10 +67,11 @@ async function fetchStats(username) {
   }
 
   const user = res.data.data.user;
+  const contributionCount = user.contributionsCollection;
 
   stats.name = user.name || user.login;
   stats.totalIssues = user.issues.totalCount;
-  stats.totalCommits = user.contributionsCollection.totalCommitContributions;
+  stats.totalCommits = count_private ? contributionCount.totalCommitContributions + contributionCount.restrictedContributionsCount : contributionCount.totalCommitContributions;
   stats.totalPRs = user.pullRequests.totalCount;
   stats.contributedTo = user.repositoriesContributedTo.totalCount;
 

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -30,7 +30,10 @@ const data = {
     user: {
       name: stats.name,
       repositoriesContributedTo: { totalCount: stats.contributedTo },
-      contributionsCollection: { totalCommitContributions: stats.totalCommits, restrictedContributionsCount: 0 },
+      contributionsCollection: {
+        totalCommitContributions: stats.totalCommits,
+        restrictedContributionsCount: 100,
+      },
       pullRequests: { totalCount: stats.totalPRs },
       issues: { totalCount: stats.totalIssues },
       followers: { totalCount: 0 },
@@ -186,15 +189,7 @@ describe("Test /api/", () => {
     const { req, res } = faker(
       {
         username: "anuraghazra",
-        hide: `["issues","prs","contribs"]`,
         count_private: true,
-        show_icons: true,
-        hide_border: true,
-        line_height: 100,
-        title_color: "fff",
-        icon_color: "fff",
-        text_color: "fff",
-        bg_color: "fff",
       },
       data
     );
@@ -203,16 +198,22 @@ describe("Test /api/", () => {
 
     expect(res.setHeader).toBeCalledWith("Content-Type", "image/svg+xml");
     expect(res.send).toBeCalledWith(
-      renderStatsCard(stats, {
-        hide: ["issues", "prs", "contribs"],
-        show_icons: true,
-        hide_border: true,
-        line_height: 100,
-        title_color: "fff",
-        icon_color: "fff",
-        text_color: "fff",
-        bg_color: "fff",
-      })
+      renderStatsCard(
+        {
+          ...stats,
+          totalCommits: stats.totalCommits + 100,
+          rank: calculateRank({
+            totalCommits: stats.totalCommits + 100,
+            totalRepos: 1,
+            followers: 0,
+            contributions: stats.contributedTo,
+            stargazers: stats.totalStars,
+            prs: stats.totalPRs,
+            issues: stats.totalIssues,
+          }),
+        },
+        {}
+      )
     );
   });
 });

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -30,7 +30,7 @@ const data = {
     user: {
       name: stats.name,
       repositoriesContributedTo: { totalCount: stats.contributedTo },
-      contributionsCollection: { totalCommitContributions: stats.totalCommits },
+      contributionsCollection: { totalCommitContributions: stats.totalCommits, restrictedContributionsCount: 0 },
       pullRequests: { totalCount: stats.totalPRs },
       issues: { totalCount: stats.totalIssues },
       followers: { totalCount: 0 },
@@ -180,5 +180,39 @@ describe("Test /api/", () => {
         ["Cache-Control", `public, max-age=${CONSTANTS.THIRTY_MINUTES}`],
       ]);
     }
+  });
+
+  it("should add private contributions", async () => {
+    const { req, res } = faker(
+      {
+        username: "anuraghazra",
+        hide: `["issues","prs","contribs"]`,
+        count_private: true,
+        show_icons: true,
+        hide_border: true,
+        line_height: 100,
+        title_color: "fff",
+        icon_color: "fff",
+        text_color: "fff",
+        bg_color: "fff",
+      },
+      data
+    );
+
+    await api(req, res);
+
+    expect(res.setHeader).toBeCalledWith("Content-Type", "image/svg+xml");
+    expect(res.send).toBeCalledWith(
+      renderStatsCard(stats, {
+        hide: ["issues", "prs", "contribs"],
+        show_icons: true,
+        hide_border: true,
+        line_height: 100,
+        title_color: "fff",
+        icon_color: "fff",
+        text_color: "fff",
+        bg_color: "fff",
+      })
+    );
   });
 });

--- a/tests/fetchStats.test.js
+++ b/tests/fetchStats.test.js
@@ -9,7 +9,7 @@ const data = {
     user: {
       name: "Anurag Hazra",
       repositoriesContributedTo: { totalCount: 61 },
-      contributionsCollection: { totalCommitContributions: 100 },
+      contributionsCollection: { totalCommitContributions: 100, restrictedContributionsCount: 50 },
       pullRequests: { totalCount: 300 },
       issues: { totalCount: 200 },
       followers: { totalCount: 100 },
@@ -76,5 +76,30 @@ describe("Test fetchStats", () => {
     await expect(fetchStats("anuraghazra")).rejects.toThrow(
       "Could not resolve to a User with the login of 'noname'."
     );
+  });
+
+  it("should fetch and add private contributions", async () => {
+    mock.onPost("https://api.github.com/graphql").reply(200, data);
+
+    let stats = await fetchStats("anuraghazra", true);
+    const rank = calculateRank({
+      totalCommits: 150,
+      totalRepos: 5,
+      followers: 100,
+      contributions: 61,
+      stargazers: 400,
+      prs: 300,
+      issues: 200,
+    });
+
+    expect(stats).toStrictEqual({
+      contributedTo: 61,
+      name: "Anurag Hazra",
+      totalCommits: 150,
+      totalIssues: 200,
+      totalPRs: 300,
+      totalStars: 400,
+      rank,
+    });
   });
 });


### PR DESCRIPTION
Hello, this PR should fix #139 

I would like your opinion about my approach to add the `count_private` flag to the fetcher, the reason why i decided to do it this way, is because it might impact the rank quite a bit so it should add the private count to the `totalContributions` on the fetch.

If you would rather me do it differently please let me know.

Also, I know that the issue only mentions the totalcontributions but I believe we could add the number of private repos to the totals as well? If that is the case are you interested in me adding it?