### PR TITLE
add theme github_dark

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -262,6 +262,12 @@ const themes = {
     icon_color: "a64833",
     text_color: "d9c8a9",
     bg_color: "402b23"
+  },
+  github_dark: {
+    title_color: "f0f6fc",
+    icon_color: "8b949e",
+    text_color: "c9d1d9",
+    bg_color: "0d1117"
   }
 };
 


### PR DESCRIPTION
is made to look more like the native github dark theme.

## Example
![image](https://user-images.githubusercontent.com/39217836/103421071-6bc03880-4b92-11eb-8745-1c1de722d410.png)
