### PR TITLE
Adds the GitHub dark mode theme

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -262,7 +262,13 @@ const themes = {
     icon_color: "a64833",
     text_color: "d9c8a9",
     bg_color: "402b23"
-  }
+  },
+  "github-dark": {
+    title_color: "58A6FF",
+    icon_color: "89E153",
+    text_color: "8C949E",
+    bg_color: "0D1117"
+  }  
 };
 
 module.exports = themes;


### PR DESCRIPTION
Theme with no borders

<img width="1522" alt="Screen Shot 2020-12-15 at 7 19 26 PM" src="https://user-images.githubusercontent.com/1918732/102301228-3a493b00-3f0b-11eb-969b-f80a2e385408.png">
