### PR TITLE
Card translations

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -28,6 +28,7 @@ module.exports = async (req, res) => {
     theme,
     cache_seconds,
     custom_title,
+    lang,
   } = req.query;
   let stats;
 
@@ -35,6 +36,9 @@ module.exports = async (req, res) => {
 
   if (blacklist.includes(username)) {
     return res.send(renderError("Something went wrong"));
+  }
+  if (lang && ![ "cn", "de", "en", "es", "fr", "it", "ja", "kr", "pt-br" ].includes(lang.toLowerCase())) {
+    return res.send(renderError("Something went wrong", "Language not found"));
   }
 
   try {
@@ -67,6 +71,7 @@ module.exports = async (req, res) => {
         bg_color,
         theme,
         custom_title,
+        lang: lang ? lang.toLowerCase() : null,
       }),
     );
   } catch (err) {

--- a/api/index.js
+++ b/api/index.js
@@ -5,6 +5,7 @@ const {
   parseArray,
   clampValue,
   CONSTANTS,
+  isLocaleAvailable,
 } = require("../src/common/utils");
 const fetchStats = require("../src/fetchers/stats-fetcher");
 const renderStatsCard = require("../src/cards/stats-card");
@@ -28,7 +29,7 @@ module.exports = async (req, res) => {
     theme,
     cache_seconds,
     custom_title,
-    lang,
+    locale,
   } = req.query;
   let stats;
 
@@ -37,7 +38,8 @@ module.exports = async (req, res) => {
   if (blacklist.includes(username)) {
     return res.send(renderError("Something went wrong"));
   }
-  if (lang && ![ "cn", "de", "en", "es", "fr", "it", "ja", "kr", "pt-br" ].includes(lang.toLowerCase())) {
+
+  if (locale && !isLocaleAvailable(locale)) {
     return res.send(renderError("Something went wrong", "Language not found"));
   }
 
@@ -71,7 +73,7 @@ module.exports = async (req, res) => {
         bg_color,
         theme,
         custom_title,
-        lang: lang ? lang.toLowerCase() : null,
+        locale: locale ? locale.toLowerCase() : null,
       }),
     );
   } catch (err) {

--- a/api/pin.js
+++ b/api/pin.js
@@ -21,6 +21,7 @@ module.exports = async (req, res) => {
     theme,
     show_owner,
     cache_seconds,
+    lang,
   } = req.query;
 
   let repoData;
@@ -29,6 +30,10 @@ module.exports = async (req, res) => {
 
   if (blacklist.includes(username)) {
     return res.send(renderError("Something went wrong"));
+  }
+
+  if (lang && ![ "cn", "de", "en", "es", "fr", "it", "ja", "kr", "pt-br" ].includes(lang.toLowerCase())) {
+    return res.send(renderError("Something went wrong", "Language not found"));
   }
 
   try {
@@ -64,6 +69,7 @@ module.exports = async (req, res) => {
         bg_color,
         theme,
         show_owner: parseBoolean(show_owner),
+        lang: lang ? lang.toLowerCase() : null,
       }),
     );
   } catch (err) {

--- a/api/pin.js
+++ b/api/pin.js
@@ -4,6 +4,7 @@ const {
   parseBoolean,
   clampValue,
   CONSTANTS,
+  isLocaleAvailable,
 } = require("../src/common/utils");
 const fetchRepo = require("../src/fetchers/repo-fetcher");
 const renderRepoCard = require("../src/cards/repo-card");
@@ -21,7 +22,7 @@ module.exports = async (req, res) => {
     theme,
     show_owner,
     cache_seconds,
-    lang,
+    locale,
   } = req.query;
 
   let repoData;
@@ -32,7 +33,7 @@ module.exports = async (req, res) => {
     return res.send(renderError("Something went wrong"));
   }
 
-  if (lang && ![ "cn", "de", "en", "es", "fr", "it", "ja", "kr", "pt-br" ].includes(lang.toLowerCase())) {
+  if (locale && !isLocaleAvailable(locale)) {
     return res.send(renderError("Something went wrong", "Language not found"));
   }
 
@@ -69,7 +70,7 @@ module.exports = async (req, res) => {
         bg_color,
         theme,
         show_owner: parseBoolean(show_owner),
-        lang: lang ? lang.toLowerCase() : null,
+        locale: locale ? locale.toLowerCase() : null,
       }),
     );
   } catch (err) {

--- a/api/top-langs.js
+++ b/api/top-langs.js
@@ -26,6 +26,7 @@ module.exports = async (req, res) => {
     langs_count,
     exclude_repo,
     custom_title,
+    lang,
   } = req.query;
   let topLangs;
 
@@ -33,6 +34,10 @@ module.exports = async (req, res) => {
 
   if (blacklist.includes(username)) {
     return res.send(renderError("Something went wrong"));
+  }
+
+  if (lang && ![ "cn", "de", "en", "es", "fr", "it", "ja", "kr", "pt-br" ].includes(lang.toLowerCase())) {
+    return res.send(renderError("Something went wrong", "Language not found"));
   }
 
   try {
@@ -62,6 +67,7 @@ module.exports = async (req, res) => {
         bg_color,
         theme,
         layout,
+        lang: lang ? lang.toLowerCase() : null,
       }),
     );
   } catch (err) {

--- a/api/top-langs.js
+++ b/api/top-langs.js
@@ -5,6 +5,7 @@ const {
   parseBoolean,
   parseArray,
   CONSTANTS,
+  isLocaleAvailable,
 } = require("../src/common/utils");
 const fetchTopLanguages = require("../src/fetchers/top-languages-fetcher");
 const renderTopLanguages = require("../src/cards/top-languages-card");
@@ -26,7 +27,7 @@ module.exports = async (req, res) => {
     langs_count,
     exclude_repo,
     custom_title,
-    lang,
+    locale,
   } = req.query;
   let topLangs;
 
@@ -36,7 +37,7 @@ module.exports = async (req, res) => {
     return res.send(renderError("Something went wrong"));
   }
 
-  if (lang && ![ "cn", "de", "en", "es", "fr", "it", "ja", "kr", "pt-br" ].includes(lang.toLowerCase())) {
+  if (locale && !isLocaleAvailable(locale)) {
     return res.send(renderError("Something went wrong", "Language not found"));
   }
 
@@ -67,7 +68,7 @@ module.exports = async (req, res) => {
         bg_color,
         theme,
         layout,
-        lang: lang ? lang.toLowerCase() : null,
+        locale: locale ? locale.toLowerCase() : null,
       }),
     );
   } catch (err) {

--- a/api/wakatime.js
+++ b/api/wakatime.js
@@ -4,6 +4,7 @@ const {
   parseBoolean,
   clampValue,
   CONSTANTS,
+  isLocaleAvailable,
 } = require("../src/common/utils");
 const { fetchLast7Days } = require("../src/fetchers/wakatime-fetcher");
 const wakatimeCard = require("../src/cards/wakatime-card");
@@ -22,12 +23,12 @@ module.exports = async (req, res) => {
     hide_title,
     hide_progress,
     custom_title,
-    lang,
+    locale,
   } = req.query;
 
   res.setHeader("Content-Type", "image/svg+xml");
 
-  if (lang && ![ "cn", "de", "en", "es", "fr", "it", "ja", "kr", "pt-br" ].includes(lang.toLowerCase())) {
+  if (locale && !isLocaleAvailable(locale)) {
     return res.send(renderError("Something went wrong", "Language not found"));
   }
 
@@ -58,7 +59,7 @@ module.exports = async (req, res) => {
         bg_color,
         theme,
         hide_progress,
-        lang: lang ? lang.toLowerCase() : null,
+        locale: locale ? locale.toLowerCase() : null,
       }),
     );
   } catch (err) {

--- a/api/wakatime.js
+++ b/api/wakatime.js
@@ -22,9 +22,14 @@ module.exports = async (req, res) => {
     hide_title,
     hide_progress,
     custom_title,
+    lang,
   } = req.query;
 
   res.setHeader("Content-Type", "image/svg+xml");
+
+  if (lang && ![ "cn", "de", "en", "es", "fr", "it", "ja", "kr", "pt-br" ].includes(lang.toLowerCase())) {
+    return res.send(renderError("Something went wrong", "Language not found"));
+  }
 
   try {
     const last7Days = await fetchLast7Days({ username });
@@ -53,6 +58,7 @@ module.exports = async (req, res) => {
         bg_color,
         theme,
         hide_progress,
+        lang: lang ? lang.toLowerCase() : null,
       }),
     );
   } catch (err) {

--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,7 @@ You can customize the appearance of your `Stats Card` or `Repo Card` however you
 - `hide_border` - Hides the card's border _(boolean)_
 - `theme` - name of the theme, choose from [all available themes](./themes/README.md)
 - `cache_seconds` - set the cache header manually _(min: 1800, max: 86400)_
+- `lang` - set the language in the card _(e.g. cn, de, es, etc.)_
 
 ##### Gradient in bg_color
 

--- a/src/cards/repo-card.js
+++ b/src/cards/repo-card.js
@@ -1,3 +1,4 @@
+const toEmoji = require("emoji-name-map");
 const {
   kFormatter,
   encodeHTML,
@@ -5,9 +6,10 @@ const {
   FlexLayout,
   wrapTextMultiline,
 } = require("../common/utils");
-const icons = require("../common/icons");
+const I18n = require("../common/I18n");
 const Card = require("../common/Card");
-const toEmoji = require("emoji-name-map");
+const icons = require("../common/icons");
+const { repoCardLocales } = require("../translations");
 
 const renderRepoCard = (repo, options = {}) => {
   const {
@@ -28,33 +30,8 @@ const renderRepoCard = (repo, options = {}) => {
     bg_color,
     show_owner,
     theme = "default_repocard",
-    lang = "en",
+    locale,
   } = options;
-
-  const translations = {
-    template: {
-      cn: "模板",
-      de: "Vorlage",
-      en: "Template",
-      es: "Modelo",
-      fr: "Modèle",
-      it: "Template",
-      ja: "テンプレート",
-      kr: "주형",
-      "pt-br": "Modelo",
-    },
-    archived: {
-      cn: "已封存",
-      de: "Archiviert",
-      en: "Archived",
-      es: "Archivé",
-      fr: "Archivé",
-      it: "Archiviata",
-      ja: "アーカイブ済み",
-      kr: "보관 됨",
-      "pt-br": "Arquivada",
-    },
-  };
 
   const header = show_owner ? nameWithOwner : name;
   const langName = (primaryLanguage && primaryLanguage.name) || "Unspecified";
@@ -76,6 +53,11 @@ const renderRepoCard = (repo, options = {}) => {
   const height =
     (descriptionLines > 1 ? 120 : 110) + descriptionLines * lineHeight;
 
+  const i18n = new I18n({
+    locale,
+    translations: repoCardLocales,
+  });
+
   // returns theme based colors with proper overrides and defaults
   const { titleColor, textColor, iconColor, bgColor } = getCardColors({
     title_color,
@@ -89,7 +71,7 @@ const renderRepoCard = (repo, options = {}) => {
   const totalForks = kFormatter(forkCount);
 
   const getBadgeSVG = (label) => `
-    <g data-testid="badge" class="badge" transform="translate(320, 38)">
+    <g data-testid="badge" class="badge" transform="translate(320, -18)">
       <rect stroke="${textColor}" stroke-width="1" width="70" height="20" x="-12" y="-14" ry="10" rx="10"></rect>
       <text
         x="23" y="-5"
@@ -158,9 +140,9 @@ const renderRepoCard = (repo, options = {}) => {
   return card.render(`
     ${
       isTemplate
-        ? getBadgeSVG(translations.template[lang] || "Template")
+        ? getBadgeSVG(i18n.t("repocard.template"))
         : isArchived
-        ? getBadgeSVG(translations.archived[lang] || "Archived")
+        ? getBadgeSVG(i18n.t("repocard.archived"))
         : ""
     }
 

--- a/src/cards/repo-card.js
+++ b/src/cards/repo-card.js
@@ -54,7 +54,7 @@ const renderRepoCard = (repo, options = {}) => {
       kr: "보관 됨",
       "pt-br": "Arquivada",
     },
-  }
+  };
 
   const header = show_owner ? nameWithOwner : name;
   const langName = (primaryLanguage && primaryLanguage.name) || "Unspecified";
@@ -156,17 +156,18 @@ const renderRepoCard = (repo, options = {}) => {
   `);
 
   return card.render(`
-    ${isTemplate
-      ? getBadgeSVG(translations.template[lang] || "Template")
-      : isArchived
+    ${
+      isTemplate
+        ? getBadgeSVG(translations.template[lang] || "Template")
+        : isArchived
         ? getBadgeSVG(translations.archived[lang] || "Archived")
         : ""
     }
 
     <text class="description" x="25" y="-5">
       ${multiLineDescription
-      .map((line) => `<tspan dy="1.2em" x="25">${encodeHTML(line)}</tspan>`)
-      .join("")}
+        .map((line) => `<tspan dy="1.2em" x="25">${encodeHTML(line)}</tspan>`)
+        .join("")}
     </text>
 
     <g transform="translate(0, ${height - 75})">

--- a/src/cards/repo-card.js
+++ b/src/cards/repo-card.js
@@ -140,9 +140,9 @@ const renderRepoCard = (repo, options = {}) => {
   return card.render(`
     ${
       isTemplate
-        ? getBadgeSVG(i18n.t("template"))
+        ? getBadgeSVG(i18n.t("repocard.template"))
         : isArchived
-        ? getBadgeSVG(i18n.t("archived"))
+        ? getBadgeSVG(i18n.t("repocard.archived"))
         : ""
     }
 

--- a/src/cards/repo-card.js
+++ b/src/cards/repo-card.js
@@ -140,9 +140,9 @@ const renderRepoCard = (repo, options = {}) => {
   return card.render(`
     ${
       isTemplate
-        ? getBadgeSVG(i18n.t("repocard.template"))
+        ? getBadgeSVG(i18n.t("template"))
         : isArchived
-        ? getBadgeSVG(i18n.t("repocard.archived"))
+        ? getBadgeSVG(i18n.t("archived"))
         : ""
     }
 

--- a/src/cards/repo-card.js
+++ b/src/cards/repo-card.js
@@ -28,7 +28,33 @@ const renderRepoCard = (repo, options = {}) => {
     bg_color,
     show_owner,
     theme = "default_repocard",
+    lang = "en",
   } = options;
+
+  const translations = {
+    template: {
+      cn: "模板",
+      de: "Vorlage",
+      en: "Template",
+      es: "Modelo",
+      fr: "Modèle",
+      it: "Modella",
+      ja: "テンプレート",
+      kr: "주형",
+      "pt-br": "Modelo",
+    },
+    archived: {
+      cn: "已封存",
+      de: "Archiviert",
+      en: "Archived",
+      es: "Archivé",
+      fr: "Archivé",
+      it: "Archiviata",
+      ja: "アーカイブ済み",
+      kr: "보관 됨",
+      "pt-br": "Arquivada",
+    },
+  }
 
   const header = show_owner ? nameWithOwner : name;
   const langName = (primaryLanguage && primaryLanguage.name) || "Unspecified";
@@ -132,9 +158,9 @@ const renderRepoCard = (repo, options = {}) => {
   return card.render(`
     ${
       isTemplate
-        ? getBadgeSVG("Template")
+        ? getBadgeSVG(translations.template[lang] || "Template")
         : isArchived
-        ? getBadgeSVG("Archived")
+        ? getBadgeSVG(translations.archived[lang] || "Archived")
         : ""
     }
 

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -87,13 +87,13 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
   const STATS = {
     stars: {
       icon: icons.star,
-      label: i18n.t("statcard.totalstars"),
+      label: i18n.t("totalstars"),
       value: totalStars,
       id: "stars",
     },
     commits: {
       icon: icons.commits,
-      label: `${i18n.t("statcard.commits")}${
+      label: `${i18n.t("commits")}${
         include_all_commits ? "" : ` (${new Date().getFullYear()})`
       }`,
       value: totalCommits,
@@ -101,19 +101,19 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     },
     prs: {
       icon: icons.prs,
-      label: i18n.t("statcard.prs"),
+      label: i18n.t("prs"),
       value: totalPRs,
       id: "prs",
     },
     issues: {
       icon: icons.issues,
-      label: i18n.t("statcard.issues"),
+      label: i18n.t("issues"),
       value: totalIssues,
       id: "issues",
     },
     contribs: {
       icon: icons.contribs,
-      label: i18n.t("statcard.contribs"),
+      label: i18n.t("contribs"),
       value: contributedTo,
       id: "contribs",
     },
@@ -172,7 +172,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
 
   const card = new Card({
     customTitle: custom_title,
-    defaultTitle: i18n.t("statcard.title"),
+    defaultTitle: i18n.t("title"),
     width: 495,
     height,
     colors: {

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -31,7 +31,7 @@ const createTextNode = ({
       <text class="stat bold" ${labelOffset} y="12.5">${label}:</text>
       <text 
         class="stat" 
-        x="${shiftValuePos ? (showIcons ? 200 : 170) : 150}" 
+        x="${(showIcons ? 140 : 120) + shiftValuePos}" 
         y="12.5" 
         data-testid="${id}"
       >${kValue}</text>
@@ -119,6 +119,8 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     },
   };
 
+  const isLongLocale = ["fr", "pt-br", "es"].includes(locale) === true;
+
   // filter out hidden stats defined by user & create the text nodes
   const statItems = Object.keys(STATS)
     .filter((key) => !hide.includes(key))
@@ -128,7 +130,8 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
         ...STATS[key],
         index,
         showIcons: show_icons,
-        shiftValuePos: !include_all_commits,
+        shiftValuePos:
+          (!include_all_commits ? 50 : 20) + (isLongLocale ? 50 : 0),
       }),
     );
 

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -1,12 +1,9 @@
-const {
-  kFormatter,
-  getCardColors,
-  FlexLayout,
-  encodeHTML,
-} = require("../common/utils");
-const { getStyles } = require("../getStyles");
-const icons = require("../common/icons");
+const I18n = require("../common/I18n");
 const Card = require("../common/Card");
+const icons = require("../common/icons");
+const { getStyles } = require("../getStyles");
+const { statCardLocales } = require("../translations");
+const { kFormatter, getCardColors, FlexLayout } = require("../common/utils");
 
 const createTextNode = ({
   icon,
@@ -66,7 +63,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     bg_color,
     theme = "default",
     custom_title,
-    lang = "en",
+    locale,
   } = options;
 
   const lheight = parseInt(line_height, 10);
@@ -81,86 +78,22 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
   });
 
   const apostrophe = ["x", "s"].includes(name.slice(-1)) ? "" : "s";
-  const translations = {
-    title: {
-      cn: `${encodeHTML(name)}的GitHub统计`,
-      de: `${encodeHTML(name) + apostrophe} GitHub-Statistiken`,
-      en: `${encodeHTML(name)}'${apostrophe} GitHub Stats`,
-      es: `Estadísticas de GitHub de ${encodeHTML(name)}`,
-      fr: `Statistiques GitHub de ${encodeHTML(name)}`,
-      it: `Statistiche GitHub di ${encodeHTML(name)}`,
-      ja: `${encodeHTML(name)}のGitHub統計`,
-      kr: `${encodeHTML(name)}의 GitHub 통계`,
-      "pt-br": `Estatísticas do GitHub de ${encodeHTML(name)}`,
-    },
-    stars: {
-      cn: "总星数",
-      de: "Sterne Insgesamt",
-      en: "Total Stars",
-      es: "Estrellas totales",
-      fr: "Total d'étoiles",
-      it: "Stelle totali",
-      ja: "星の合計",
-      kr: "총 별",
-      "pt-br": "Total de estrelas",
-    },
-    commits: {
-      cn: "总承诺",
-      de: "Anzahl Commits",
-      en: "Total Commits",
-      es: "Compromisos totales",
-      fr: "Total des engagements",
-      it: "Commit totali",
-      ja: "総コミット",
-      kr: "총 커밋",
-      "pt-br": "Total de compromissos",
-    },
-    prs: {
-      cn: "总公关",
-      de: "PRs Insgesamt",
-      en: "Total PRs",
-      es: "RP totales",
-      fr: "Total des PR",
-      it: "PR totali",
-      ja: "合計PR",
-      kr: "총 PR",
-      "pt-br": "Total de PRs",
-    },
-    issues: {
-      cn: "总发行量",
-      de: "Anzahl Issues",
-      en: "Total Issues",
-      es: "Problemas totales",
-      fr: "Nombre total de problèmes",
-      it: "Segnalazioni totali",
-      ja: "総問題",
-      kr: "총 문제",
-      "pt-br": "Total de problemas",
-    },
-    contribs: {
-      cn: "有助于",
-      de: "Beigetragen zu",
-      en: "Contributed to",
-      es: "Contribuido a",
-      fr: "Contribué à",
-      it: "Ha contribuito a",
-      ja: "に貢献しました",
-      kr: "에 기여하다",
-      "pt-br": "Contribuiu para",
-    },
-  };
+  const i18n = new I18n({
+    locale,
+    translations: statCardLocales({ name, apostrophe }),
+  });
 
   // Meta data for creating text nodes with createTextNode function
   const STATS = {
     stars: {
       icon: icons.star,
-      label: translations.stars[lang] || "Total Stars",
+      label: i18n.t("statcard.totalstars"),
       value: totalStars,
       id: "stars",
     },
     commits: {
       icon: icons.commits,
-      label: `${translations.commits[lang] || "Total Commits"}${
+      label: `${i18n.t("statcard.commits")}${
         include_all_commits ? "" : ` (${new Date().getFullYear()})`
       }`,
       value: totalCommits,
@@ -168,19 +101,19 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     },
     prs: {
       icon: icons.prs,
-      label: translations.prs[lang] || "Total PRs",
+      label: i18n.t("statcard.prs"),
       value: totalPRs,
       id: "prs",
     },
     issues: {
       icon: icons.issues,
-      label: translations.issues[lang] || "Total Issues",
+      label: i18n.t("statcard.issues"),
       value: totalIssues,
       id: "issues",
     },
     contribs: {
       icon: icons.contribs,
-      label: translations.contribs[lang] || "Contributed to",
+      label: i18n.t("statcard.contribs"),
       value: contributedTo,
       id: "contribs",
     },
@@ -239,9 +172,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
 
   const card = new Card({
     customTitle: custom_title,
-    defaultTitle:
-      translations.title[lang] ||
-      `${encodeHTML(name)}'${apostrophe} GitHub Stats`,
+    defaultTitle: i18n.t("statcard.title"),
     width: 495,
     height,
     colors: {

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -95,7 +95,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     },
     stars: {
       cn: "总星数",
-      de: "Insgesamt Sterne",
+      de: "Sterne Insgesamt",
       en: "Total Stars",
       es: "Estrellas totales",
       fr: "Total d'étoiles",
@@ -106,7 +106,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     },
     commits: {
       cn: "总承诺",
-      de: "Total Commits",
+      de: "Anzahl Commits",
       en: "Total Commits",
       es: "Compromisos totales",
       fr: "Total des engagements",
@@ -117,7 +117,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     },
     prs: {
       cn: "总公关",
-      de: "PRs insgesamt",
+      de: "PRs Insgesamt",
       en: "Total PRs",
       es: "RP totales",
       fr: "Total des PR",
@@ -128,7 +128,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     },
     issues: {
       cn: "总发行量",
-      de: "Gesamtausgaben",
+      de: "Anzahl Issues",
       en: "Total Issues",
       es: "Problemas totales",
       fr: "Nombre total de problèmes",

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -66,6 +66,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     bg_color,
     theme = "default",
     custom_title,
+    lang = "en",
   } = options;
 
   const lheight = parseInt(line_height, 10);
@@ -79,17 +80,87 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     theme,
   });
 
+  const apostrophe = ["x", "s"].includes(name.slice(-1)) ? "" : "s";
+  const translations = {
+    title: {
+      cn: `${encodeHTML(name)}的GitHub统计`,
+      de: `${encodeHTML(name) + apostrophe} GitHub-Statistiken`,
+      en: `${encodeHTML(name)}'${apostrophe} GitHub Stats`,
+      es: `Estadísticas de GitHub de ${encodeHTML(name)}`,
+      fr: `Statistiques GitHub de ${encodeHTML(name)}`,
+      it: `Statistiche GitHub di ${encodeHTML(name)}`,
+      ja: `${encodeHTML(name)}のGitHub統計`,
+      kr: `${encodeHTML(name)}의 GitHub 통계`,
+      "pt-br": `Estatísticas do GitHub de ${encodeHTML(name)}`,
+    },
+    stars: {
+      cn: "总星数",
+      de: "Insgesamt Sterne",
+      en: "Total Stars",
+      es: "Estrellas totales",
+      fr: "Total d'étoiles",
+      it: "Stelle totali",
+      ja: "星の合計",
+      kr: "총 별",
+      "pt-br": "Total de estrelas",
+    },
+    commits: {
+      cn: "总承诺",
+      de: "Total Commits",
+      en: "Total Commits",
+      es: "Compromisos totales",
+      fr: "Total des engagements",
+      it: "Impegni totali",
+      ja: "総コミット",
+      kr: "총 커밋",
+      "pt-br": "Total de compromissos",
+    },
+    prs: {
+      cn: "总公关",
+      de: "PRs insgesamt",
+      en: "Total PRs",
+      es: "RP totales",
+      fr: "Total des PR",
+      it: "PR totali",
+      ja: "合計PR",
+      kr: "총 PR",
+      "pt-br": "Total de PRs",
+    },
+    issues: {
+      cn: "总发行量",
+      de: "Gesamtausgaben",
+      en: "Total Issues",
+      es: "Problemas totales",
+      fr: "Nombre total de problèmes",
+      it: "Problemi totali",
+      ja: "総問題",
+      kr: "총 문제",
+      "pt-br": "Total de problemas",
+    },
+    contribs: {
+      cn: "有助于",
+      de: "Beigetragen zu",
+      en: "Contributed to",
+      es: "Contribuido a",
+      fr: "Contribué à",
+      it: "Ha contribuito a",
+      ja: "に貢献しました",
+      kr: "에 기여하다",
+      "pt-br": "Contribuiu para",
+    }
+  }
+
   // Meta data for creating text nodes with createTextNode function
   const STATS = {
     stars: {
       icon: icons.star,
-      label: "Total Stars",
+      label: translations.stars[lang] || "Total Stars",
       value: totalStars,
       id: "stars",
     },
     commits: {
       icon: icons.commits,
-      label: `Total Commits${
+      label: `${translations.commits[lang] || "Total Commits"}${
         include_all_commits ? "" : ` (${new Date().getFullYear()})`
       }`,
       value: totalCommits,
@@ -97,19 +168,19 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     },
     prs: {
       icon: icons.prs,
-      label: "Total PRs",
+      label: translations.prs[lang] || "Total PRs",
       value: totalPRs,
       id: "prs",
     },
     issues: {
       icon: icons.issues,
-      label: "Total Issues",
+      label: translations.issues[lang] || "Total Issues",
       value: totalIssues,
       id: "issues",
     },
     contribs: {
       icon: icons.contribs,
-      label: "Contributed to",
+      label: translations.contribs[lang] || "Contributed to",
       value: contributedTo,
       id: "contribs",
     },
@@ -166,10 +237,9 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     progress,
   });
 
-  const apostrophe = ["x", "s"].includes(name.slice(-1)) ? "" : "s";
   const card = new Card({
     customTitle: custom_title,
-    defaultTitle: `${encodeHTML(name)}'${apostrophe} GitHub Stats`,
+    defaultTitle: translations.title[lang] || `${encodeHTML(name)}'${apostrophe} GitHub Stats`,
     width: 495,
     height,
     colors: {

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -87,13 +87,13 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
   const STATS = {
     stars: {
       icon: icons.star,
-      label: i18n.t("totalstars"),
+      label: i18n.t("statcard.totalstars"),
       value: totalStars,
       id: "stars",
     },
     commits: {
       icon: icons.commits,
-      label: `${i18n.t("commits")}${
+      label: `${i18n.t("statcard.commits")}${
         include_all_commits ? "" : ` (${new Date().getFullYear()})`
       }`,
       value: totalCommits,
@@ -101,19 +101,19 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     },
     prs: {
       icon: icons.prs,
-      label: i18n.t("prs"),
+      label: i18n.t("statcard.prs"),
       value: totalPRs,
       id: "prs",
     },
     issues: {
       icon: icons.issues,
-      label: i18n.t("issues"),
+      label: i18n.t("statcard.issues"),
       value: totalIssues,
       id: "issues",
     },
     contribs: {
       icon: icons.contribs,
-      label: i18n.t("contribs"),
+      label: i18n.t("statcard.contribs"),
       value: contributedTo,
       id: "contribs",
     },
@@ -172,7 +172,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
 
   const card = new Card({
     customTitle: custom_title,
-    defaultTitle: i18n.t("title"),
+    defaultTitle: i18n.t("statcard.title"),
     width: 495,
     height,
     colors: {

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -147,8 +147,8 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
       ja: "に貢献しました",
       kr: "에 기여하다",
       "pt-br": "Contribuiu para",
-    }
-  }
+    },
+  };
 
   // Meta data for creating text nodes with createTextNode function
   const STATS = {
@@ -160,8 +160,9 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     },
     commits: {
       icon: icons.commits,
-      label: `${translations.commits[lang] || "Total Commits"}${include_all_commits ? "" : ` (${new Date().getFullYear()})`
-        }`,
+      label: `${translations.commits[lang] || "Total Commits"}${
+        include_all_commits ? "" : ` (${new Date().getFullYear()})`
+      }`,
       value: totalCommits,
       id: "commits",
     },
@@ -238,7 +239,9 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
 
   const card = new Card({
     customTitle: custom_title,
-    defaultTitle: translations.title[lang] || `${encodeHTML(name)}'${apostrophe} GitHub Stats`,
+    defaultTitle:
+      translations.title[lang] ||
+      `${encodeHTML(name)}'${apostrophe} GitHub Stats`,
     width: 495,
     height,
     colors: {
@@ -258,10 +261,10 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
 
     <svg x="0" y="0">
       ${FlexLayout({
-    items: statItems,
-    gap: lheight,
-    direction: "column",
-  }).join("")}
+        items: statItems,
+        gap: lheight,
+        direction: "column",
+      }).join("")}
     </svg> 
   `);
 };

--- a/src/cards/top-languages-card.js
+++ b/src/cards/top-languages-card.js
@@ -11,13 +11,13 @@ const createProgressTextNode = ({ width, color, name, progress }) => {
     <text data-testid="lang-name" x="2" y="15" class="lang-name">${name}</text>
     <text x="${progressTextX}" y="34" class="lang-name">${progress}%</text>
     ${createProgressNode({
-    x: 0,
-    y: 25,
-    color,
-    width: progressWidth,
-    progress,
-    progressBarBackgroundColor: "#ddd",
-  })}
+      x: 0,
+      y: 25,
+      color,
+      width: progressWidth,
+      progress,
+      progressBarBackgroundColor: "#ddd",
+    })}
   `;
 };
 
@@ -88,7 +88,7 @@ const renderTopLanguages = (topLangs, options = {}) => {
       kr: "가장 많이 사용되는 언어",
       "pt-br": "Línguas Mais Usadas",
     },
-  }
+  };
 
   // populate langsToHide map for quick lookup
   // while filtering out
@@ -158,8 +158,9 @@ const renderTopLanguages = (topLangs, options = {}) => {
 
     finalLayout = `
       <mask id="rect-mask">
-        <rect x="0" y="0" width="${width - 50
-      }" height="8" fill="white" rx="5" />
+        <rect x="0" y="0" width="${
+          width - 50
+        }" height="8" fill="white" rx="5" />
       </mask>
       ${compactProgressBar}
       ${createLanguageTextNode({

--- a/src/cards/top-languages-card.js
+++ b/src/cards/top-languages-card.js
@@ -70,10 +70,25 @@ const renderTopLanguages = (topLangs, options = {}) => {
     theme,
     layout,
     custom_title,
+    lang= "en",
   } = options;
 
   let langs = Object.values(topLangs);
   let langsToHide = {};
+
+  const translations = {
+    title: {
+      cn: "最常用的语言",
+      de: "Meist verwendete Sprachen",
+      en: "Most Used Languages",
+      es: "Idiomas más usados",
+      fr: "Langues les plus utilisées",
+      it: "Lingue più utilizzate",
+      ja: "最もよく使われる言語",
+      kr: "가장 많이 사용되는 언어",
+      "pt-br": "Línguas Mais Usadas",
+    },
+  }
 
   // populate langsToHide map for quick lookup
   // while filtering out
@@ -172,7 +187,7 @@ const renderTopLanguages = (topLangs, options = {}) => {
 
   const card = new Card({
     customTitle: custom_title,
-    defaultTitle: "Most Used Languages",
+    defaultTitle: translations.title[lang] || "Most Used Languages",
     width,
     height,
     colors: {

--- a/src/cards/top-languages-card.js
+++ b/src/cards/top-languages-card.js
@@ -180,7 +180,7 @@ const renderTopLanguages = (topLangs, options = {}) => {
 
   const card = new Card({
     customTitle: custom_title,
-    defaultTitle: i18n.t("title"),
+    defaultTitle: i18n.t("langcard.title"),
     width,
     height,
     colors: {

--- a/src/cards/top-languages-card.js
+++ b/src/cards/top-languages-card.js
@@ -1,6 +1,8 @@
 const Card = require("../common/Card");
 const { getCardColors, FlexLayout } = require("../common/utils");
 const { createProgressNode } = require("../common/createProgressNode");
+const { langCardLocales } = require("../translations");
+const I18n = require("../common/I18n");
 
 const createProgressTextNode = ({ width, color, name, progress }) => {
   const paddingRight = 95;
@@ -70,25 +72,16 @@ const renderTopLanguages = (topLangs, options = {}) => {
     theme,
     layout,
     custom_title,
-    lang = "en",
+    locale,
   } = options;
+
+  const i18n = new I18n({
+    locale,
+    translations: langCardLocales,
+  });
 
   let langs = Object.values(topLangs);
   let langsToHide = {};
-
-  const translations = {
-    title: {
-      cn: "最常用的语言",
-      de: "Meist verwendete Sprachen",
-      en: "Most Used Languages",
-      es: "Idiomas más usados",
-      fr: "Langues les plus utilisées",
-      it: "Linguaggi più utilizzati",
-      ja: "最もよく使われる言語",
-      kr: "가장 많이 사용되는 언어",
-      "pt-br": "Línguas Mais Usadas",
-    },
-  };
 
   // populate langsToHide map for quick lookup
   // while filtering out
@@ -187,7 +180,7 @@ const renderTopLanguages = (topLangs, options = {}) => {
 
   const card = new Card({
     customTitle: custom_title,
-    defaultTitle: translations.title[lang] || "Most Used Languages",
+    defaultTitle: i18n.t("langcard.title"),
     width,
     height,
     colors: {

--- a/src/cards/top-languages-card.js
+++ b/src/cards/top-languages-card.js
@@ -180,7 +180,7 @@ const renderTopLanguages = (topLangs, options = {}) => {
 
   const card = new Card({
     customTitle: custom_title,
-    defaultTitle: i18n.t("langcard.title"),
+    defaultTitle: i18n.t("title"),
     width,
     height,
     colors: {

--- a/src/cards/wakatime-card.js
+++ b/src/cards/wakatime-card.js
@@ -1,5 +1,7 @@
 const Card = require("../common/Card");
+const I18n = require("../common/I18n");
 const { getStyles } = require("../getStyles");
+const { wakatimeCardLocales } = require("../translations");
 const { getCardColors, FlexLayout } = require("../common/utils");
 const { createProgressNode } = require("../common/createProgressNode");
 
@@ -60,33 +62,13 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
     theme = "default",
     hide_progress,
     custom_title,
-    lang = "en",
+    locale,
   } = options;
 
-  const translations = {
-    title: {
-      cn: "Wakatime周统计",
-      de: "Wakatime Wochen Status",
-      en: "Wakatime Week Stats",
-      es: "Estadísticas de la semana de Wakatime",
-      fr: "Statistiques de la semaine Wakatime",
-      it: "Statistiche della settimana di Wakatime",
-      ja: "ワカタイムウィーク統計",
-      kr: "Wakatime 주간 통계",
-      "pt-br": "Estatísticas da semana Wakatime",
-    },
-    noCodingActivity: {
-      cn: "本周没有编码活动",
-      de: "Keine Codierungsaktivität diese Woche",
-      en: "No coding activity this week",
-      es: "No hay actividad de codificación esta semana",
-      fr: "Aucune activité de codage cette semaine",
-      it: "Nessuna attività in questa settimana",
-      ja: "今週のコーディング活動はありません",
-      kr: "이번 주 코딩 활동 없음",
-      "pt-br": "Nenhuma atividade de codificação esta semana",
-    },
-  };
+  const i18n = new I18n({
+    locale,
+    translations: wakatimeCardLocales,
+  });
 
   const lheight = parseInt(line_height, 10);
 
@@ -127,7 +109,7 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
 
   const card = new Card({
     customTitle: custom_title,
-    defaultTitle: translations.title[lang] || "Wakatime Week Stats",
+    defaultTitle: i18n.t("wakatimecard.title"),
     width: 495,
     height,
     colors: {
@@ -155,9 +137,7 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
           : [
               noCodingActivityNode({
                 color: textColor,
-                text:
-                  translations.noCodingActivity[lang] ||
-                  "No coding activity this week",
+                text: i18n.t("wakatimecard.nocodingactivity"),
               }),
             ],
         gap: lheight,

--- a/src/cards/wakatime-card.js
+++ b/src/cards/wakatime-card.js
@@ -109,7 +109,7 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
 
   const card = new Card({
     customTitle: custom_title,
-    defaultTitle: i18n.t("wakatimecard.title"),
+    defaultTitle: i18n.t("title"),
     width: 495,
     height,
     colors: {
@@ -137,7 +137,7 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
           : [
               noCodingActivityNode({
                 color: textColor,
-                text: i18n.t("wakatimecard.nocodingactivity"),
+                text: i18n.t("nocodingactivity"),
               }),
             ],
         gap: lheight,

--- a/src/cards/wakatime-card.js
+++ b/src/cards/wakatime-card.js
@@ -66,7 +66,7 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
   const translations = {
     title: {
       cn: "Wakatime周统计",
-      de: "Wakatime Week Stats",
+      de: "Wakatime Wochen Status",
       en: "Wakatime Week Stats",
       es: "Estadísticas de la semana de Wakatime",
       fr: "Statistiques de la semaine Wakatime",

--- a/src/cards/wakatime-card.js
+++ b/src/cards/wakatime-card.js
@@ -3,9 +3,9 @@ const { getStyles } = require("../getStyles");
 const { getCardColors, FlexLayout } = require("../common/utils");
 const { createProgressNode } = require("../common/createProgressNode");
 
-const noCodingActivityNode = ({ color }) => {
+const noCodingActivityNode = ({ color, text }) => {
   return `
-    <text x="25" y="11" class="stat bold" fill="${color}">No coding activity this week</text>
+    <text x="25" y="11" class="stat bold" fill="${color}">${text}</text>
   `;
 };
 
@@ -60,7 +60,33 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
     theme = "default",
     hide_progress,
     custom_title,
+    lang = "en",
   } = options;
+
+  const translations = {
+    title: {
+      cn: "Wakatime周统计",
+      de: "Wakatime Week Stats",
+      en: "Wakatime Week Stats",
+      es: "Estadísticas de la semana de Wakatime",
+      fr: "Statistiques de la semaine Wakatime",
+      it: "Statistiche della settimana di Wakatime",
+      ja: "ワカタイムウィーク統計",
+      kr: "Wakatime 주간 통계",
+      "pt-br": "Estatísticas da semana Wakatime",
+    },
+    noCodingActivity: {
+      cn: "本周没有编码活动",
+      de: "Keine Codierungsaktivität diese Woche",
+      en: "No coding activity this week",
+      es: "No hay actividad de codificación esta semana",
+      fr: "Aucune activité de codage cette semaine",
+      it: "Nessuna attività di codifica questa settimana",
+      ja: "今週のコーディング活動はありません",
+      kr: "이번 주 코딩 활동 없음",
+      "pt-br": "Nenhuma atividade de codificação esta semana",
+    },
+  }
 
   const lheight = parseInt(line_height, 10);
 
@@ -101,7 +127,7 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
 
   const card = new Card({
     customTitle: custom_title,
-    defaultTitle: "Wakatime Week Stats",
+    defaultTitle: translations.title[lang] || "Wakatime Week Stats",
     width: 495,
     height,
     colors: {
@@ -126,7 +152,7 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
       ${FlexLayout({
         items: statItems.length
           ? statItems
-          : [noCodingActivityNode({ color: textColor })],
+          : [noCodingActivityNode({ color: textColor, text: translations.noCodingActivity[lang] || "No coding activity this week" })],
         gap: lheight,
         direction: "column",
       }).join("")}

--- a/src/cards/wakatime-card.js
+++ b/src/cards/wakatime-card.js
@@ -109,7 +109,7 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
 
   const card = new Card({
     customTitle: custom_title,
-    defaultTitle: i18n.t("title"),
+    defaultTitle: i18n.t("wakatimecard.title"),
     width: 495,
     height,
     colors: {
@@ -137,7 +137,7 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
           : [
               noCodingActivityNode({
                 color: textColor,
-                text: i18n.t("nocodingactivity"),
+                text: i18n.t("wakatimecard.nocodingactivity"),
               }),
             ],
         gap: lheight,

--- a/src/cards/wakatime-card.js
+++ b/src/cards/wakatime-card.js
@@ -24,14 +24,14 @@ const createTextNode = ({
   const cardProgress = hideProgress
     ? null
     : createProgressNode({
-      x: 110,
-      y: 4,
-      progress: percent,
-      color: progressBarColor,
-      width: 220,
-      name: label,
-      progressBarBackgroundColor,
-    });
+        x: 110,
+        y: 4,
+        progress: percent,
+        color: progressBarColor,
+        width: 220,
+        name: label,
+        progressBarBackgroundColor,
+      });
 
   return `
     <g class="stagger" style="animation-delay: ${staggerDelay}ms" transform="translate(25, 0)">
@@ -86,7 +86,7 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
       kr: "이번 주 코딩 활동 없음",
       "pt-br": "Nenhuma atividade de codificação esta semana",
     },
-  }
+  };
 
   const lheight = parseInt(line_height, 10);
 
@@ -101,18 +101,18 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
 
   const statItems = languages
     ? languages
-      .filter((language) => language.hours || language.minutes)
-      .map((language) => {
-        return createTextNode({
-          id: language.name,
-          label: language.name,
-          value: language.text,
-          percent: language.percent,
-          progressBarColor: titleColor,
-          progressBarBackgroundColor: textColor,
-          hideProgress: hide_progress,
-        });
-      })
+        .filter((language) => language.hours || language.minutes)
+        .map((language) => {
+          return createTextNode({
+            id: language.name,
+            label: language.name,
+            value: language.text,
+            percent: language.percent,
+            progressBarColor: titleColor,
+            progressBarBackgroundColor: textColor,
+            hideProgress: hide_progress,
+          });
+        })
     : [];
 
   // Calculate the card height depending on how many items there are
@@ -150,12 +150,19 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
   return card.render(`
     <svg x="0" y="0" width="100%">
       ${FlexLayout({
-    items: statItems.length
-      ? statItems
-      : [noCodingActivityNode({ color: textColor, text: translations.noCodingActivity[lang] || "No coding activity this week" })],
-    gap: lheight,
-    direction: "column",
-  }).join("")}
+        items: statItems.length
+          ? statItems
+          : [
+              noCodingActivityNode({
+                color: textColor,
+                text:
+                  translations.noCodingActivity[lang] ||
+                  "No coding activity this week",
+              }),
+            ],
+        gap: lheight,
+        direction: "column",
+      }).join("")}
     </svg> 
   `);
 };

--- a/src/common/I18n.js
+++ b/src/common/I18n.js
@@ -1,0 +1,21 @@
+class I18n {
+  constructor({ locale, translations }) {
+    this.locale = locale;
+    this.translations = translations;
+    this.fallbackLocale = "en";
+  }
+
+  t(str) {
+    if (!this.translations[str]) {
+      throw new Error(`${str} Translation string not found`);
+    }
+
+    if (!this.translations[str][this.locale || this.fallbackLocale]) {
+      throw new Error(`${str} Translation locale not found`);
+    }
+
+    return this.translations[str][this.locale || this.fallbackLocale];
+  }
+}
+
+module.exports = I18n;

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -188,6 +188,12 @@ class CustomError extends Error {
   static USER_NOT_FOUND = "USER_NOT_FOUND";
 }
 
+function isLocaleAvailable(locale) {
+  return ["cn", "de", "en", "es", "fr", "it", "ja", "kr", "pt-br"].includes(
+    locale.toLowerCase(),
+  );
+}
+
 module.exports = {
   renderError,
   kFormatter,
@@ -201,6 +207,7 @@ module.exports = {
   getCardColors,
   clampValue,
   wrapTextMultiline,
+  isLocaleAvailable,
   logger,
   CONSTANTS,
   CustomError,

--- a/src/translations.js
+++ b/src/translations.js
@@ -124,7 +124,7 @@ const wakatimeCardLocales = {
   },
   "nocodingactivity": {
     cn: "本周没有编码活动",
-    de: "Keine Codierungsaktivität diese Woche",
+    de: "Keine Aktivitäten in dieser Woche",
     en: "No coding activity this week",
     es: "No hay actividad de codificación esta semana",
     fr: "Aucune activité de codage cette semaine",

--- a/src/translations.js
+++ b/src/translations.js
@@ -1,0 +1,143 @@
+const { encodeHTML } = require("./common/utils");
+
+const statCardLocales = ({ name, apostrophe }) => {
+  return {
+    "statcard.title": {
+      cn: `${encodeHTML(name)}的GitHub统计`,
+      de: `${encodeHTML(name) + apostrophe} GitHub-Statistiken`,
+      en: `${encodeHTML(name)}'${apostrophe} GitHub Stats`,
+      es: `Estadísticas de GitHub de ${encodeHTML(name)}`,
+      fr: `Statistiques GitHub de ${encodeHTML(name)}`,
+      it: `Statistiche GitHub di ${encodeHTML(name)}`,
+      ja: `${encodeHTML(name)}のGitHub統計`,
+      kr: `${encodeHTML(name)}의 GitHub 통계`,
+      "pt-br": `Estatísticas do GitHub de ${encodeHTML(name)}`,
+    },
+    "statcard.totalstars": {
+      cn: "总星数",
+      de: "Sterne Insgesamt",
+      en: "Total Stars",
+      es: "Estrellas totales",
+      fr: "Total d'étoiles",
+      it: "Stelle totali",
+      ja: "星の合計",
+      kr: "총 별",
+      "pt-br": "Total de estrelas",
+    },
+    "statcard.commits": {
+      cn: "总承诺",
+      de: "Anzahl Commits",
+      en: "Total Commits",
+      es: "Compromisos totales",
+      fr: "Total des engagements",
+      it: "Commit totali",
+      ja: "総コミット",
+      kr: "총 커밋",
+      "pt-br": "Total de compromissos",
+    },
+    "statcard.prs": {
+      cn: "总公关",
+      de: "PRs Insgesamt",
+      en: "Total PRs",
+      es: "RP totales",
+      fr: "Total des PR",
+      it: "PR totali",
+      ja: "合計PR",
+      kr: "총 PR",
+      "pt-br": "Total de PRs",
+    },
+    "statcard.issues": {
+      cn: "总发行量",
+      de: "Anzahl Issues",
+      en: "Total Issues",
+      es: "Problemas totales",
+      fr: "Nombre total de problèmes",
+      it: "Segnalazioni totali",
+      ja: "総問題",
+      kr: "총 문제",
+      "pt-br": "Total de problemas",
+    },
+    "statcard.contribs": {
+      cn: "有助于",
+      de: "Beigetragen zu",
+      en: "Contributed to",
+      es: "Contribuido a",
+      fr: "Contribué à",
+      it: "Ha contribuito a",
+      ja: "に貢献しました",
+      kr: "에 기여하다",
+      "pt-br": "Contribuiu para",
+    },
+  };
+};
+
+const repoCardLocales = {
+  "repocard.template": {
+    cn: "模板",
+    de: "Vorlage",
+    en: "Template",
+    es: "Modelo",
+    fr: "Modèle",
+    it: "Template",
+    ja: "テンプレート",
+    kr: "주형",
+    "pt-br": "Modelo",
+  },
+  "repocard.archived": {
+    cn: "已封存",
+    de: "Archiviert",
+    en: "Archived",
+    es: "Archivé",
+    fr: "Archivé",
+    it: "Archiviata",
+    ja: "アーカイブ済み",
+    kr: "보관 됨",
+    "pt-br": "Arquivada",
+  },
+};
+
+const langCardLocales = {
+  "langcard.title": {
+    cn: "最常用的语言",
+    de: "Meist verwendete Sprachen",
+    en: "Most Used Languages",
+    es: "Idiomas más usados",
+    fr: "Langues les plus utilisées",
+    it: "Linguaggi più utilizzati",
+    ja: "最もよく使われる言語",
+    kr: "가장 많이 사용되는 언어",
+    "pt-br": "Línguas Mais Usadas",
+  },
+};
+
+const wakatimeCardLocales = {
+  "wakatimecard.title": {
+    cn: "Wakatime周统计",
+    de: "Wakatime Wochen Status",
+    en: "Wakatime Week Stats",
+    es: "Estadísticas de la semana de Wakatime",
+    fr: "Statistiques de la semaine Wakatime",
+    it: "Statistiche della settimana di Wakatime",
+    ja: "ワカタイムウィーク統計",
+    kr: "Wakatime 주간 통계",
+    "pt-br": "Estatísticas da semana Wakatime",
+  },
+  "wakatimecard.nocodingactivity": {
+    cn: "本周没有编码活动",
+    de: "Keine Codierungsaktivität diese Woche",
+    en: "No coding activity this week",
+    es: "No hay actividad de codificación esta semana",
+    fr: "Aucune activité de codage cette semaine",
+    it: "Nessuna attività in questa settimana",
+    ja: "今週のコーディング活動はありません",
+    kr: "이번 주 코딩 활동 없음",
+    "pt-br": "Nenhuma atividade de codificação esta semana",
+  },
+};
+
+module.exports = {
+  statCardLocales,
+  repoCardLocales,
+  langCardLocales,
+  wakatimeCardLocales,
+};

--- a/src/translations.js
+++ b/src/translations.js
@@ -2,7 +2,7 @@ const { encodeHTML } = require("./common/utils");
 
 const statCardLocales = ({ name, apostrophe }) => {
   return {
-    "statcard.title": {
+    "title": {
       cn: `${encodeHTML(name)}的GitHub统计`,
       de: `${encodeHTML(name) + apostrophe} GitHub-Statistiken`,
       en: `${encodeHTML(name)}'${apostrophe} GitHub Stats`,
@@ -13,7 +13,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       kr: `${encodeHTML(name)}의 GitHub 통계`,
       "pt-br": `Estatísticas do GitHub de ${encodeHTML(name)}`,
     },
-    "statcard.totalstars": {
+    "totalstars": {
       cn: "总星数",
       de: "Sterne Insgesamt",
       en: "Total Stars",
@@ -24,7 +24,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       kr: "총 별",
       "pt-br": "Total de estrelas",
     },
-    "statcard.commits": {
+    "commits": {
       cn: "总承诺",
       de: "Anzahl Commits",
       en: "Total Commits",
@@ -35,7 +35,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       kr: "총 커밋",
       "pt-br": "Total de compromissos",
     },
-    "statcard.prs": {
+    "prs": {
       cn: "总公关",
       de: "PRs Insgesamt",
       en: "Total PRs",
@@ -46,7 +46,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       kr: "총 PR",
       "pt-br": "Total de PRs",
     },
-    "statcard.issues": {
+    "issues": {
       cn: "总发行量",
       de: "Anzahl Issues",
       en: "Total Issues",
@@ -57,7 +57,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       kr: "총 문제",
       "pt-br": "Total de problemas",
     },
-    "statcard.contribs": {
+    "contribs": {
       cn: "有助于",
       de: "Beigetragen zu",
       en: "Contributed to",
@@ -72,7 +72,7 @@ const statCardLocales = ({ name, apostrophe }) => {
 };
 
 const repoCardLocales = {
-  "repocard.template": {
+  "template": {
     cn: "模板",
     de: "Vorlage",
     en: "Template",
@@ -83,7 +83,7 @@ const repoCardLocales = {
     kr: "주형",
     "pt-br": "Modelo",
   },
-  "repocard.archived": {
+  "archived": {
     cn: "已封存",
     de: "Archiviert",
     en: "Archived",
@@ -97,7 +97,7 @@ const repoCardLocales = {
 };
 
 const langCardLocales = {
-  "langcard.title": {
+  "title": {
     cn: "最常用的语言",
     de: "Meist verwendete Sprachen",
     en: "Most Used Languages",
@@ -111,7 +111,7 @@ const langCardLocales = {
 };
 
 const wakatimeCardLocales = {
-  "wakatimecard.title": {
+  "title": {
     cn: "Wakatime周统计",
     de: "Wakatime Wochen Status",
     en: "Wakatime Week Stats",
@@ -122,7 +122,7 @@ const wakatimeCardLocales = {
     kr: "Wakatime 주간 통계",
     "pt-br": "Estatísticas da semana Wakatime",
   },
-  "wakatimecard.nocodingactivity": {
+  "nocodingactivity": {
     cn: "本周没有编码活动",
     de: "Keine Codierungsaktivität diese Woche",
     en: "No coding activity this week",

--- a/src/translations.js
+++ b/src/translations.js
@@ -2,7 +2,7 @@ const { encodeHTML } = require("./common/utils");
 
 const statCardLocales = ({ name, apostrophe }) => {
   return {
-    "title": {
+    "statcard.title": {
       cn: `${encodeHTML(name)}的GitHub统计`,
       de: `${encodeHTML(name) + apostrophe} GitHub-Statistiken`,
       en: `${encodeHTML(name)}'${apostrophe} GitHub Stats`,
@@ -13,7 +13,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       kr: `${encodeHTML(name)}의 GitHub 통계`,
       "pt-br": `Estatísticas do GitHub de ${encodeHTML(name)}`,
     },
-    "totalstars": {
+    "statcard.totalstars": {
       cn: "总星数",
       de: "Sterne Insgesamt",
       en: "Total Stars",
@@ -24,7 +24,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       kr: "총 별",
       "pt-br": "Total de estrelas",
     },
-    "commits": {
+    "statcard.commits": {
       cn: "总承诺",
       de: "Anzahl Commits",
       en: "Total Commits",
@@ -35,7 +35,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       kr: "총 커밋",
       "pt-br": "Total de compromissos",
     },
-    "prs": {
+    "statcard.prs": {
       cn: "总公关",
       de: "PRs Insgesamt",
       en: "Total PRs",
@@ -46,7 +46,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       kr: "총 PR",
       "pt-br": "Total de PRs",
     },
-    "issues": {
+    "statcard.issues": {
       cn: "总发行量",
       de: "Anzahl Issues",
       en: "Total Issues",
@@ -57,7 +57,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       kr: "총 문제",
       "pt-br": "Total de problemas",
     },
-    "contribs": {
+    "statcard.contribs": {
       cn: "有助于",
       de: "Beigetragen zu",
       en: "Contributed to",
@@ -72,7 +72,7 @@ const statCardLocales = ({ name, apostrophe }) => {
 };
 
 const repoCardLocales = {
-  "template": {
+  "repocard.template": {
     cn: "模板",
     de: "Vorlage",
     en: "Template",
@@ -83,7 +83,7 @@ const repoCardLocales = {
     kr: "주형",
     "pt-br": "Modelo",
   },
-  "archived": {
+  "repocard.archived": {
     cn: "已封存",
     de: "Archiviert",
     en: "Archived",
@@ -97,7 +97,7 @@ const repoCardLocales = {
 };
 
 const langCardLocales = {
-  "title": {
+  "langcard.title": {
     cn: "最常用的语言",
     de: "Meist verwendete Sprachen",
     en: "Most Used Languages",
@@ -111,7 +111,7 @@ const langCardLocales = {
 };
 
 const wakatimeCardLocales = {
-  "title": {
+  "wakatimecard.title": {
     cn: "Wakatime周统计",
     de: "Wakatime Wochen Status",
     en: "Wakatime Week Stats",
@@ -122,7 +122,7 @@ const wakatimeCardLocales = {
     kr: "Wakatime 주간 통계",
     "pt-br": "Estatísticas da semana Wakatime",
   },
-  "nocodingactivity": {
+  "wakatimecard.nocodingactivity": {
     cn: "本周没有编码活动",
     de: "Keine Aktivitäten in dieser Woche",
     en: "No coding activity this week",

--- a/tests/renderRepoCard.test.js
+++ b/tests/renderRepoCard.test.js
@@ -307,4 +307,23 @@ describe("Test renderRepoCard", () => {
     });
     expect(queryByTestId(document.body, "badge")).toBeNull();
   });
+
+  it("should render translated badges", () => {
+    document.body.innerHTML = renderRepoCard({
+      ...data_repo.repository,
+      isArchived: true,
+    }, {
+      lang: 'cn'
+    });
+
+    expect(queryByTestId(document.body, "badge")).toHaveTextContent("已封存");
+
+    document.body.innerHTML = renderRepoCard({
+      ...data_repo.repository,
+      isTemplate: true,
+    }, {
+      lang: 'cn'
+    });
+    expect(queryByTestId(document.body, "badge")).toHaveTextContent("模板");
+  });
 });

--- a/tests/renderRepoCard.test.js
+++ b/tests/renderRepoCard.test.js
@@ -309,21 +309,27 @@ describe("Test renderRepoCard", () => {
   });
 
   it("should render translated badges", () => {
-    document.body.innerHTML = renderRepoCard({
-      ...data_repo.repository,
-      isArchived: true,
-    }, {
-      lang: 'cn'
-    });
+    document.body.innerHTML = renderRepoCard(
+      {
+        ...data_repo.repository,
+        isArchived: true,
+      },
+      {
+        locale: "cn",
+      },
+    );
 
     expect(queryByTestId(document.body, "badge")).toHaveTextContent("已封存");
 
-    document.body.innerHTML = renderRepoCard({
-      ...data_repo.repository,
-      isTemplate: true,
-    }, {
-      lang: 'cn'
-    });
+    document.body.innerHTML = renderRepoCard(
+      {
+        ...data_repo.repository,
+        isTemplate: true,
+      },
+      {
+        locale: "cn",
+      },
+    );
     expect(queryByTestId(document.body, "badge")).toHaveTextContent("模板");
   });
 });

--- a/tests/renderStatsCard.test.js
+++ b/tests/renderStatsCard.test.js
@@ -209,4 +209,14 @@ describe("Test renderStatsCard", () => {
       queryByTestId(document.body, "stars").previousElementSibling, // the label
     ).not.toHaveAttribute("x");
   });
+
+  it("should render translations", () => {
+    document.body.innerHTML = renderStatsCard(stats, { lang: "cn" })
+    expect(document.getElementsByClassName("header")[0].textContent).toBe("Anurag Hazra的GitHub统计");
+    expect(document.querySelector("g[transform=\"translate(0, 0)\"]>.stagger>.stat.bold").textContent).toBe("总星数:");
+    expect(document.querySelector("g[transform=\"translate(0, 25)\"]>.stagger>.stat.bold").textContent).toBe("总承诺 (2020):");
+    expect(document.querySelector("g[transform=\"translate(0, 50)\"]>.stagger>.stat.bold").textContent).toBe("总公关:");
+    expect(document.querySelector("g[transform=\"translate(0, 75)\"]>.stagger>.stat.bold").textContent).toBe("总发行量:");
+    expect(document.querySelector("g[transform=\"translate(0, 100)\"]>.stagger>.stat.bold").textContent).toBe("有助于:");
+  })
 });

--- a/tests/renderStatsCard.test.js
+++ b/tests/renderStatsCard.test.js
@@ -211,12 +211,34 @@ describe("Test renderStatsCard", () => {
   });
 
   it("should render translations", () => {
-    document.body.innerHTML = renderStatsCard(stats, { lang: "cn" })
-    expect(document.getElementsByClassName("header")[0].textContent).toBe("Anurag Hazra的GitHub统计");
-    expect(document.querySelector("g[transform=\"translate(0, 0)\"]>.stagger>.stat.bold").textContent).toBe("总星数:");
-    expect(document.querySelector("g[transform=\"translate(0, 25)\"]>.stagger>.stat.bold").textContent).toBe("总承诺 (2020):");
-    expect(document.querySelector("g[transform=\"translate(0, 50)\"]>.stagger>.stat.bold").textContent).toBe("总公关:");
-    expect(document.querySelector("g[transform=\"translate(0, 75)\"]>.stagger>.stat.bold").textContent).toBe("总发行量:");
-    expect(document.querySelector("g[transform=\"translate(0, 100)\"]>.stagger>.stat.bold").textContent).toBe("有助于:");
-  })
+    document.body.innerHTML = renderStatsCard(stats, { locale: "cn" });
+    expect(document.getElementsByClassName("header")[0].textContent).toBe(
+      "Anurag Hazra的GitHub统计",
+    );
+    expect(
+      document.querySelector(
+        'g[transform="translate(0, 0)"]>.stagger>.stat.bold',
+      ).textContent,
+    ).toBe("总星数:");
+    expect(
+      document.querySelector(
+        'g[transform="translate(0, 25)"]>.stagger>.stat.bold',
+      ).textContent,
+    ).toBe("总承诺 (2020):");
+    expect(
+      document.querySelector(
+        'g[transform="translate(0, 50)"]>.stagger>.stat.bold',
+      ).textContent,
+    ).toBe("总公关:");
+    expect(
+      document.querySelector(
+        'g[transform="translate(0, 75)"]>.stagger>.stat.bold',
+      ).textContent,
+    ).toBe("总发行量:");
+    expect(
+      document.querySelector(
+        'g[transform="translate(0, 100)"]>.stagger>.stat.bold',
+      ).textContent,
+    ).toBe("有助于:");
+  });
 });

--- a/tests/renderTopLanguages.test.js
+++ b/tests/renderTopLanguages.test.js
@@ -216,4 +216,9 @@ describe("Test renderTopLanguages", () => {
       "60.00",
     );
   });
+
+  it("should render a translated title", () => {
+    document.body.innerHTML = renderTopLanguages(langs, { lang: "cn" })
+    expect(document.getElementsByClassName("header")[0].textContent).toBe("最常用的语言")
+  });
 });

--- a/tests/renderTopLanguages.test.js
+++ b/tests/renderTopLanguages.test.js
@@ -218,7 +218,9 @@ describe("Test renderTopLanguages", () => {
   });
 
   it("should render a translated title", () => {
-    document.body.innerHTML = renderTopLanguages(langs, { lang: "cn" })
-    expect(document.getElementsByClassName("header")[0].textContent).toBe("最常用的语言")
+    document.body.innerHTML = renderTopLanguages(langs, { locale: "cn" });
+    expect(document.getElementsByClassName("header")[0].textContent).toBe(
+      "最常用的语言",
+    );
   });
 });

--- a/tests/renderWakatimeCard.test.js
+++ b/tests/renderWakatimeCard.test.js
@@ -113,9 +113,15 @@ describe("Test Render Wakatime Card", () => {
           "
     `);
   });
+
   it("should render translations", () => {
-    document.body.innerHTML = renderWakatimeCard({}, {lang: "cn"})
-    expect(document.getElementsByClassName("header")[0].textContent).toBe("Wakatime周统计")
-    expect(document.querySelector("g[transform=\"translate(0, 0)\"]>text.stat.bold").textContent).toBe("本周没有编码活动")
-  })
+    document.body.innerHTML = renderWakatimeCard({}, { locale: "cn" });
+    expect(document.getElementsByClassName("header")[0].textContent).toBe(
+      "Wakatime周统计",
+    );
+    expect(
+      document.querySelector('g[transform="translate(0, 0)"]>text.stat.bold')
+        .textContent,
+    ).toBe("本周没有编码活动");
+  });
 });

--- a/tests/renderWakatimeCard.test.js
+++ b/tests/renderWakatimeCard.test.js
@@ -113,4 +113,9 @@ describe("Test Render Wakatime Card", () => {
           "
     `);
   });
+  it("should render translations", () => {
+    document.body.innerHTML = renderWakatimeCard({}, {lang: "cn"})
+    expect(document.getElementsByClassName("header")[0].textContent).toBe("Wakatime周统计")
+    expect(document.querySelector("g[transform=\"translate(0, 0)\"]>text.stat.bold").textContent).toBe("本周没有编码活动")
+  })
 });


### PR DESCRIPTION
Add translations for the cards. Fixes #508.

- [x] Add translation functionality (with Google Translate)
- [x] Add tests and documentation
- [ ] Get translations verified or improved.
  - [ ] Chinese
  - [x] German
  - [ ] Spanish
  - [ ] French
  - [x] Itallian
  - [ ] Japanese
  - [ ] Korean
  - [ ] Portuguese
- [x] Maybe move translations to one file (like `src/common/translations.js`) instead of in each `src/cards/*` file.
