### PR TITLE
fix: use consistent case for card titles

### DIFF
--- a/src/cards/wakatime-card.js
+++ b/src/cards/wakatime-card.js
@@ -120,7 +120,7 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
   });
 
   const card = new Card({
-    title: "Wakatime week stats",
+    title: "Wakatime Week Stats",
     width: 495,
     height,
     colors: {


### PR DESCRIPTION
The WakaTIme stats card used different casing for the title than other cards.