### PR TITLE
style(theme): Adding two themes based on the light blue known as Aofuji

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -180,15 +180,15 @@ const themes = {
     bg_color: "002b36",
   },
   "fuji-light":{
-    title_color: "8aa2d3",
-    icon_color: "8aa2d3",
-    text_color: "9ea1a3",
+    title_color: "7793cc",
+    icon_color: "7793cc",
+    text_color: "595858",
     bg_color: "ffffff",
   },
   "fuji-dark":{
-    title_color: "8aa2d3",
-    icon_color: "8aa2d3",
-    text_color: "c0c0c0",
+    title_color: "a1b4db",
+    icon_color: "a1b4db",
+    text_color: "e6e6e6",
     bg_color: "4d5158",
   }
 };

--- a/themes/index.js
+++ b/themes/index.js
@@ -178,6 +178,18 @@ const themes = {
     icon_color: "19f9d8",
     text_color: "ffffff",
     bg_color: "002b36",
+  },
+  "fuji-light":{
+    title_color: "8aa2d3",
+    icon_color: "8aa2d3",
+    text_color: "9ea1a3",
+    bg_color: "ffffff",
+  },
+  "fuji-dark":{
+    title_color: "8aa2d3",
+    icon_color: "8aa2d3",
+    text_color: "c0c0c0",
+    bg_color: "4d5158",
   }
 };
 


### PR DESCRIPTION
Adding two light-weight themes based on the light blue known as Aofuji.
These two were used a lot in most of my own web design projects, and I received quite a bit of positive feedback from the community.

Fuji lite example: `fuji-light`
![DSRKafuU's Github Stats](https://github-readme-stats.vercel.app/api?username=amzrk2&count_private=true&show_icons=true&title_color=8aa2d3&icon_color=8aa2d3&text_color=9ea1a3&bg_color=ffffff)
Fuji dark example: `fuji-dark`
![DSRKafuU's Github Stats](https://github-readme-stats.vercel.app/api?username=amzrk2&count_private=true&show_icons=true&title_color=8aa2d3&icon_color=8aa2d3&text_color=c0c0c0&bg_color=4d5158)
