### PR TITLE
docs : Update readme parameter

### DIFF
--- a/docs/readme_cn.md
+++ b/docs/readme_cn.md
@@ -154,7 +154,6 @@ dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontr
 - `hide` - 隐藏特定统计信息 _(以逗号分隔)_
 - `hide_title` - _(boolean)_
 - `hide_rank` - _(boolean)_
-- `hide_border` - _(boolean)_
 - `show_icons` - _(boolean)_
 - `include_all_commits` - 统计总提交次数而不是仅统计今年的提交次数 _(boolean)_
 - `count_private` - 统计私人提交 _(boolean)_
@@ -168,7 +167,6 @@ dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontr
 
 - `hide` - 从卡片中隐藏指定语言 _(Comma seperated values)_
 - `hide_title` - _(boolean)_
-- `hide_border` - _(boolean)_
 - `layout` - 在两个可用布局 `default` & `compact` 间切换
 - `card_width` - 手动设置卡片的宽度 _(number)_
 

--- a/docs/readme_de.md
+++ b/docs/readme_de.md
@@ -144,7 +144,6 @@ Du kannst mehrere, mit Kommas separierte, Werte in der bg_color Option angeben, 
 - `hide` - Verbirgt die angegeben Elemente _(mit Komma abgegrenzte Werte)_
 - `hide_title` - _(boolean)_
 - `hide_rank` - _(boolean)_
-- `hide_border` - _(boolean)_
 - `show_icons` - _(boolean)_
 - `include_all_commits` - Zähle alle Beiträge anstatt nur das aktuelle Jahr _(boolean)_
 - `count_private` - Zähle private Beiträge _(boolean)_
@@ -158,7 +157,6 @@ Du kannst mehrere, mit Kommas separierte, Werte in der bg_color Option angeben, 
 
 - `hide` - Verbirgt die angegebenen Sprachen von der Karte _(Komma separierte Werte)_
 - `hide_title` - _(boolean)_
-- `hide_border` - _(boolean)_
 - `layout` - Wechsel zwischen den zwei verfügbaren Layouts `default` & `compact`
 - `card_width` - Lege die Breite der Karte manuell fest _(Zahl)_
 

--- a/docs/readme_es.md
+++ b/docs/readme_es.md
@@ -146,7 +146,6 @@ Puedes personalizar el aspecto de tu `Stats Card` o `Repo Card` de la manera que
 - `hide` - Ocultar los elementos especificados de las estadísticas _ (valores separados por comas) _
 - `hide_title` - _(boolean)_
 - `hide_rank` - _(boolean)_
-- `hide_border` - _(boolean)_
 - `show_icons` - _(boolean)_
 - `include_all_commits` - Cuente los commits totales en lugar de solo los commits del año actual _(boolean)_
 - `count_private` - Cuenta los commits privadas _(boolean)_
@@ -161,7 +160,6 @@ Puedes personalizar el aspecto de tu `Stats Card` o `Repo Card` de la manera que
 
 - `hide` - Ocultar los lenguajes especificados de la tarjeta _(valores separados por comas)_
 - `hide_title` - _(boolean)_
-- `hide_border` - _(boolean)_
 - `layout` - Cambiar entre dos diseños disponibles `default` & `compact`
 - `card_width` - Establecer el ancho de la tarjeta manualmente _(number)_
 

