### PR TITLE
Top Languages: fix fetching

### DIFF
--- a/src/fetchers/top-languages-fetcher.js
+++ b/src/fetchers/top-languages-fetcher.js
@@ -51,7 +51,6 @@ async function fetchTopLanguages(username) {
     })
     // flatten the list of language nodes
     .reduce((acc, curr) => curr.languages.edges.concat(acc), [])
-    .sort((a, b) => b.size - a.size)
     .reduce((acc, prev) => {
       // get the size of the language (bytes)
       let langSize = prev.size;
@@ -73,6 +72,7 @@ async function fetchTopLanguages(username) {
     }, {});
 
   const topLangs = Object.keys(repoNodes)
+    .sort((a, b) => repoNodes[b].size - repoNodes[a].size)
     .slice(0, 5)
     .reduce((result, key) => {
       result[key] = repoNodes[key];


### PR DESCRIPTION
This is a lazy fix: the sorting now is done properly, not relying on **Object.keys** method.

Should fix #432, fix #403, and fix #303.