### PR TITLE
Fix commits count when include_all_commits is true

### DIFF
--- a/src/fetchers/stats-fetcher.js
+++ b/src/fetchers/stats-fetcher.js
@@ -102,11 +102,6 @@ async function fetchStats(
 
   let res = await retryer(fetcher, { login: username });
 
-  let experimental_totalCommits = 0;
-  if (include_all_commits) {
-    experimental_totalCommits = await totalCommitsFetcher(username);
-  }
-
   if (res.data.errors) {
     logger.error(res.data.errors);
     throw new CustomError(
@@ -116,16 +111,18 @@ async function fetchStats(
   }
 
   const user = res.data.data.user;
-  const contributionCount = user.contributionsCollection;
 
   stats.name = user.name || user.login;
   stats.totalIssues = user.issues.totalCount;
 
-  stats.totalCommits =
-    contributionCount.totalCommitContributions + experimental_totalCommits;
+  stats.totalCommits = user.contributionsCollection.totalCommitContributions;
 
   if (count_private) {
-    stats.totalCommits += contributionCount.restrictedContributionsCount;
+    stats.totalCommits += user.contributionsCollection.restrictedContributionsCount;
+  }
+
+  if (include_all_commits) {
+    stats.totalCommits = await totalCommitsFetcher(username);
   }
 
   stats.totalPRs = user.pullRequests.totalCount;

--- a/tests/fetchStats.test.js
+++ b/tests/fetchStats.test.js
@@ -114,7 +114,7 @@ describe("Test fetchStats", () => {
 
     let stats = await fetchStats("anuraghazra", true, true);
     const rank = calculateRank({
-      totalCommits: 1000 + 150,
+      totalCommits: 1000,
       totalRepos: 5,
       followers: 100,
       contributions: 61,
@@ -126,7 +126,7 @@ describe("Test fetchStats", () => {
     expect(stats).toStrictEqual({
       contributedTo: 61,
       name: "Anurag Hazra",
-      totalCommits: 1000 + 150,
+      totalCommits: 1000,
       totalIssues: 200,
       totalPRs: 300,
       totalStars: 400,


### PR DESCRIPTION
The `totalCommitsFetcher` already sends the total number of commits, we don't need to add the values returned by the GraphQL API

Fixes #298

#### Current master:
![Minji's Stats](https://github-readme-stats.vercel.app/api?username=minji-o-j&count_private=true&include_all_commits=true)
![Minji's Stats](https://github-readme-stats.vercel.app/api?username=minji-o-j&count_private=true)

#### My fork:
![Minji's Stats](https://ghrs.vercel.app/api?username=minji-o-j&count_private=true&include_all_commits=true)
![Minji's Stats](https://ghrs.vercel.app/api?username=minji-o-j&count_private=true)
