### PR TITLE
feat: Support Org-Mode Markup

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "source": "/",
       "destination": "https://github.com/anuraghazra/github-readme-stats"
+    },
+    {
+      "source": "/(.*).svg",
+      "destination": "/$1"
     }
   ]
 }


### PR DESCRIPTION
# Allows embedding in [org-mode](https://orgmode.org/) markup language
Org-Mode requires a file extension when used in html-export

#### Example Usage
```org-mode
[[https://github-readme-stats.vercel.app/api.svg?username=anuraghazra][https://github.com/anuraghazra/github-readme-stats]]
```

note: originally pulled #506 