### PR TITLE
Added theme (RedTouch-Dark)

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -262,6 +262,12 @@ const themes = {
     icon_color: "a64833",
     text_color: "d9c8a9",
     bg_color: "402b23"
+  },
+  "redtouch-dark": {
+    title_color: "ff1744",
+    icon_color: "f05545",
+    text_color: "fff",
+    bg_color: "424242"
   }
 };
 


### PR DESCRIPTION

![Screenshot_35](https://user-images.githubusercontent.com/26970976/103432710-e7d27480-4bc2-11eb-95d7-3b3c83938281.jpg)

A dark theme with a smooth red touch.

Light theme of this is proposed on #769 