### PR TITLE
add Page Views

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,6 +16,7 @@
     <a href="https://github.com/anuraghazra/github-readme-stats/pulls">
       <img alt="GitHub pull requests" src="https://img.shields.io/github/issues-pr/anuraghazra/github-readme-stats?color=0088ff" />
     </a>
+    <a href="https://hits.seeyoufarm.com"><img src="https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Fanuraghazra%2Fgithub-readme-stats&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=PAGE+VIEWS&edge_flat=false"/></a>
     <br />
     <br />
     <a href="https://a.paddle.com/v2/click/16413/119403?link=1227">


### PR DESCRIPTION
When we add this service, it will count every hit of this repo. And this will guide us more about the visitors each day and will indicate the total views. For me, this is very helpful both for us and for those will view this repo seeing this page views. If there is the website built from this repo, it can be simply added there too.

![Screenshot (1652)](https://user-images.githubusercontent.com/47092464/98452865-3993eb00-218e-11eb-9279-63dfa14b2729.png)
