### PR TITLE
docs: fix typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ _(make sure you already have a [vercel](https://vercel.com/) account)_
 
 ## Themes Contribution
 
-Github readme stats supports custom theming and you can also contribute new themes!
+GitHub Readme Stats supports custom theming and you can also contribute new themes!
 
 All you need to do is edit [themes/index.js](./themes/index.js) file and add your theme at the end of the file.
 
@@ -43,7 +43,7 @@ While creating the Pull request to add a new theme **don't forget to add a scree
 
 In short, when you submit changes, your submissions are understood to be under the same [MIT License](http://choosealicense.com/licenses/mit/) that covers the project. Feel free to contact the maintainers if that's a concern.
 
-## Report issues/bugs using Github's [issues](https://github.com/anuraghazra/github-readme-stats/issues)
+## Report issues/bugs using GitHub's [issues](https://github.com/anuraghazra/github-readme-stats/issues)
 
 We use GitHub issues to track public bugs. Report a bug by [opening a new issue](https://github.com/anuraghazra/github-readme-stats/issues/new/choose); it's that easy!
 
@@ -55,7 +55,7 @@ We use GitHub issues to track public bugs. Report a bug by [opening a new issue]
 - Steps to reproduce
   - Be specific!
   - Share the snapshot, if possible.
-  - Github Readme Stats' live link
+  - GitHub Readme Stats' live link
 - What actually happens
 - What you expected would happen
 - Notes (possibly including why you think this might be happening, or stuff you tried that didn't work)

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,5 @@
 <p align="center">
- <img width="100px" src="https://res.cloudinary.com/anuraghazra/image/upload/v1594908242/logo_ccswme.svg" align="center" alt="Github Readme Stats" />
+ <img width="100px" src="https://res.cloudinary.com/anuraghazra/image/upload/v1594908242/logo_ccswme.svg" align="center" alt="GitHub Readme Stats" />
  <h2 align="center">GitHub Readme Stats</h2>
  <p align="center">Get dynamically generated GitHub stats on your readmes!</p>
 </p>
@@ -103,7 +103,7 @@ Use `?theme=THEME_NAME` parameter like so :-
 
 dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontrast, dracula
 
-<img src="https://res.cloudinary.com/anuraghazra/image/upload/v1595174536/grs-themes_l4ynja.png" alt="Github Readme Stat Themes" width="600px"/>
+<img src="https://res.cloudinary.com/anuraghazra/image/upload/v1595174536/grs-themes_l4ynja.png" alt="GitHub Readme Stat Themes" width="600px"/>
 
 You can look at a preview for [all available themes](./themes/README.md) or checkout the [theme config file](./themes/index.js) & **you can also contribute new themes** if you like :D
 
@@ -127,9 +127,9 @@ Customization Options:
 | show_owner    | boolean   | shows owner name in repo card               | N/A                  | false               | N/A                     |
 | show_icons    | boolean   | shows icons                                 | false                | N/A                 | N/A                     |
 | theme         | string    | sets inbuilt theme                          | 'default'            | 'default_repocard'  | 'default'               |
-| cache_seconds | number    | manually set custom cache control           | 1800                 | 1800                | '1800'                  |
+| cache_seconds | number    | manually set custom cache control           | 1800                 | 1800                | 1800                    |
 | count_private | boolean   | counts private contributions too if enabled | false                | N/A                 | N/A                     |
-| layout        | string    | choose a layout option                      | N/A                  | N/A                 | "default"               |
+| layout        | string    | choose a layout option                      | N/A                  | N/A                 | 'default'               |
 
 > Note on cache: Repo cards have default cache of 30mins (1800 seconds) if the fork count & star count is less than 1k otherwise it's 2hours (7200). Also note that cache is clamped to minimum of 30min and maximum of 24hours
 

--- a/readme_cn.md
+++ b/readme_cn.md
@@ -1,5 +1,5 @@
 <p align="center">
- <img width="100px" src="https://res.cloudinary.com/anuraghazra/image/upload/v1594908242/logo_ccswme.svg" align="center" alt="Github Readme Stats" />
+ <img width="100px" src="https://res.cloudinary.com/anuraghazra/image/upload/v1594908242/logo_ccswme.svg" align="center" alt="GitHub Readme Stats" />
  <h2 align="center">GitHub Readme Stats</h2>
  <p align="center">在你的 README 中获取动态生成的 GitHub 统计信息！</p>
 </p>
@@ -101,7 +101,7 @@ _注：如果你是自己部署本项目，私人贡献将会默认被计数，�
 
 dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontrast, dracula
 
-<img src="https://res.cloudinary.com/anuraghazra/image/upload/v1595174536/grs-themes_l4ynja.png" alt="Github Readme Stat Themes" width="600px"/>
+<img src="https://res.cloudinary.com/anuraghazra/image/upload/v1595174536/grs-themes_l4ynja.png" alt="GitHub Readme Stat Themes" width="600px"/>
 
 在 [theme config 文件](./themes/index.js) 中查看更多主题，或者 **贡献新的主题** :D
 
@@ -125,7 +125,7 @@ dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontr
 | show_owner  | boolean   | 显示 Repo 卡片所属账户用户名  | N/A                  | false               | N/A                |
 | show_icons  | boolean   | 显示图标                   | false                | N/A                 | N/A                 |
 | theme       | string    | 设置主题                   | 'default'            | 'default_repocard'  | 'default'          |
-| cache_seconds | number  | 手动设置自定义缓存控制        | 1800                 | 1800               |'1800'            |
+| cache_seconds | number  | 手动设置自定义缓存控制        | 1800                 | 1800               | 1800             |
 | count_private | boolean   | 统计私人贡献计数           | false                | N/A                 | N/A                |
 | layout        | string    | 布局方式                  | N/A                  | N/A                 | 'default'          |
 
@@ -158,9 +158,9 @@ Endpoint: `api/pin?username=anuraghazra&repo=github-readme-stats`
 
 # 热门语言卡片
 
-热门语言卡片显示了Github用户常用的编程语言。
+热门语言卡片显示了GitHub用户常用的编程语言。
 
-*注意：热门语言并不表示我的技能水平或类似的水平，它是用户在Github上拥有最多代码的一项指标，它是github-readme-stats的新功能*
+*注意：热门语言并不表示我的技能水平或类似的水平，它是用户在GitHub上拥有最多代码的一项指标，它是github-readme-stats的新功能*
 
 ### 使用细则
 

--- a/readme_de.md
+++ b/readme_de.md
@@ -1,5 +1,5 @@
 <p align="center">
- <img width="100px" src="https://res.cloudinary.com/anuraghazra/image/upload/v1594908242/logo_ccswme.svg" align="center" alt="Github Readme Stats" /> 
+ <img width="100px" src="https://res.cloudinary.com/anuraghazra/image/upload/v1594908242/logo_ccswme.svg" align="center" alt="GitHub Readme Stats" /> 
  <h2 align="center">GitHub Readme Stats</h2>
  <p align="center">Zeige dynamisch generierte GitHub-Statistiken in deinen Readmes!</p>
 </p>
@@ -82,7 +82,7 @@ Benutze den `?theme=THEME_NAME`-Parameter wie folgt :-
 
 dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontrast, dracula
 
-<img src="https://res.cloudinary.com/anuraghazra/image/upload/v1595174536/grs-themes_l4ynja.png" alt="Github Readme Stat Themes" width="600px"/>
+<img src="https://res.cloudinary.com/anuraghazra/image/upload/v1595174536/grs-themes_l4ynja.png" alt="GitHub Readme Stat Themes" width="600px"/>
 
 Du kannst dir eine Vorschau [aller verfügbaren Themes](./themes/README.md) ansehen oder die [theme config Datei](./themes/index.js) auschecken.
 Außerdem **kannst du neue Themes beisteuern** wenn du möchtest, contributions sind gern gesehen :D
@@ -106,7 +106,7 @@ Anpassungsoptionen:
 | show_owner       | boolean   | zeigt den Namen des Besitzers in der Repo-Karte      | N/A                   | false               | N/A                     |
 | show_icons       | boolean   | zeige Icons an                                       | false                 | N/A                 | N/A                     |
 | theme            | string    | setze eingebaute themes                              | 'default'             | 'default_repocard'  | 'default'               |
-| cache_seconds    | number    | manuelles setzen der Cachezeiten                     | 1800                  | 1800                | '1800'                  |
+| cache_seconds    | number    | manuelles setzen der Cachezeiten                     | 1800                  | 1800                | 1800                    |
 | hide_langs_below | number    | verberge Sprachen unter einem bestimmten Schwellwert | N/A                   | N/A                 | undefined               |
 
 > Hinweis bzgl. des Caches: Wenn die Anzahl der Forks und Stars geringer als 1Tsd ist, haben die Repo-Cards eine default Cachezeit von 30 Minuten (1800 Sekunden), ansonsten beträgt diese 2 Stunden (7200 Sekunden). Außerdem ist der Cache auf eine Minimum von 30 Minuten und ein Maximum von 24 Stunden begrenzt.

--- a/readme_es.md
+++ b/readme_es.md
@@ -1,5 +1,5 @@
 <p align="center">
- <img width="100px" src="https://res.cloudinary.com/anuraghazra/image/upload/v1594908242/logo_ccswme.svg" align="center" alt="Github Readme Stats" />
+ <img width="100px" src="https://res.cloudinary.com/anuraghazra/image/upload/v1594908242/logo_ccswme.svg" align="center" alt="GitHub Readme Stats" />
  <h2 align="center">GitHub Readme Stats</h2>
  <p align="center">¡Obtén tus estadísticas de GitHub generadas dinámicamente en tu README!</p>
 </p>
@@ -97,7 +97,7 @@ Utiliza el parámetro `?theme=THEME_NAME`, de esta manera:
 
 dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontrast, dracula
 
-<img src="https://res.cloudinary.com/anuraghazra/image/upload/v1595174536/grs-themes_l4ynja.png" alt="Github Readme Stat Themes" width="600px"/>
+<img src="https://res.cloudinary.com/anuraghazra/image/upload/v1595174536/grs-themes_l4ynja.png" alt="GitHub Readme Stat Themes" width="600px"/>
 
 Puedes ver una vista previa de [todos los temas disponibles](./themes/README.md) o ver el [archivo de configuración](./themes/index.js) del tema y también **puedes contribuir con nuevos temas** si lo deseas: D
 

--- a/readme_ja.md
+++ b/readme_ja.md
@@ -1,5 +1,5 @@
 <p align="center">
- <img width="100px" src="https://res.cloudinary.com/anuraghazra/image/upload/v1594908242/logo_ccswme.svg" align="center" alt="Github Readme Stats" />
+ <img width="100px" src="https://res.cloudinary.com/anuraghazra/image/upload/v1594908242/logo_ccswme.svg" align="center" alt="GitHub Readme Stats" />
  <h2 align="center">GitHub Readme Stats</h2>
  <p align="center">あなたのREADMEに動的に生成されたGitHubの統計情報を載せましょう！</p>
 </p>
@@ -102,7 +102,7 @@ _Note: このプロジェクトを自分でデプロイしている場合、デ�
 
 dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontrast, dracula
 
-<img src="https://res.cloudinary.com/anuraghazra/image/upload/v1595174536/grs-themes_l4ynja.png" alt="Github Readme Stat Themes" width="600px"/>
+<img src="https://res.cloudinary.com/anuraghazra/image/upload/v1595174536/grs-themes_l4ynja.png" alt="GitHub Readme Stat Themes" width="600px"/>
 
 用意されている全てのテーマの[プレビュー](./themes/README.md)や[設定ファイル](./themes/index.js)を見ることができます。もしよろしければ、**新しいテーマを投稿してみてください** (´∀` )
 
@@ -126,9 +126,9 @@ Customization Options:
 | show_owner    | boolean   | オーナー名の表示                             | N/A                  | false               | N/A                     |
 | show_icons    | boolean   | アイコンの表示                               | false                | N/A                 | N/A                     |
 | theme         | string    | 用意されているテーマ                          | 'default'            | 'default_repocard'  | 'default'               |
-| cache_seconds | number    | キャッシュコントロール                        | 1800                 | 1800                | '1800'                  |
+| cache_seconds | number    | キャッシュコントロール                        | 1800                 | 1800                | 1800                    |
 | count_private | boolean   | private contributions 数をコミット総数に追加  | false                | N/A                 | N/A                     |
-| layout        | string    | レイアウトのオプション選択                    | N/A                  | N/A                 | "default"               |
+| layout        | string    | レイアウトのオプション選択                    | N/A                  | N/A                 | 'default'               |
 
 > キャッシュに関する注意点: Repo cards のデフォルトのキャッシュは、フォーク数とスター数が 1k 未満の場合は 30分(1800秒) で、それ以外の場合は 2時間(7200) です。また、キャッシュは最低でも 30分、最大でも 24時間に制限されていることに注意してください。
 


### PR DESCRIPTION
The following typo has been corrected.

1. Corrected instance of "Github readme stats" to "GitHub Readme Stats"
2. Corrected many instances of "Github" to "GitHub"
3. Corrected the default value of an number type was a string type. (e.g. '1800')
4. Unified to 'default', because "default" and 'default' were mixed up.

Thanks for the useful service.
My README is now cool too.

<3