### PR TITLE
docs: fix typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ To hide any specific stats, you can pass a query parameter `?hide=` with comma s
 > Options: `&hide=stars,commits,prs,issues,contribs`
 
 ```md
-![Anurag's github stats](https://github-readme-stats.vercel.app/api?username=anuraghazra&hide=contribs,prs])
+![Anurag's github stats](https://github-readme-stats.vercel.app/api?username=anuraghazra&hide=contribs,prs)
 ```
 
 ### Adding private contributions count to total commits count
@@ -190,7 +190,7 @@ You can use `?hide=language1,language2` parameter to hide individual languages.
 
 - Hiding specific stats
 
-![Anurag's github stats](https://github-readme-stats.vercel.app/api?username=anuraghazra&hide=contribs,issues])
+![Anurag's github stats](https://github-readme-stats.vercel.app/api?username=anuraghazra&hide=contribs,issues)
 
 - Showing icons
 


### PR DESCRIPTION
I found typo in the `readme.md` and fixed it.

---
before:
```md
 ![Anurag's github stats](https://github-readme-stats.vercel.app/api?username=anuraghazra&hide=contribs,issues])
```
![before](https://user-images.githubusercontent.com/17886370/88482523-c67ab600-cf9c-11ea-9b73-1a8248be94a7.png)

after:
```md
 ![Anurag's github stats](https://github-readme-stats.vercel.app/api?username=anuraghazra&hide=contribs,issues)
```
![after](https://user-images.githubusercontent.com/17886370/88482524-ca0e3d00-cf9c-11ea-9850-133f58b7be84.png)
