### PR TITLE
fix: fetch top lang in each repository

### DIFF
--- a/src/fetchTopLanguages.js
+++ b/src/fetchTopLanguages.js
@@ -8,9 +8,9 @@ const fetcher = (variables, token) => {
       query: `
       query userInfo($login: String!) {
         user(login: $login) {
-          repositories(isFork: false, first: 100) {
+          repositories(isFork: false, first: 100, orderBy: {field: UPDATED_AT, direction: DESC}) {
             nodes {
-              languages(first: 1) {
+              languages(first: 1, orderBy: {field: SIZE, direction: DESC}) {
                 edges {
                   size
                   node {


### PR DESCRIPTION
- Fetch top language in each repo by adding `orderBy: {field: SIZE, direction: DESC}` constrain.
- Using the most recent 100 repositories for calculation.