### PR TITLE
Stats-card: Added units to 'Contributed To' field

### DIFF
--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -117,7 +117,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     contribs: {
       icon: icons.contribs,
       label: i18n.t("statcard.contribs"),
-      value: contributedTo,
+      value: contributedTo+ " projects" ,
       id: "contribs",
     },
   };


### PR DESCRIPTION
Mentioned 'projects' as the unit for the 'Contributed To' field for better readability.


```diff

- Contributed To : 417
+ Contributed To : 417 projects 