### PR TITLE
docs: add documentation note for uri-encoded names

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -181,6 +181,10 @@ You can use `?hide=language1,language2` parameter to hide individual languages.
 [![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=anuraghazra&hide=javascript,html)](https://github.com/anuraghazra/github-readme-stats)
 ```
 
+> :warning: **Important:**  
+> Language names should be uri-escaped, as specified in [Percent Encoding](https://en.wikipedia.org/wiki/Percent-encoding)  
+> (i.e: `c++` should become `c%2B%2B`, `jupyter notebook` should become `jupyter%20notebook`, etc.)
+
 ### Compact Language Card Layout
 
 You can use the `&layout=compact` option to change the card design.


### PR DESCRIPTION
### Description:
Add extra reminder for folks who trying to hide languages with uri-reserved characters like "c++" or "jupyter notebook".

Demo:
```
[![swapnanildutta](https://github-readme-stats.vercel.app/api/top-langs/?username=swapnanildutta&hide=c%2B%2B)](https://github.com/swapnanildutta)
```
[![swapnanildutta](https://github-readme-stats.vercel.app/api/top-langs/?username=swapnanildutta&hide=c%2B%2B)](https://github.com/swapnanildutta)

### Issues addressed:
#251