### PR TITLE
Changed most used languages height

### DIFF
--- a/src/renderTopLanguages.js
+++ b/src/renderTopLanguages.js
@@ -110,7 +110,7 @@ const renderTopLanguages = (topLangs, options = {}) => {
   // RENDER COMPACT LAYOUT
   if (layout === "compact") {
     width = width + 50;
-    height = 30 + (langs.length / 2 + 1) * 40;
+    height = 55 + (langs.length / 2 + 1) * 40;
 
     // progressOffset holds the previous language's width and used to offset the next language
     // so that we can stack them one after another, like this: [--][----][---]


### PR DESCRIPTION
I only use StatsCard and TopLanguages, so I put them side by side.
The height of the TopLanguages card is less than of StatsCard.
In this PR I changed the height and they were the same.
And it was like this.

![e.g](https://user-images.githubusercontent.com/56807558/88830865-f0062e00-d1a4-11ea-9b3f-a9f1e7ce411d.png)
