### PR TITLE
Update vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,7 +4,7 @@
       "source": "/",
       "destination": "https://github.com/anuraghazra/github-readme-stats"
     }
-  ]
+  ],
   "cleanUrls": true,
   "trailingSlash": false
 }

--- a/vercel.json
+++ b/vercel.json
@@ -5,4 +5,6 @@
       "destination": "https://github.com/anuraghazra/github-readme-stats"
     }
   ]
+  "cleanUrls": true,
+  "trailingSlash": false
 }


### PR DESCRIPTION
Allowed clean URLs and disallowed trailing slashes in Vercel.json.

Will cause the following example redirects:
`https://github-readme-stats.vercel.app/api/pin.js` → `https://github-readme-stats.vercel.app/api/pin`
`https://github-readme-stats.vercel.app/api/pin/` → `https://github-readme-stats.vercel.app/api/pin`