### PR TITLE
feat: improved top lang fetching & changed title

### DIFF
--- a/src/renderTopLanguages.js
+++ b/src/renderTopLanguages.js
@@ -185,7 +185,7 @@ const renderTopLanguages = (topLangs, options = {}) => {
       ${
         hide_title
           ? ""
-          : `<text data-testid="header" x="25" y="35" class="header">Top Languages</text>`
+          : `<text data-testid="header" x="25" y="35" class="header">Most Used Languages</text>`
       }
 
       <svg data-testid="lang-items" x="25" y="${hide_title ? 25 : 55}">

--- a/tests/renderTopLanguages.test.js
+++ b/tests/renderTopLanguages.test.js
@@ -32,7 +32,7 @@ describe("Test renderTopLanguages", () => {
     document.body.innerHTML = renderTopLanguages(langs);
 
     expect(queryByTestId(document.body, "header")).toHaveTextContent(
-      "Top Languages"
+      "Most Used Languages"
     );
 
     expect(queryAllByTestId(document.body, "lang-name")[0]).toHaveTextContent(
@@ -211,7 +211,7 @@ describe("Test renderTopLanguages", () => {
   it('should render with layout compact', () => {
     document.body.innerHTML = renderTopLanguages(langs, {layout: 'compact'});
 
-    expect(queryByTestId(document.body, "header")).toHaveTextContent("Top Languages");
+    expect(queryByTestId(document.body, "header")).toHaveTextContent("Most Used Languages");
 
     expect(queryAllByTestId(document.body, "lang-name")[0]).toHaveTextContent("HTML 40.00%");
     expect(queryAllByTestId(document.body, "lang-progress")[0]).toHaveAttribute("width","120.00");

--- a/tests/top-langs.test.js
+++ b/tests/top-langs.test.js
@@ -12,7 +12,7 @@ const data_langs = {
         nodes: [
           {
             languages: {
-              edges: [{ size: 100, node: { color: "#0f0", name: "HTML" } }],
+              edges: [{ size: 150, node: { color: "#0f0", name: "HTML" } }],
             },
           },
           {
@@ -55,7 +55,7 @@ const langs = {
   HTML: {
     color: "#0f0",
     name: "HTML",
-    size: 200,
+    size: 250,
   },
   javascript: {
     color: "#0ff",


### PR DESCRIPTION
This Fix improves the top languages card's stats by instead of counting only the first language returned from repos it counts all the languages in a repo. 

fixes #136 

Also checkout my this comment https://github.com/anuraghazra/github-readme-stats/issues/136#issuecomment-665172181