### PR TITLE
Added missing stats card options in docs translations

### DIFF
--- a/docs/readme_cn.md
+++ b/docs/readme_cn.md
@@ -132,8 +132,10 @@ dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontr
 - `text_color` - 内容文本颜色 _（十六进制色码）_
 - `icon_color` - 图标颜色（如果可用）_（十六进制色码）_
 - `bg_color` - 卡片背景颜色 _（十六进制色码）_ **或者** 以 _angle,start,end_ 的形式渐变
+- `hide_border` - 隐藏卡的边框 _(布尔值)_
 - `theme` - 主题名称，从[所有可用主题](../themes/README.md)中选择
 - `cache_seconds` - 手动设置缓存头 _（最小值: 1800，最大值: 86400）_
+- `locale` - 在卡片中设置语言 _(例如 cn, de, es, 等等)_
 
 ##### bg_color 渐变
 

--- a/docs/readme_de.md
+++ b/docs/readme_de.md
@@ -122,8 +122,10 @@ Du kannst das Erscheinungsbild deiner `Stats Card` oder `Repo Card`, mithilfe vo
 - `text_color` - Textkörperfarbe _(hex color)_
 - `icon_color` - Symbolfarbe (falls verfügbar) _(hex color)_
 - `bg_color` - Hintergrundfarbe _(hex color)_ **oder** ein Farbverlauf in der Form von _winkel,start,ende_
+- `hide_border` - Blendet den Rand der Karte aus _(Boolescher Wert)_
 - `theme` - Name des Erscheinungsbildes/Themes [alle verfügbaren Themes](../themes/README.md)
 - `cache_seconds` - manuelles festlegen der Cachezeiten _(min: 1800, max: 86400)_
+- `locale` - Stellen Sie die Sprache auf der Karte ein _(z.B. cn, de, es, etc.)_
 
 ##### Farbverlauf in bg_color
 

--- a/docs/readme_es.md
+++ b/docs/readme_es.md
@@ -132,8 +132,10 @@ Puedes personalizar el aspecto de tu `Stats Card` o `Repo Card` de la manera que
 - `text_color` - Color del contenido _(hex color)_
 - `icon_color` - Color de icono si esta disponible _(hex color)_
 - `bg_color` - Color de fondo _(hex color)_
+- `hide_border` - Oculta el borde de la tarjeta _(booleano)_
 - `theme` - Nombre del tema, elige uno de [todos los temas disponible ](../themes/README.md)
 - `cache_seconds` - Cache _(min: 1800, max: 86400)_
+- `locale` - configurar el idioma en la tarjeta _(p.ej. cn, de, es, etc.)_
 
 > Nota sobre la caché: las tarjetas de Repo tienen un caché predeterminado de 30 minutos (1800 segundos) si el recuento forks y el recuento de estrellas es inferior a 1k; de lo contrario, son 2 horas (7200). También tenga en cuenta que el caché está sujeto a un mínimo de 30 minutos y un máximo de 24 horas
 

--- a/docs/readme_fr.md
+++ b/docs/readme_fr.md
@@ -128,12 +128,14 @@ Vous pouvez personnaliser l'apparence de votre `Carte des stats` ou `Carte de r�
 
 #### Options principales:
 
--   `title_color` - Couleur du titre de la carte _(hex color)_
--   `text_color` - Couleur du texte _(hex color)_
--   `icon_color` - Couleur des icônes si disponibles _(hex color)_
--   `bg_color` - Couleur du fond de la carte _(hex color)_ **ou** un gradiant de la forme _angle,start,end_
--   `theme` - Nom du thème, parmis [tous les thèmes disponibles](./themes/README.md)
--   `cache_seconds` - Paramétrer le cache manuellement _(min: 1800, max: 86400)_
+- `title_color` - Couleur du titre de la carte _(hex color)_
+- `text_color` - Couleur du texte _(hex color)_
+- `icon_color` - Couleur des icônes si disponibles _(hex color)_
+- `bg_color` - Couleur du fond de la carte _(hex color)_ **ou** un gradiant de la forme _angle,start,end_
+- `hide_border` - Cache la bordure de la carte _(booléen)_
+- `theme` - Nom du thème, parmis [tous les thèmes disponibles](./themes/README.md)
+- `cache_seconds` - Paramétrer le cache manuellement _(min: 1800, max: 86400)_
+- `locale` - définir la langue de la carte _(par exemple. cn, de, es, etc.)_
 
 ##### Gradient in bg_color
 