--- a/docs/readme_fr.md
+++ b/docs/readme_fr.md
@@ -154,7 +154,6 @@ Vous pouvez fournir plusieurs valeurs (suivie d'une virgule) dans l'option bg_co
 -   `hide` - Masquer les éléments spécifiés dans les statistiques _(Comma seperated values)_
 -   `hide_title` - Masquer le titre _(boolean)_
 -   `hide_rank` - Masquer le rang _(boolean)_
--   `hide_border` - _(boolean)_
 -   `show_icons` - Afficher les icônes _(boolean)_
 -   `include_all_commits` - Compter le total de commits au lieu de ne compter que les commits de l'année en cours _(boolean)_
 -   `count_private` - Compter les commits privés _(boolean)_
@@ -168,7 +167,6 @@ Vous pouvez fournir plusieurs valeurs (suivie d'une virgule) dans l'option bg_co
 
 -   `hide` - Masquer les langages spécifiés sur la carte _(Comma seperated values)_
 -   `hide_title` - Masquer le titre _(boolean)_
--   `hide_border` - _(boolean)_
 -   `layout` - Alterner entre 2 mise en page `default` & `compact`
 -   `card_width` - Fixer la largeur de la carte manuellement _(number)_
 

--- a/docs/readme_it.md
+++ b/docs/readme_it.md
@@ -154,7 +154,6 @@ Puoi fornire valori separati da virgola nel parametro bg_color per creare un gra
 - `hide` - Nasconde gli oggetti selezionati _(valori separati da virgola)_
 - `hide_title` - Nasconde il titolo _(booleano)_
 - `hide_rank` - Nasconde il punteggio _(booleano)_
-- `hide_border` - _(boolean)_
 - `show_icons` - Mostra le icone _(booleano)_
 - `include_all_commits` - Mostra tutti i commit e non solo quelli dell'anno corrente _(booleano)_
 - `count_private` - Include i contributi privati _(booleano)_
@@ -168,7 +167,6 @@ Puoi fornire valori separati da virgola nel parametro bg_color per creare un gra
 
 - `hide` - Nasconde un linguaggio specifico _(valori separati da virgola)_
 - `hide_title` - Nasconde il titolo _(booleano)_
-- `hide_border` - _(boolean)_
 - `layout` - Specifica il tipo di layout, `default` (esteso) o `compact` (compatto)
 - `card_width` - Specifica il valore della larghezza _(numero)_
 

--- a/docs/readme_ja.md
+++ b/docs/readme_ja.md
@@ -159,6 +159,8 @@ bg_color オプションで複数のカンマ区切りの値を指定してグ�
 - `include_all_commits` - 今年度のコミット数だけでなく、コミット数の総数をカウントする _(boolean)_
 - `count_private` - プライベートリポジトリへのコミットをカウントする _(boolean)_
 - `line_height` - テキストの行の高さ _(number)_
+- `custom_title` - タイトル文字列を変更する
+- `disable_animations` - カードのアニメーションを無効にする _(boolean)_
 
 #### Repo Card だけに存在するオプション
 
@@ -170,6 +172,9 @@ bg_color オプションで複数のカンマ区切りの値を指定してグ�
 - `hide_title` - _(boolean)_
 - `layout` - `default` か `compact` のいずれかのレイアウトに切り替える
 - `card_width` - カードの横幅 _(number)_
+- `langs_count` - 表示される言語の数　_(1 ~ 10, 初期値 5)_
+- `exclude_repo` - 指定されたリポジトリを除外する _(カンマ区切りで指定)_
+- `custom_title` - タイトル文字列を変更する
 
 > :warning: **重要:**
 > [Percent Encoding](https://en.wikipedia.org/wiki/Percent-encoding) で指定されているように、プログラミング言語の名前は URL エンコードされている必要があります。

--- a/docs/readme_ja.md
+++ b/docs/readme_ja.md
@@ -155,7 +155,6 @@ bg_color オプションで複数のカンマ区切りの値を指定してグ�
 - `hide` - 特定の統計情報を隠す _(カンマ区切りで指定)_
 - `hide_title` - _(boolean)_
 - `hide_rank` - _(boolean)_
-- `hide_border` - _(boolean)_
 - `show_icons` - _(boolean)_
 - `include_all_commits` - 今年度のコミット数だけでなく、コミット数の総数をカウントする _(boolean)_
 - `count_private` - プライベートリポジトリへのコミットをカウントする _(boolean)_
@@ -169,7 +168,6 @@ bg_color オプションで複数のカンマ区切りの値を指定してグ�
 
 - `hide` - 特定の言語を隠す _(カンマ区切りで指定)_
 - `hide_title` - _(boolean)_
-- `hide_border` - _(boolean)_
 - `layout` - `default` か `compact` のいずれかのレイアウトに切り替える
 - `card_width` - カードの横幅 _(number)_
 

--- a/docs/readme_kr.md
+++ b/docs/readme_kr.md
@@ -170,7 +170,6 @@ dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontr
 - `hide` - 통계에서 특정한 값 제외 _(Comma-separated values)_
 - `hide_title` - 타이틀 표시 여부 _(boolean)_
 - `hide_rank` - 랭크 표시 여부 _(boolean)_
-- `hide_border` - 테두리 표시 여부 _(boolean)_
 - `show_icons` - 아이콘 표시 여부 _(boolean)_
 - `include_all_commits` - 올해가 아닌 전체 연도에 대한 커밋 포함 여부 _(boolean)_
 - `count_private` - 비공개 기여도 포함 여부 _(boolean)_
@@ -186,7 +185,6 @@ dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontr
 
 - `hide` - 카드에서 특정 언어 제외 _(Comma-separated values)_
 - `hide_title` - 타이틀 제외 _(boolean)_
-- `hide_border` - 테두리 제외 _(boolean)_
 - `layout` - 사용 가능한 두 가지 값, `default` & `compact` 중 표시 형태 선택
 - `card_width` - 카드 너비 직접 설정 _(number)_
 - `langs_count` - 카드에 표시할 언어의 수 (1-10 사이, 기본 값 : 5) _(number)_

--- a/docs/readme_nl.md
+++ b/docs/readme_nl.md
@@ -158,7 +158,6 @@ Je kan meerdere komma verdeelde waarden in de bg_color optie geven om een kleure
 - `hide` - Verbergt gespecificeerde items van de statistieken. _(komma gescheiden waardes)_
 - `hide_title` - _(boolean)_
 - `hide_rank` - _(boolean)_
-- `hide_border` - _(boolean)_
 - `show_icons` - _(boolean)_
 - `include_all_commits` - Tel alle commits inplaats van alleen de commits van het huidige jaar _(boolean)_
 - `count_private` - Tel privé commits mee _(boolean)_
@@ -173,7 +172,6 @@ Je kan meerdere komma verdeelde waarden in de bg_color optie geven om een kleure
 
 - `hide` - Verbergt specifieke talen van de kaart _(komma gescheiden waardes)_
 - `hide_title` - _(boolean)_
-- `hide_border` - _(boolean)_
 - `layout` - Keuze voor de twee beschikbare layouts `default` & `compact`
 - `card_width` - Stelt de breedte van de kaart handmatig in. _(nummer)_
 - `langs_count` - Laat meer talen op de kaart zien, waarde tussen 1-10, staat standaard op to 5 _(nummer)_

--- a/docs/readme_np.md
+++ b/docs/readme_np.md
@@ -156,7 +156,6 @@ You can provide multiple comma-separated values in bg_color option to render a g
 - `hide` - Hides the specified items from stats _(Comma-separated values)_
 - `hide_title` - _(boolean)_
 - `hide_rank` - _(boolean)_
-- `hide_border` - _(boolean)_
 - `show_icons` - _(boolean)_
 - `include_all_commits` - Count total commits instead of just the current year commits _(boolean)_
 - `count_private` - Count private commits _(boolean)_
@@ -171,7 +170,6 @@ You can provide multiple comma-separated values in bg_color option to render a g
 
 - `hide` - Hide the languages specified from the card _(Comma-separated values)_
 - `hide_title` - _(boolean)_
-- `hide_border` - _(boolean)_
 - `layout` - Switch between two available layouts `default` & `compact`
 - `card_width` - Set the card's width manually _(number)_
 - `langs_count` - Show more languages on the card, between 1-10, defaults to 5 _(number)_

--- a/docs/readme_pt-BR.md
+++ b/docs/readme_pt-BR.md
@@ -147,7 +147,6 @@ Personalize a aparência do seu `Stats Card` ou `Repo Card` da maneira que desej
 - `hide` - Oculta itens específicos das estatísticas _(Valores separados por vírgulas)_
 - `hide_title` - Ocutar o título _(boolean)_
 - `hide_rank` - Ocultar a classificação _(boolean)_
-- `hide_border` - _(boolean)_
 - `show_icons` - Mostrar ícones _(boolean)_
 - `include_all_commits` - Contabiliza todos os commits ao invés de apenas os atual ano _(boolean)_
 - `count_private` - Contabiliza commits privados _(boolean)_
@@ -161,7 +160,6 @@ Personalize a aparência do seu `Stats Card` ou `Repo Card` da maneira que desej
 
 - `hide` - Oculta linguagens específicas _(Valores separados por vírgulas)_
 - `hide_title` - Oculta o título _(boolean)_
-- `hide_border` - _(boolean)_
 - `layout` - Alterna entre os dois layouts disponíveis `default` & `compact`
 - `card_width` - Define a largura do cartão manualmente _(number)_
 

--- a/docs/readme_tr.md
+++ b/docs/readme_tr.md
@@ -159,7 +159,6 @@ bg_color içerisinde birden fazla rengi gradient olarak göstermek için virgül
 - `hide` - Spesifik özellikleri istatistiklerden gizleyebilirsiniz.  _(Virgül ile ayırılmış değerlerle)_
 - `hide_title` - _(boolean)_
 - `hide_rank` - _(boolean)_ Sıralamayı gizler ve kartın genişliğini otomatik olarak tekrar düzenler
-- `hide_border` - _(boolean)_
 - `show_icons` - _(boolean)_
 - `include_all_commits` - _(boolean)_ Sadece bu yılın değil tüm zamanlarda yaptığınız commit sayısını gösterir
 - `count_private` - _(boolean)_ Özel depolarda yaptığınız commitleri gösterir
@@ -175,7 +174,6 @@ bg_color içerisinde birden fazla rengi gradient olarak göstermek için virgül
 
 - `hide` - Belirli bir dili listede gizler _(Virgül ile ayırılmış değerlerle)_
 - `hide_title` - _(boolean)_
-- `hide_border` - _(boolean)_
 - `layout` - Uygun olan iki tasarım / layout arasında değişiklik yapar `default` & `compact`
 - `card_width` - Kartın genişliğini manuel olarak belirler _(number)_
 - `langs_count` - 1-10 arasında istediğiniz kadar dil gösterebilirsiniz. Varsayılan: 5 _(number)_

--- a/readme.md
+++ b/readme.md
@@ -159,7 +159,6 @@ You can provide multiple comma-separated values in bg_color option to render a g
 - `hide` - Hides the specified items from stats _(Comma-separated values)_
 - `hide_title` - _(boolean)_
 - `hide_rank` - _(boolean)_ hides the rank and automatically resizes the card width
-- `hide_border` - _(boolean)_
 - `show_icons` - _(boolean)_
 - `include_all_commits` - Count total commits instead of just the current year commits _(boolean)_
 - `count_private` - Count private commits _(boolean)_
@@ -175,7 +174,6 @@ You can provide multiple comma-separated values in bg_color option to render a g
 
 - `hide` - Hide the languages specified from the card _(Comma-separated values)_
 - `hide_title` - _(boolean)_
-- `hide_border` - _(boolean)_
 - `layout` - Switch between two available layouts `default` & `compact`
 - `card_width` - Set the card's width manually _(number)_
 - `langs_count` - Show more languages on the card, between 1-10, defaults to 5 _(number)_


### PR DESCRIPTION
- Remove common option for all cards. `hide_border `
Currently, `hide_border` is a valid option for all cards, so there is no need to list it as a separate option.

- Updated Stats Card and Language Card options for Japanese.

( related #815 )