### PR TITLE
Add material-palenight theme

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -155,6 +155,12 @@ const themes = {
     text_color: "99d1ce",
     bg_color: "0c1014",
   },
+  "material-palenight": {
+    title_color: "c792ea",
+    icon_color: "89ddff",
+    text_color: "a6accd",
+    bg_color: "292d3e",
+  },
 };
 
 module.exports = themes;


### PR DESCRIPTION
Hi! I love this colorscheme and I use on my entire system. so I would like to add this theme.
You can see preview [here](https://github.com/btwiusegentoo)

links about this colorscheme
https://www.material-theme.com/docs/reference/color-palette/
https://github.com/drewtempelmeyer/palenight.vim
https://marketplace.visualstudio.com/items?itemName=whizkydee.material-palenight-theme

Edit: Add actual pictures as preview
![GitHub stats](https://github-readme-stats.vercel.app/api?username=btwiusegentoo&show_icons=true&theme=dracula&title_color=c792ea&text_color=a6accd&icon_color=89ddff&bg_color=292d3e)

![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=btwiusegentoo&layout=compact&theme=dracula&title_color=c792ea&text_color=a6accd&icon_color=89ddff&bg_color=292d3e)