### PR TITLE
Feature/multiline repo description

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   },
   "dependencies": {
     "dotenv": "^8.2.0",
-    "emoji-name-map": "^1.2.8"
+    "emoji-name-map": "^1.2.8",
+    "word-wrap": "^1.2.3"
   },
   "husky": {
     "hooks": {

--- a/src/renderRepoCard.js
+++ b/src/renderRepoCard.js
@@ -45,7 +45,8 @@ const renderRepoCard = (repo, options = {}) => {
   const descriptionLines = multiLineDescription.length;
   const lineHeight = 10;
 
-  const height = 120 + descriptionLines * lineHeight;
+  const height =
+    (descriptionLines > 1 ? 120 : 110) + descriptionLines * lineHeight;
 
   // returns theme based colors with proper overrides and defaults
   const { titleColor, textColor, iconColor, bgColor } = getCardColors({

--- a/src/renderRepoCard.js
+++ b/src/renderRepoCard.js
@@ -3,10 +3,10 @@ const {
   encodeHTML,
   getCardColors,
   FlexLayout,
+  wrapTextMultiline,
 } = require("../src/utils");
 const icons = require("./icons");
 const toEmoji = require("emoji-name-map");
-const wrap = require("word-wrap");
 
 const renderRepoCard = (repo, options = {}) => {
   const {
@@ -41,7 +41,7 @@ const renderRepoCard = (repo, options = {}) => {
     return toEmoji.get(emoji) || "";
   });
 
-  const multiLineDescription = getMultiLineDescription(desc);
+  const multiLineDescription = wrapTextMultiline(desc);
   const descriptionLines = multiLineDescription.length;
   const lineHeight = 10;
 
@@ -76,7 +76,7 @@ const renderRepoCard = (repo, options = {}) => {
 
   const svgLanguage = primaryLanguage
     ? `
-    <g data-testid="primary-lang" transform="translate(30, ${100 + descriptionLines * lineHeight})">
+    <g data-testid="primary-lang" transform="translate(30, 0)">
       <circle data-testid="lang-color" cx="0" cy="-5" r="6" fill="${langColor}" />
       <text data-testid="lang-name" class="gray" x="15">${langName}</text>
     </g>
@@ -127,35 +127,24 @@ const renderRepoCard = (repo, options = {}) => {
           : ""
       }
 
-      <text class="description" x="25" y="70"
-      >${multiLineDescription.reduce((acc, cur) => acc + `<tspan dy="1.2em" x="25">${encodeHTML(cur)}</tspan>`)}
+      <text class="description" x="25" y="50">
+        ${multiLineDescription
+          .map((line) => `<tspan dy="1.2em" x="25">${encodeHTML(line)}</tspan>`)
+          .join("")}
       </text>
 
-      ${svgLanguage}
+      <g transform="translate(0, ${height - 20})">
+        ${svgLanguage}
 
-      <g transform="translate(${primaryLanguage ? 155 - shiftText : 25}, ${100 + descriptionLines * lineHeight})">
-        ${FlexLayout({ items: [svgStars, svgForks], gap: 65 }).join("")}
+        <g 
+          data-testid="star-fork-group" 
+          transform="translate(${primaryLanguage ? 155 - shiftText : 25}, 0)"
+        >
+          ${FlexLayout({ items: [svgStars, svgForks], gap: 65 }).join("")}
+        </g>
       </g>
-
     </svg>
   `;
 };
-
-function getMultiLineDescription(description, width = 55, maxLines = 3) {
-  const wrapped = wrap(description, { width })
-    .split("\n") // Split wrapped lines to get an array of lines
-    .map(line => line.trim()); // Remove leading and trailing whitespace of each line
-
-  const lines = wrapped.slice(0, maxLines); // Only consider maxLines lines
-
-  // Add "..." to the last line if the description exceeds maxLines
-  if (wrapped.length > maxLines) {
-    lines[maxLines - 1] += "...";
-  }
-
-  // Remove empty lines if description fits in less than maxLines lines
-  const multiLineDescription = lines.filter(Boolean);
-  return multiLineDescription;
-}
 
 module.exports = renderRepoCard;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,5 @@
 const axios = require("axios");
+const wrap = require("word-wrap");
 const themes = require("../themes");
 
 const renderError = (message, secondaryMessage = "") => {
@@ -127,10 +128,27 @@ function getCardColors({
   return { titleColor, iconColor, textColor, bgColor };
 }
 
-const fn = () => {};
+function wrapTextMultiline(text, width = 60, maxLines = 3) {
+  const wrapped = wrap(encodeHTML(text), { width })
+    .split("\n") // Split wrapped lines to get an array of lines
+    .map((line) => line.trim()); // Remove leading and trailing whitespace of each line
+
+  const lines = wrapped.slice(0, maxLines); // Only consider maxLines lines
+
+  // Add "..." to the last line if the text exceeds maxLines
+  if (wrapped.length > maxLines) {
+    lines[maxLines - 1] += "...";
+  }
+
+  // Remove empty lines if text fits in less than maxLines lines
+  const multiLineText = lines.filter(Boolean);
+  return multiLineText;
+}
+
+const noop = () => {};
 // return console instance based on the environment
 const logger =
-  process.env.NODE_ENV !== "test" ? console : { log: fn, error: fn };
+  process.env.NODE_ENV !== "test" ? console : { log: noop, error: noop };
 
 const CONSTANTS = {
   THIRTY_MINUTES: 1800,
@@ -150,6 +168,7 @@ module.exports = {
   FlexLayout,
   getCardColors,
   clampValue,
+  wrapTextMultiline,
   logger,
   CONSTANTS,
 };

--- a/tests/renderRepoCard.test.js
+++ b/tests/renderRepoCard.test.js
@@ -29,7 +29,7 @@ describe("Test renderRepoCard", () => {
     expect(header).toHaveTextContent("convoychat");
     expect(header).not.toHaveTextContent("anuraghazra");
     expect(document.getElementsByClassName("description")[0]).toHaveTextContent(
-      "Help us take over the world! React + TS + GraphQL Chat .."
+      "Help us take over the world! React + TS + GraphQL ChatApp"
     );
     expect(queryByTestId(document.body, "stargazers")).toHaveTextContent("38k");
     expect(queryByTestId(document.body, "forkcount")).toHaveTextContent("100");
@@ -55,11 +55,14 @@ describe("Test renderRepoCard", () => {
     document.body.innerHTML = renderRepoCard({
       ...data_repo.repository,
       description:
-        "Very long long long long long long long long text it should trim it",
+        "Very long long long long long long long long long long long long long long long long text it should trim it",
     });
 
-    expect(document.getElementsByClassName("description")[0]).toHaveTextContent(
-      "Very long long long long long long long long text it sh.."
+    expect(document.getElementsByClassName("description")[0].childNodes[0].textContent).toBe(
+      "Very long long long long long long long long long long"
+    );
+    expect(document.getElementsByClassName("description")[0].childNodes[1].textContent).toBe(
+      "long long long long long long text it should trim it"
     );
 
     // Should not trim
@@ -97,7 +100,7 @@ describe("Test renderRepoCard", () => {
     expect(queryByTestId(document.body, "primary-lang")).toBeInTheDocument();
     expect(document.getElementsByTagName("g")[1]).toHaveAttribute(
       "transform",
-      "translate(155, 100)"
+      "translate(155, 120)"
     );
 
     // Small lang
@@ -111,7 +114,7 @@ describe("Test renderRepoCard", () => {
 
     expect(document.getElementsByTagName("g")[1]).toHaveAttribute(
       "transform",
-      "translate(125, 100)"
+      "translate(125, 120)"
     );
   });
 

--- a/tests/renderRepoCard.test.js
+++ b/tests/renderRepoCard.test.js
@@ -29,7 +29,7 @@ describe("Test renderRepoCard", () => {
     expect(header).toHaveTextContent("convoychat");
     expect(header).not.toHaveTextContent("anuraghazra");
     expect(document.getElementsByClassName("description")[0]).toHaveTextContent(
-      "Help us take over the world! React + TS + GraphQL ChatApp"
+      "Help us take over the world! React + TS + GraphQL Chat App"
     );
     expect(queryByTestId(document.body, "stargazers")).toHaveTextContent("38k");
     expect(queryByTestId(document.body, "forkcount")).toHaveTextContent("100");
@@ -55,15 +55,19 @@ describe("Test renderRepoCard", () => {
     document.body.innerHTML = renderRepoCard({
       ...data_repo.repository,
       description:
-        "Very long long long long long long long long long long long long long long long long text it should trim it",
+        "The quick brown fox jumps over the lazy dog is an English-language pangram—a sentence that contains all of the letters of the English alphabet",
     });
 
-    expect(document.getElementsByClassName("description")[0].childNodes[0].textContent).toBe(
-      "Very long long long long long long long long long long"
-    );
-    expect(document.getElementsByClassName("description")[0].childNodes[1].textContent).toBe(
-      "long long long long long long text it should trim it"
-    );
+    console.log({
+      t: document.getElementsByClassName("description")[0].textContent,
+    });
+    expect(
+      document.getElementsByClassName("description")[0].children[0].textContent
+    ).toBe("The quick brown fox jumps over the lazy dog is an");
+
+    expect(
+      document.getElementsByClassName("description")[0].children[1].textContent
+    ).toBe("English-language pangram—a sentence that contains all");
 
     // Should not trim
     document.body.innerHTML = renderRepoCard({
@@ -98,9 +102,9 @@ describe("Test renderRepoCard", () => {
     });
 
     expect(queryByTestId(document.body, "primary-lang")).toBeInTheDocument();
-    expect(document.getElementsByTagName("g")[1]).toHaveAttribute(
+    expect(queryByTestId(document.body, "star-fork-group")).toHaveAttribute(
       "transform",
-      "translate(155, 120)"
+      "translate(155, 0)"
     );
 
     // Small lang
@@ -112,9 +116,9 @@ describe("Test renderRepoCard", () => {
       },
     });
 
-    expect(document.getElementsByTagName("g")[1]).toHaveAttribute(
+    expect(queryByTestId(document.body, "star-fork-group")).toHaveAttribute(
       "transform",
-      "translate(125, 120)"
+      "translate(125, 0)"
     );
   });
 

--- a/tests/renderRepoCard.test.js
+++ b/tests/renderRepoCard.test.js
@@ -58,9 +58,6 @@ describe("Test renderRepoCard", () => {
         "The quick brown fox jumps over the lazy dog is an English-language pangram—a sentence that contains all of the letters of the English alphabet",
     });
 
-    console.log({
-      t: document.getElementsByClassName("description")[0].textContent,
-    });
     expect(
       document.getElementsByClassName("description")[0].children[0].textContent
     ).toBe("The quick brown fox jumps over the lazy dog is an");

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -5,6 +5,7 @@ const {
   renderError,
   FlexLayout,
   getCardColors,
+  wrapTextMultiline,
 } = require("../src/utils");
 
 const { queryByTestId } = require("@testing-library/dom");
@@ -106,5 +107,30 @@ describe("Test utils.js", () => {
       iconColor: "#79ff97",
       bgColor: "#151515",
     });
+  });
+});
+
+describe("wrapTextMultiline", () => {
+  it("should not wrap small texts", () => {
+    {
+      let multiLineText = wrapTextMultiline("Small text should not wrap");
+      expect(multiLineText).toEqual(["Small text should not wrap"]);
+    }
+  });
+  it("should wrap large texts", () => {
+    let multiLineText = wrapTextMultiline(
+      "Hello world long long long text",
+      20,
+      3
+    );
+    expect(multiLineText).toEqual(["Hello world long", "long long text"]);
+  });
+  it("should wrap large texts and limit max lines", () => {
+    let multiLineText = wrapTextMultiline(
+      "Hello world long long long text",
+      10,
+      2
+    );
+    expect(multiLineText).toEqual(["Hello", "world long..."]);
   });
 });


### PR DESCRIPTION
# Description
Enables to render multi line descriptions on repo cards.

# Changes
* Transform repo description to multiline description using [`word-wrap`](https://www.npmjs.com/package/word-wrap)
* Dynamically generate the card's height according to the line count of the description
* Adjusted unit tests

# Related issues
Related to #94 
Fixes #184 

# Examples

Number of description lines | current state | with PR
-|-|-
1 | ![image](https://user-images.githubusercontent.com/23164374/88489938-1440ef80-cf98-11ea-912b-f47916a6b3c2.png) | ![image](https://user-images.githubusercontent.com/23164374/88489851-5b7ab080-cf97-11ea-8dd3-2b4209108cd0.png)
\>3 | ![image](https://user-images.githubusercontent.com/23164374/88489952-3f2b4380-cf98-11ea-8de5-20ca698243b5.png) | ![image](https://user-images.githubusercontent.com/23164374/88489972-5ff39900-cf98-11ea-9fae-fc08810d4ed4.png)





