### PR TITLE
Remove random +10

### DIFF
--- a/src/cards/top-languages-card.js
+++ b/src/cards/top-languages-card.js
@@ -122,16 +122,13 @@ const renderTopLanguages = (topLangs, options = {}) => {
           (width - 50)
         ).toFixed(2);
 
-        const progress =
-          percentage < 10 ? parseFloat(percentage) + 10 : percentage;
-
         const output = `
           <rect
             mask="url(#rect-mask)" 
             data-testid="lang-progress"
             x="${progressOffset}" 
             y="0"
-            width="${progress}" 
+            width="${percentage}" 
             height="8"
             fill="${lang.color || "#858585"}"
           />


### PR DESCRIPTION
Basically, I want to have 2 versions of the image; one for wide-devices and one for tall-devices. In order to not fetch the URL twice, I want to just take the bar data and multiply it. This is my code

```js
			let WideBoxBarWidth = 0;
			let WideBoxRectWidth;
			wideLangBox
				.querySelectorAll('[data-testid="lang-progress"]')
				.forEach(r => {
					WideBoxRectWidth = r.getAttribute("width") * 2;

					r.setAttribute("x", WideBoxBarWidth);
					r.setAttribute("width", WideBoxRectWidth)

					WideBoxBarWidth += WideBoxRectWidth;
				})

			wideLangBox
				.getElementById("rect-mask")
				.firstElementChild
				.setAttribute("width", WideBoxBarWidth)
```

Unfortunately, the +10 breaks this, making the end result 230% and the bar ends up being inaccurate. I do not see the benefit of having the +10 in the first place, so I removed it.
If it was useful for something, please inform me in the comments