### PR TITLE
improve: improve translathion of Chinese

### DIFF
--- a/src/translations.js
+++ b/src/translations.js
@@ -3,7 +3,7 @@ const { encodeHTML } = require("./common/utils");
 const statCardLocales = ({ name, apostrophe }) => {
   return {
     "statcard.title": {
-      cn: `${encodeHTML(name)}的GitHub统计`,
+      cn: `${encodeHTML(name)} 的 GitHub 统计`,
       de: `${encodeHTML(name) + apostrophe} GitHub-Statistiken`,
       en: `${encodeHTML(name)}'${apostrophe} GitHub Stats`,
       es: `Estadísticas de GitHub de ${encodeHTML(name)}`,
@@ -14,7 +14,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       "pt-br": `Estatísticas do GitHub de ${encodeHTML(name)}`,
     },
     "statcard.totalstars": {
-      cn: "总星数",
+      cn: "总 Star",
       de: "Sterne Insgesamt",
       en: "Total Stars",
       es: "Estrellas totales",
@@ -25,7 +25,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       "pt-br": "Total de estrelas",
     },
     "statcard.commits": {
-      cn: "总承诺",
+      cn: "总提交",
       de: "Anzahl Commits",
       en: "Total Commits",
       es: "Compromisos totales",
@@ -36,7 +36,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       "pt-br": "Total de compromissos",
     },
     "statcard.prs": {
-      cn: "总公关",
+      cn: "总 PR",
       de: "PRs Insgesamt",
       en: "Total PRs",
       es: "RP totales",
@@ -47,7 +47,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       "pt-br": "Total de PRs",
     },
     "statcard.issues": {
-      cn: "总发行量",
+      cn: "总 Issue",
       de: "Anzahl Issues",
       en: "Total Issues",
       es: "Problemas totales",
@@ -58,7 +58,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       "pt-br": "Total de problemas",
     },
     "statcard.contribs": {
-      cn: "有助于",
+      cn: "总贡献",
       de: "Beigetragen zu",
       en: "Contributed to",
       es: "Contribuido a",
@@ -84,7 +84,7 @@ const repoCardLocales = {
     "pt-br": "Modelo",
   },
   "repocard.archived": {
-    cn: "已封存",
+    cn: "已归档",
     de: "Archiviert",
     en: "Archived",
     es: "Archivé",
@@ -112,7 +112,7 @@ const langCardLocales = {
 
 const wakatimeCardLocales = {
   "wakatimecard.title": {
-    cn: "Wakatime周统计",
+    cn: "Wakatime 周统计",
     de: "Wakatime Wochen Status",
     en: "Wakatime Week Stats",
     es: "Estadísticas de la semana de Wakatime",
@@ -123,7 +123,7 @@ const wakatimeCardLocales = {
     "pt-br": "Estatísticas da semana Wakatime",
   },
   "wakatimecard.nocodingactivity": {
-    cn: "本周没有编码活动",
+    cn: "本周没有编程活动",
     de: "Keine Aktivitäten in dieser Woche",
     en: "No coding activity this week",
     es: "No hay actividad de codificación esta semana",

--- a/tests/renderRepoCard.test.js
+++ b/tests/renderRepoCard.test.js
@@ -319,7 +319,7 @@ describe("Test renderRepoCard", () => {
       },
     );
 
-    expect(queryByTestId(document.body, "badge")).toHaveTextContent("已封存");
+    expect(queryByTestId(document.body, "badge")).toHaveTextContent("已归档");
 
     document.body.innerHTML = renderRepoCard(
       {

--- a/tests/renderStatsCard.test.js
+++ b/tests/renderStatsCard.test.js
@@ -213,32 +213,32 @@ describe("Test renderStatsCard", () => {
   it("should render translations", () => {
     document.body.innerHTML = renderStatsCard(stats, { locale: "cn" });
     expect(document.getElementsByClassName("header")[0].textContent).toBe(
-      "Anurag Hazra的GitHub统计",
+      "Anurag Hazra 的 GitHub 统计",
     );
     expect(
       document.querySelector(
         'g[transform="translate(0, 0)"]>.stagger>.stat.bold',
       ).textContent,
-    ).toBe("总星数:");
+    ).toBe("总 Star:");
     expect(
       document.querySelector(
         'g[transform="translate(0, 25)"]>.stagger>.stat.bold',
       ).textContent,
-    ).toBe("总承诺 (2020):");
+    ).toBe("总提交 (2020):");
     expect(
       document.querySelector(
         'g[transform="translate(0, 50)"]>.stagger>.stat.bold',
       ).textContent,
-    ).toBe("总公关:");
+    ).toBe("总 PR:");
     expect(
       document.querySelector(
         'g[transform="translate(0, 75)"]>.stagger>.stat.bold',
       ).textContent,
-    ).toBe("总发行量:");
+    ).toBe("总 Issue:");
     expect(
       document.querySelector(
         'g[transform="translate(0, 100)"]>.stagger>.stat.bold',
       ).textContent,
-    ).toBe("有助于:");
+    ).toBe("总贡献:");
   });
 });

--- a/tests/renderWakatimeCard.test.js
+++ b/tests/renderWakatimeCard.test.js
@@ -117,11 +117,11 @@ describe("Test Render Wakatime Card", () => {
   it("should render translations", () => {
     document.body.innerHTML = renderWakatimeCard({}, { locale: "cn" });
     expect(document.getElementsByClassName("header")[0].textContent).toBe(
-      "Wakatime周统计",
+      "Wakatime 周统计",
     );
     expect(
       document.querySelector('g[transform="translate(0, 0)"]>text.stat.bold')
         .textContent,
-    ).toBe("本周没有编码活动");
+    ).toBe("本周没有编程活动");
   });
 });


### PR DESCRIPTION
1. Improve translathion of Chinese
2. Change some words into English

Some words seems not good when translating into Chinese. There is a website like GitHub in China, it also keep some words in origin. So I restored them.