### PR TITLE
Update stats-card.js

### DIFF
--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -89,7 +89,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     commits: {
       icon: icons.commits,
       label: `Total Commits${
-        include_all_commits ? "" : ` (${new Date().getFullYear()})`
+        include_all_commits ? "" : ` (last year)`
       }`,
       value: totalCommits,
       id: "commits",


### PR DESCRIPTION
Since, totalCommits is counting the commits from "past one year" and not just of the current year, so the label should display last year instead.