### PR TITLE
Add query parameter for last year of languages shown in languages card (#371)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vercel
 .env
+.idea
 node_modules
 package-lock.json
 *.lock

--- a/api/top-langs.js
+++ b/api/top-langs.js
@@ -14,6 +14,7 @@ module.exports = async (req, res) => {
     username,
     hide,
     hide_title,
+    from_date,
     hide_border,
     card_width,
     title_color,
@@ -28,7 +29,11 @@ module.exports = async (req, res) => {
   res.setHeader("Content-Type", "image/svg+xml");
 
   try {
-    topLangs = await fetchTopLanguages(username);
+    const fetchFromDate = new Date(from_date);
+    topLangs = await fetchTopLanguages(
+      username,
+      !isNaN(fetchFromDate.getTime()) ? fetchFromDate : null
+    );
 
     const cacheSeconds = clampValue(
       parseInt(cache_seconds || CONSTANTS.TWO_HOURS, 10),

--- a/readme.md
+++ b/readme.md
@@ -157,6 +157,7 @@ You can provide multiple comma separated values in bg_color option to render a g
 
 #### Language Card Exclusive Options:
 
+- `from_date` - Include only languages in repos that you pushed to after specified date
 - `hide` - Hide the languages specified from the card _(Comma seperated values)_
 - `hide_title` - _(boolean)_
 - `layout` - Switch between two available layouts `default` & `compact`

--- a/tests/fetchTopLanguages.test.js
+++ b/tests/fetchTopLanguages.test.js
@@ -15,16 +15,19 @@ const data_langs = {
       repositories: {
         nodes: [
           {
+            pushedAt: "2020-06-04T06:32:05Z",
             languages: {
               edges: [{ size: 100, node: { color: "#0f0", name: "HTML" } }],
             },
           },
           {
+            pushedAt: "2020-06-05T06:32:05Z",
             languages: {
               edges: [{ size: 100, node: { color: "#0f0", name: "HTML" } }],
             },
           },
           {
+            pushedAt: "2020-07-05T06:32:05Z",
             languages: {
               edges: [
                 { size: 100, node: { color: "#0ff", name: "javascript" } },
@@ -32,6 +35,7 @@ const data_langs = {
             },
           },
           {
+            pushedAt: "2020-07-06T06:32:05Z",
             languages: {
               edges: [
                 { size: 100, node: { color: "#0ff", name: "javascript" } },
@@ -66,6 +70,19 @@ describe("FetchTopLanguages", () => {
         name: "HTML",
         size: 200,
       },
+      javascript: {
+        color: "#0ff",
+        name: "javascript",
+        size: 200,
+      },
+    });
+  });
+
+  it('should fetch correct language data after given date', async () => {
+    mock.onPost("https://api.github.com/graphql").reply(200, data_langs);
+
+    let repo = await fetchTopLanguages("anuraghazra", new Date("2020-06-05T07:32:05Z"));
+    expect(repo).toStrictEqual({
       javascript: {
         color: "#0ff",
         name: "javascript",


### PR DESCRIPTION
I added a query parameter `from_date` that excludes languages in repositories that had no push activity after the specified date. 

DEMO : https://github-readme-stats.bartolomej.vercel.app/api/top-langs/?username=bartolomej&from_date=2020-07-01