### PR TITLE
add github-dark theme

### DIFF
--- a/themes/README.md
+++ b/themes/README.md
@@ -30,7 +30,7 @@ Use `?theme=THEME_NAME` parameter like so :-
 | `calm` ![calm][calm] | `flag-india` ![flag-india][flag-india] | `omni` ![omni][omni] |
 | `react` ![react][react] | `jolly` ![jolly][jolly] | `maroongold` ![maroongold][maroongold] |
 | `yeblu` ![yeblu][yeblu] | `blueberry` ![blueberry][blueberry] | `slateorange` ![slateorange][slateorange] |
-| `kacho_ga` ![kacho_ga][kacho_ga] |  | [Add your theme][add-theme] |
+| `kacho_ga` ![kacho_ga][kacho_ga] | `github-dark` ![github-dark][github-dark] | [Add your theme][add-theme] |
 
 ## Repo Card
 
@@ -52,7 +52,7 @@ Use `?theme=THEME_NAME` parameter like so :-
 | `calm` ![calm][calm_repo] | `flag-india` ![flag-india][flag-india_repo] | `omni` ![omni][omni_repo] |
 | `react` ![react][react_repo] | `jolly` ![jolly][jolly_repo] | `maroongold` ![maroongold][maroongold_repo] |
 | `yeblu` ![yeblu][yeblu_repo] | `blueberry` ![blueberry][blueberry_repo] | `slateorange` ![slateorange][slateorange_repo] |
-| `kacho_ga` ![kacho_ga][kacho_ga_repo] |  | [Add your theme][add-theme] |
+| `kacho_ga` ![kacho_ga][kacho_ga_repo] | `github-dark` ![github-dark][github-dark] | [Add your theme][add-theme] |
 
 
 [default]: https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&hide=contribs,prs&cache_seconds=86400&theme=default
@@ -99,6 +99,7 @@ Use `?theme=THEME_NAME` parameter like so :-
 [blueberry]: https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&hide=contribs,prs&cache_seconds=86400&theme=blueberry
 [slateorange]: https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&hide=contribs,prs&cache_seconds=86400&theme=slateorange
 [kacho_ga]: https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&hide=contribs,prs&cache_seconds=86400&theme=kacho_ga
+[github-dark]: https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&hide=contribs,prs&cache_seconds=86400&theme=github-dark
 
 
 [default_repo]: https://github-readme-stats.vercel.app/api/pin/?username=anuraghazra&repo=github-readme-stats&cache_seconds=86400&theme=default
@@ -145,6 +146,7 @@ Use `?theme=THEME_NAME` parameter like so :-
 [blueberry_repo]: https://github-readme-stats.vercel.app/api/pin/?username=anuraghazra&repo=github-readme-stats&cache_seconds=86400&theme=blueberry
 [slateorange_repo]: https://github-readme-stats.vercel.app/api/pin/?username=anuraghazra&repo=github-readme-stats&cache_seconds=86400&theme=slateorange
 [kacho_ga_repo]: https://github-readme-stats.vercel.app/api/pin/?username=anuraghazra&repo=github-readme-stats&cache_seconds=86400&theme=kacho_ga
+[github-dark_repo]: https://github-readme-stats.vercel.app/api/pin/?username=anuraghazra&repo=github-readme-stats&cache_seconds=86400&theme=github-dark
 
 
 [add-theme]: https://github.com/anuraghazra/github-readme-stats/edit/master/themes/index.js

--- a/themes/index.js
+++ b/themes/index.js
@@ -263,6 +263,12 @@ const themes = {
     text_color: "d9c8a9",
     bg_color: "402b23",
   },
+  "github-dark": {
+    title_color: "ffffff",
+    icon_color: "58A6FF",
+    text_color: "8B949E",
+    bg_color: "0D1117",
+  }
 };
 
 module.exports = themes;


### PR DESCRIPTION
Hi! First of all, thanks for making such a great tool, really makes profile readmes look more exciting and interesting.

I wanted to make a theme which has the same 'look and feel' as the new github dark mode.

It also lets the stats blend in seamlessly with the background when dark mode is enabled and borders are disabled (e.g. my [profile readme](https://github.com/microhod)).

Here's some example images of how the theme looks (both in light and dark mode on github).
<img width="524" alt="github-stats-dark" src="https://user-images.githubusercontent.com/55709069/104652533-2717bf80-56b1-11eb-973a-bab6b15d580f.png">
<img width="522" alt="github-stats-light" src="https://user-images.githubusercontent.com/55709069/104652539-2848ec80-56b1-11eb-80d5-7a045dc849d7.png">



> Hope I've added the right things to the themes readme etc, just let me know if anything else needs doing.