### PR TITLE
fix: stats hide border bug

### DIFF
--- a/src/renderStatsCard.js
+++ b/src/renderStatsCard.js
@@ -130,8 +130,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     ? ""
     : `<text x="25" y="35" class="header">${name}'${apostrophe} GitHub Stats</text>`;
 
-  const border = hide_border
-    ? `
+  const border = `
     <rect 
       data-testid="card-bg"
       x="0.5"
@@ -141,20 +140,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
       rx="4.5"
       fill="${bgColor}"
       stroke="#E4E2E2"
-      stroke-opacity="0"
-    />
-  `
-    : `
-    <rect 
-      data-testid="card-bg"
-      x="0.5"
-      y="0.5"
-      width="494"
-      height="99%"
-      rx="4.5"
-      fill="${bgColor}"
-      stroke="#E4E2E2"
-      stroke-opacity="1"
+      stroke-opacity="${hide_border ? 0 : 1}"
     />
   `;
 

--- a/tests/renderStatsCard.test.js
+++ b/tests/renderStatsCard.test.js
@@ -71,8 +71,16 @@ describe("Test renderStatsCard", () => {
 
   it("should hide_border", () => {
     document.body.innerHTML = renderStatsCard(stats, { hide_border: true });
+    expect(queryByTestId(document.body, "card-bg")).toHaveAttribute(
+      "stroke-opacity",
+      "0"
+    );
 
-    expect(document.querySelector("rect")).toHaveAttribute("stroke-opacity", "0")
+    document.body.innerHTML = renderStatsCard(stats, { hide_border: false });
+    expect(queryByTestId(document.body, "card-bg")).toHaveAttribute(
+      "stroke-opacity",
+      "1"
+    );
   });
 
   it("should hide_rank", () => {


### PR DESCRIPTION
Currently when you hide the border on the stats card, you're also removing the background color, therefore breaking the theme.

Production: https://github-readme-stats.vercel.app/api/?username=terror&hide_border=true&theme=dark

This PR fixes this bug.

My Deployment: https://github-readme-stats-fc6mcm9vh.vercel.app/api/?username=terror&hide_border=true&theme=dark