--- a/docs/readme_it.md
+++ b/docs/readme_it.md
@@ -132,8 +132,10 @@ Puoi personalizzare l'aspetto delle tue `Stats Card` o delle `Repo Card` in qual
 - `text_color` - Colore del testo _(in esadecimale)_
 - `icon_color` - Colore delle icone, se disponibili _(in esadecimale)_
 - `bg_color` - Colore dello sfondo _(in esadecimale)_ **oppure** un gradiente nella forma _angolo,inizio,fine_
+- `hide_border` - Nasconde il bordo della carta _(booleano)_
 - `theme` - Nome del tema, dai un'occhiata a [tutti i temi disponibili](./themes/README.md)
 - `cache_seconds` - Specifica manualmente il valore di cache, in secondi _(min: 1800, max: 86400)_
+- `locale` - Impostare la lingua nella scheda _(per esempio. cn, de, es, eccetera.)_
 
 ##### Gradiente nello sfondo
 

--- a/docs/readme_ja.md
+++ b/docs/readme_ja.md
@@ -133,8 +133,10 @@ dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontr
 - `text_color` - 中身のテキストの色 _(16 進数カラーコード)_
 - `icon_color` - アイコンの色（変更可能な場合のみ） _(16 進数カラーコード)_
 - `bg_color` - 背景の色 _(16 進数カラーコード)_ **または** _angle,start,end_ の形式でグラデーションを指定することも可
+- `hide_border` - カードの境界線を非表示にします _(ブール値)_
 - `theme` - [使用可能なテーマ一覧](../themes/README.md) から選んだテーマ名
 - `cache_seconds` - キャッシュ時間の秒数 _(最小値: 1800, 最大値: 86400)_
+- `locale` - カードに言語を設定する _(例えば cn, de, es, 等)_
 
 ##### bg_color の グラデーション指定
 

--- a/docs/readme_kr.md
+++ b/docs/readme_kr.md
@@ -132,8 +132,10 @@ URL 파라미터를 사용하여 원하는대로 `Stats Card` 또는 `Repo Card`
 - `text_color` - 본문 글자 색상 _(hex color)_
 - `icon_color` - 아이콘 색상(활성화된 경우) _(hex color)_
 - `bg_color` - 카드 배경 색상 _(hex color)_
+- `hide_border` - 카드의 테두리를 숨 깁니다 _(부울)_
 - `theme` - 테마의 이름, [사용 가능한 모든 테마](../themes/README.md)에서 선택
 - `cache_seconds` - 캐시 헤더를 수동으로 설정 _(min: 1800, max: 86400)_
+- `locale` - 카드에 언어 설정 _(예 : cn, de, es, 기타)_
 
 > 캐시 관련 참고: Repo 카드는 fork 개수와 star 카운트가 1천 개 미만인 경우 기본 캐시가 30분(1800초)이고, 그렇지 않은 경우 2시간(7200초) 입니다. 또한 캐시는 최소 30분 및 최대 24시간으로 고정됩니다.
 

--- a/docs/readme_pt-BR.md
+++ b/docs/readme_pt-BR.md
@@ -133,8 +133,10 @@ Personalize a aparência do seu `Stats Card` ou `Repo Card` da maneira que desej
 - `text_color` - Cor de texto do conteúdo _(hex color)_
 - `icon_color` - Cor dos ícones (se disponível) _(hex color)_
 - `bg_color` - Cor de fundo do cartão _(hex color)_
+- `hide_border` - Esconde a borda do cartão _(boleano)_
 - `theme` - Nome do tema, escolha em [todos os temas disponíveis](../themes/README.md)
 - `cache_seconds` - Defina o cabeçalho do cache manualmente _(min: 1800, max: 86400)_
+- `locale` - defina o idioma no cartão _(por exemplo. cn, de, es, etc.)_
 
 > Nota sobre o cache: Cartões de repositório tem um cache padrão de 30 minutos (1800 segundos), se o número a contagem de forks e contagem de estrelas é menor que 1 mil o padrão é 2 horas (7200). Note também que o cache é limitado a um mínimo de 30 minutos e um máximo de 24 horas.
 


### PR DESCRIPTION
Unfortunately, I cannot guarantee that all of these translations are grammatically correct. But I think that it would be better if these translations would be corrected later than information about these options would be missing.