### PR TITLE
feat: number of languages param for top langs card

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ node_modules
 package-lock.json
 *.lock
 .vscode/
+.idea/
 coverage

--- a/api/top-langs.js
+++ b/api/top-langs.js
@@ -23,6 +23,7 @@ module.exports = async (req, res) => {
     theme,
     cache_seconds,
     layout,
+    num_langs
   } = req.query;
   let topLangs;
 
@@ -33,7 +34,7 @@ module.exports = async (req, res) => {
   }
 
   try {
-    topLangs = await fetchTopLanguages(username);
+    topLangs = await fetchTopLanguages(username, num_langs);
 
     const cacheSeconds = clampValue(
       parseInt(cache_seconds || CONSTANTS.TWO_HOURS, 10),

--- a/api/top-langs.js
+++ b/api/top-langs.js
@@ -23,7 +23,7 @@ module.exports = async (req, res) => {
     theme,
     cache_seconds,
     layout,
-    num_langs
+    langs_count,
   } = req.query;
   let topLangs;
 
@@ -34,7 +34,7 @@ module.exports = async (req, res) => {
   }
 
   try {
-    topLangs = await fetchTopLanguages(username, num_langs);
+    topLangs = await fetchTopLanguages(username, langs_count);
 
     const cacheSeconds = clampValue(
       parseInt(cache_seconds || CONSTANTS.TWO_HOURS, 10),

--- a/readme.md
+++ b/readme.md
@@ -165,6 +165,7 @@ You can provide multiple comma separated values in bg_color option to render a g
 - `hide_title` - _(boolean)_
 - `layout` - Switch between two available layouts `default` & `compact`
 - `card_width` - Set the card's width manually _(number)_
+- `langs_count` - Show more languages on the card, between 1-10, defaults to 5 _(number)_
 
 > :warning: **Important:**  
 > Language names should be uri-escaped, as specified in [Percent Encoding](https://en.wikipedia.org/wiki/Percent-encoding)  
@@ -220,12 +221,12 @@ You can use `?hide=language1,language2` parameter to hide individual languages.
 [![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=anuraghazra&hide=javascript,html)](https://github.com/anuraghazra/github-readme-stats)
 ```
 
-### Shore more languages
+### Show more languages
 
-You can use the `&num_langs=num` option to increase or decrease the number of languages shown on the card. Valid values are integers between 1 and 10 (inclusive), and the default is 5.
+You can use the `&langs_count=` option to increase or decrease the number of languages shown on the card. Valid values are integers between 1 and 10 (inclusive), and the default is 5.
 
 ```md
-[![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=anuraghazra&num_langs=8)](https://github.com/anuraghazra/github-readme-stats)
+[![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=anuraghazra&langs_count=8)](https://github.com/anuraghazra/github-readme-stats)
 ```
 
 ### Compact Language Card Layout

--- a/readme.md
+++ b/readme.md
@@ -200,7 +200,7 @@ Use [show_owner](#customization) variable to include the repo's owner username
 
 Top languages card shows github user's top languages which have been mostly used.
 
-_NOTE: Top languages does not indicate my skill level or something like that, it's a github metric of which languages i have the most code on github, it's a new feature of github-readme-stats_
+_NOTE: Top languages does not indicate my skill level or something like that, it's a github metric of which languages have the most code on github, it's a new feature of github-readme-stats_
 
 ### Usage
 
@@ -218,6 +218,14 @@ You can use `?hide=language1,language2` parameter to hide individual languages.
 
 ```md
 [![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=anuraghazra&hide=javascript,html)](https://github.com/anuraghazra/github-readme-stats)
+```
+
+### Shore more languages
+
+You can use the `&num_langs=num` option to increase or decrease the number of languages shown on the card. Valid values are integers between 1 and 10 (inclusive), and the default is 5.
+
+```md
+[![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=anuraghazra&num_langs=8)](https://github.com/anuraghazra/github-readme-stats)
 ```
 
 ### Compact Language Card Layout

--- a/src/cards/top-languages-card.js
+++ b/src/cards/top-languages-card.js
@@ -112,7 +112,7 @@ const renderTopLanguages = (topLangs, options = {}) => {
   // RENDER COMPACT LAYOUT
   if (layout === "compact") {
     width = width + 50;
-    height = 30 + (langs.length / 2 + 1) * 40;
+    height = 90 + Math.round(langs.length / 2) * 25;
 
     // progressOffset holds the previous language's width and used to offset the next language
     // so that we can stack them one after another, like this: [--][----][---]

--- a/src/fetchers/top-languages-fetcher.js
+++ b/src/fetchers/top-languages-fetcher.js
@@ -1,4 +1,4 @@
-const { request, logger } = require("../common/utils");
+const { request, logger, clampValue } = require("../common/utils");
 const retryer = require("../common/retryer");
 require("dotenv").config();
 
@@ -36,8 +36,7 @@ const fetcher = (variables, token) => {
 async function fetchTopLanguages(username, amount=5) {
   if (!username) throw Error("Invalid username");
 
-  amount = parseInt(amount)
-  if (amount > 10 || amount < 1) throw Error("Invalid number of languages")
+  amount = clampValue(parseInt(amount) || 5, 1, 10)
 
   let res = await retryer(fetcher, { login: username });
 

--- a/src/fetchers/top-languages-fetcher.js
+++ b/src/fetchers/top-languages-fetcher.js
@@ -33,12 +33,12 @@ const fetcher = (variables, token) => {
   );
 };
 
-async function fetchTopLanguages(username, amount=5) {
+async function fetchTopLanguages(username, langsCount = 5) {
   if (!username) throw Error("Invalid username");
 
-  amount = clampValue(parseInt(amount) || 5, 1, 10)
+  langsCount = clampValue(parseInt(langsCount), 1, 10);
 
-  let res = await retryer(fetcher, { login: username });
+  const res = await retryer(fetcher, { login: username });
 
   if (res.data.errors) {
     logger.error(res.data.errors);
@@ -75,7 +75,7 @@ async function fetchTopLanguages(username, amount=5) {
     }, {});
 
   const topLangs = Object.keys(repoNodes)
-    .slice(0, amount)
+    .slice(0, langsCount)
     .reduce((result, key) => {
       result[key] = repoNodes[key];
       return result;

--- a/src/fetchers/top-languages-fetcher.js
+++ b/src/fetchers/top-languages-fetcher.js
@@ -33,8 +33,11 @@ const fetcher = (variables, token) => {
   );
 };
 
-async function fetchTopLanguages(username) {
+async function fetchTopLanguages(username, amount=5) {
   if (!username) throw Error("Invalid username");
+
+  amount = parseInt(amount)
+  if (amount > 10 || amount < 1) throw Error("Invalid number of languages")
 
   let res = await retryer(fetcher, { login: username });
 
@@ -73,7 +76,7 @@ async function fetchTopLanguages(username) {
     }, {});
 
   const topLangs = Object.keys(repoNodes)
-    .slice(0, 5)
+    .slice(0, amount)
     .reduce((result, key) => {
       result[key] = repoNodes[key];
       return result;

--- a/tests/fetchTopLanguages.test.js
+++ b/tests/fetchTopLanguages.test.js
@@ -74,6 +74,19 @@ describe("FetchTopLanguages", () => {
     });
   });
 
+  it("should fetch langs with specified langs_count", async () => {
+    mock.onPost("https://api.github.com/graphql").reply(200, data_langs);
+
+    let repo = await fetchTopLanguages("anuraghazra", 1);
+    expect(repo).toStrictEqual({
+      javascript: {
+        color: "#0ff",
+        name: "javascript",
+        size: 200,
+      },
+    });
+  });
+
   it("should throw error", async () => {
     mock.onPost("https://api.github.com/graphql").reply(200, error);
 


### PR DESCRIPTION
Simply allows a user to specify how many languages to show on the top-langs card, between 1 and 10. Default is still 5.

Example here: [https://benjamins-readme-stats-bt29bovd9.vercel.app/api/top-langs/?username=scitronboy&layout=compact&theme=gruvbox&num_langs=10](https://benjamins-readme-stats-bt29bovd9.vercel.app/api/top-langs/?username=scitronboy&layout=compact&theme=gruvbox&num_langs=10)

Let me know if I need to add anything else to the PR.