### PR TITLE
Update ranking alignment within dynamic circles.

### DIFF
--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -151,8 +151,8 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
         <circle class="rank-circle" cx="-10" cy="8" r="40" />
         <g class="rank-text">
           <text
-            x="${rank.level.length === 1 ? "-4" : "0"}"
-            y="0"
+            x="-4"
+            y="4"
             alignment-baseline="central"
             dominant-baseline="central"
             text-anchor="middle"


### PR DESCRIPTION
It appeared the text was being offset through two sets of logic. One part was centering in all axis, whilst another was off-setting it (or lack of) in anticipation of it being longer or otherwise different.

I've removed that logic (as it's implicit with `alignment-baseline="central"`, `baseline="central"` and `anchor="middle"`) and should look great now!

Such a minor thing, but hopefully it helps with #580.