### PR TITLE
Add github_dark theme

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -262,6 +262,12 @@ const themes = {
     icon_color: "a64833",
     text_color: "d9c8a9",
     bg_color: "402b23"
+  },
+  github_dark: {
+    title_color: "58A6FF",
+    icon_color: "58A6FF",
+    text_color: "C9D1D9",
+    bg_color: "161B22"
   }
 };
 


### PR DESCRIPTION
Uses the colors of GitHub's new dark mode to blend in rather than popping out too much.