### PR TITLE
Count top language in all repos

### DIFF
--- a/tests/fetchTopLanguages.test.js
+++ b/tests/fetchTopLanguages.test.js
@@ -39,6 +39,10 @@ const data_langs = {
             },
           },
         ],
+        pageInfo: {
+          endCursor: "",
+          hasNextPage: false,
+        },
       },
     },
   },

--- a/tests/top-langs.test.js
+++ b/tests/top-langs.test.js
@@ -35,6 +35,10 @@ const data_langs = {
             },
           },
         ],
+        pageInfo: {
+          endCursor: "",
+          hasNextPage: false,
+        },
       },
     },
   },


### PR DESCRIPTION
For #270.

Not measure the execute time in vercel serverless function.
I think it will be a good solution for instance server.
``` 
http://localhost:3000/api/top-langs/?username=sindresorhus&layout=compact&count_private=true&theme=dark
```
I just test on my machine.
The execute time for sindresorhus who has 1029 repos is 4.57 seconds on master  branch.
![image](https://user-images.githubusercontent.com/20241522/89387012-79cd7280-d734-11ea-8d2b-60d7cd98abf2.png)

And on this branch, the execute time it 22.74 seconds.
![image](https://user-images.githubusercontent.com/20241522/89387161-aed9c500-d734-11ea-9bb8-85051ae4d8ae.png)



For tj who has 296 repos it is 4.13 seconds on master branch.
```
http://localhost:3000/api/top-langs/?username=tj&layout=compact&count_private=true&theme=dark
```
![image](https://user-images.githubusercontent.com/20241522/89387820-a2a23780-d735-11ea-929c-158d105d447b.png)


And it is 7.64 seconds on this branch.
![image](https://user-images.githubusercontent.com/20241522/89387877-bbaae880-d735-11ea-90ab-3426d6700c0e.png)

