### PR TITLE
Add `solarized` themes

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -125,6 +125,18 @@ const themes = {
     text_color: "ffd95b",
     bg_color: "000000",
   },
+  "solarized-dark": {
+    title_color: "268bd2",
+    icon_color: "b58900",
+    text_color: "859900",
+    bg_color: "002b36",
+  },
+  "solarized-light": {
+    title_color: "268bd2",
+    icon_color: "b58900",
+    text_color: "859900",
+    bg_color: "fdf6e3",
+  },
 };
 
 module.exports = themes;


### PR DESCRIPTION
Hi! @anuraghazra 
`Solarized` is one of the most popular color theme on text editor and terminal.
So I created themes based on solarized-dark and solarized-light.

### solarized-dark
![image](https://user-images.githubusercontent.com/20528138/89100573-ebef4000-d432-11ea-8a74-5a20999ea4cb.png)

### solarized-light
![image](https://user-images.githubusercontent.com/20528138/89100577-f3aee480-d432-11ea-819d-7499a0880daf.png)
