### PR TITLE
add corner rounding parameter so we can make square cards

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -31,7 +31,7 @@ module.exports = async (req, res) => {
     custom_title,
     locale,
     disable_animations,
-    rx,
+    border_radius,
   } = req.query;
   let stats;
 
@@ -75,7 +75,7 @@ module.exports = async (req, res) => {
         bg_color,
         theme,
         custom_title,
-        rx,
+        border_radius,
         locale: locale ? locale.toLowerCase() : null,
         disable_animations: parseBoolean(disable_animations),
       }),

--- a/api/index.js
+++ b/api/index.js
@@ -31,6 +31,7 @@ module.exports = async (req, res) => {
     custom_title,
     locale,
     disable_animations,
+    rx,
   } = req.query;
   let stats;
 
@@ -74,6 +75,7 @@ module.exports = async (req, res) => {
         bg_color,
         theme,
         custom_title,
+        rx,
         locale: locale ? locale.toLowerCase() : null,
         disable_animations: parseBoolean(disable_animations),
       }),

--- a/api/pin.js
+++ b/api/pin.js
@@ -23,6 +23,7 @@ module.exports = async (req, res) => {
     show_owner,
     cache_seconds,
     locale,
+    rx,
   } = req.query;
 
   let repoData;
@@ -69,6 +70,7 @@ module.exports = async (req, res) => {
         text_color,
         bg_color,
         theme,
+        rx,
         show_owner: parseBoolean(show_owner),
         locale: locale ? locale.toLowerCase() : null,
       }),

--- a/api/pin.js
+++ b/api/pin.js
@@ -23,7 +23,7 @@ module.exports = async (req, res) => {
     show_owner,
     cache_seconds,
     locale,
-    rx,
+    border_radius,
   } = req.query;
 
   let repoData;
@@ -70,7 +70,7 @@ module.exports = async (req, res) => {
         text_color,
         bg_color,
         theme,
-        rx,
+        border_radius,
         show_owner: parseBoolean(show_owner),
         locale: locale ? locale.toLowerCase() : null,
       }),

--- a/api/top-langs.js
+++ b/api/top-langs.js
@@ -28,6 +28,7 @@ module.exports = async (req, res) => {
     exclude_repo,
     custom_title,
     locale,
+    rx
   } = req.query;
   let topLangs;
 
@@ -68,6 +69,7 @@ module.exports = async (req, res) => {
         bg_color,
         theme,
         layout,
+        rx,
         locale: locale ? locale.toLowerCase() : null,
       }),
     );

--- a/api/top-langs.js
+++ b/api/top-langs.js
@@ -28,7 +28,7 @@ module.exports = async (req, res) => {
     exclude_repo,
     custom_title,
     locale,
-    rx
+    border_radius
   } = req.query;
   let topLangs;
 
@@ -69,7 +69,7 @@ module.exports = async (req, res) => {
         bg_color,
         theme,
         layout,
-        rx,
+        border_radius,
         locale: locale ? locale.toLowerCase() : null,
       }),
     );

--- a/api/wakatime.js
+++ b/api/wakatime.js
@@ -26,7 +26,7 @@ module.exports = async (req, res) => {
     locale,
     layout,
     api_domain,
-    rx,
+    border_radius,
   } = req.query;
 
   res.setHeader("Content-Type", "image/svg+xml");
@@ -62,7 +62,7 @@ module.exports = async (req, res) => {
         bg_color,
         theme,
         hide_progress,
-        rx,
+        border_radius,
         locale: locale ? locale.toLowerCase() : null,
         layout,
       }),

--- a/api/wakatime.js
+++ b/api/wakatime.js
@@ -26,6 +26,7 @@ module.exports = async (req, res) => {
     locale,
     layout,
     api_domain,
+    rx,
   } = req.query;
 
   res.setHeader("Content-Type", "image/svg+xml");
@@ -61,6 +62,7 @@ module.exports = async (req, res) => {
         bg_color,
         theme,
         hide_progress,
+        rx,
         locale: locale ? locale.toLowerCase() : null,
         layout,
       }),

--- a/readme.md
+++ b/readme.md
@@ -143,7 +143,7 @@ You can customize the appearance of your `Stats Card` or `Repo Card` however you
 - `theme` - name of the theme, choose from [all available themes](./themes/README.md)
 - `cache_seconds` - set the cache header manually _(min: 1800, max: 86400)_
 - `locale` - set the language in the card _(e.g. cn, de, es, etc.)_
-- `rx` - Corner rounding on the card_
+- `border_radius` - Corner rounding on the card_
 
 ##### Gradient in bg_color
 

--- a/readme.md
+++ b/readme.md
@@ -143,6 +143,7 @@ You can customize the appearance of your `Stats Card` or `Repo Card` however you
 - `theme` - name of the theme, choose from [all available themes](./themes/README.md)
 - `cache_seconds` - set the cache header manually _(min: 1800, max: 86400)_
 - `locale` - set the language in the card _(e.g. cn, de, es, etc.)_
+- `rx` - Corner rounding on the card_
 
 ##### Gradient in bg_color
 

--- a/src/cards/repo-card.js
+++ b/src/cards/repo-card.js
@@ -30,7 +30,7 @@ const renderRepoCard = (repo, options = {}) => {
     bg_color,
     show_owner,
     theme = "default_repocard",
-    rx,
+    border_radius,
     locale,
   } = options;
 
@@ -119,7 +119,7 @@ const renderRepoCard = (repo, options = {}) => {
     titlePrefixIcon: icons.contribs,
     width: 400,
     height,
-    rx,
+    border_radius,
     colors: {
       titleColor,
       textColor,

--- a/src/cards/repo-card.js
+++ b/src/cards/repo-card.js
@@ -30,6 +30,7 @@ const renderRepoCard = (repo, options = {}) => {
     bg_color,
     show_owner,
     theme = "default_repocard",
+    rx,
     locale,
   } = options;
 
@@ -118,6 +119,7 @@ const renderRepoCard = (repo, options = {}) => {
     titlePrefixIcon: icons.contribs,
     width: 400,
     height,
+    rx,
     colors: {
       titleColor,
       textColor,

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -69,7 +69,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     bg_color,
     theme = "default",
     custom_title,
-    rx,
+    border_radius,
     locale,
     disable_animations = false,
   } = options;
@@ -201,7 +201,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     defaultTitle: i18n.t("statcard.title"),
     width,
     height,
-    rx,
+    border_radius,
     colors: {
       titleColor,
       textColor,

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -69,6 +69,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     bg_color,
     theme = "default",
     custom_title,
+    rx,
     locale,
     disable_animations = false,
   } = options;
@@ -200,6 +201,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     defaultTitle: i18n.t("statcard.title"),
     width,
     height,
+    rx,
     colors: {
       titleColor,
       textColor,

--- a/src/cards/top-languages-card.js
+++ b/src/cards/top-languages-card.js
@@ -73,6 +73,7 @@ const renderTopLanguages = (topLangs, options = {}) => {
     layout,
     custom_title,
     locale,
+    rx
   } = options;
 
   const i18n = new I18n({
@@ -183,6 +184,7 @@ const renderTopLanguages = (topLangs, options = {}) => {
     defaultTitle: i18n.t("langcard.title"),
     width,
     height,
+    rx,
     colors: {
       titleColor,
       textColor,

--- a/src/cards/top-languages-card.js
+++ b/src/cards/top-languages-card.js
@@ -73,7 +73,7 @@ const renderTopLanguages = (topLangs, options = {}) => {
     layout,
     custom_title,
     locale,
-    rx
+    border_radius
   } = options;
 
   const i18n = new I18n({
@@ -184,7 +184,7 @@ const renderTopLanguages = (topLangs, options = {}) => {
     defaultTitle: i18n.t("langcard.title"),
     width,
     height,
-    rx,
+    border_radius,
     colors: {
       titleColor,
       textColor,

--- a/src/cards/wakatime-card.js
+++ b/src/cards/wakatime-card.js
@@ -99,6 +99,7 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
     custom_title,
     locale,
     layout,
+    rx
   } = options;
 
   const i18n = new I18n({
@@ -210,6 +211,7 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
     defaultTitle: i18n.t("wakatimecard.title"),
     width: 495,
     height,
+    rx,
     colors: {
       titleColor,
       textColor,

--- a/src/cards/wakatime-card.js
+++ b/src/cards/wakatime-card.js
@@ -99,7 +99,7 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
     custom_title,
     locale,
     layout,
-    rx
+    border_radius
   } = options;
 
   const i18n = new I18n({
@@ -211,7 +211,7 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
     defaultTitle: i18n.t("wakatimecard.title"),
     width: 495,
     height,
-    rx,
+    border_radius,
     colors: {
       titleColor,
       textColor,

--- a/src/common/Card.js
+++ b/src/common/Card.js
@@ -5,6 +5,7 @@ class Card {
   constructor({
     width = 100,
     height = 100,
+    rx = 4.5,
     colors = {},
     customTitle,
     defaultTitle = "",
@@ -15,6 +16,8 @@ class Card {
 
     this.hideBorder = false;
     this.hideTitle = false;
+
+    this.rx = rx;
 
     // returns theme based colors with proper overrides and defaults
     this.colors = colors;
@@ -142,7 +145,7 @@ class Card {
           data-testid="card-bg"
           x="0.5"
           y="0.5"
-          rx="4.5"
+          rx="${this.rx}"
           height="99%"
           stroke="#E4E2E2"
           width="${this.width - 1}"

--- a/src/common/Card.js
+++ b/src/common/Card.js
@@ -5,7 +5,7 @@ class Card {
   constructor({
     width = 100,
     height = 100,
-    rx = 4.5,
+    border_radius = 4.5,
     colors = {},
     customTitle,
     defaultTitle = "",
@@ -17,7 +17,7 @@ class Card {
     this.hideBorder = false;
     this.hideTitle = false;
 
-    this.rx = rx;
+    this.border_radius = border_radius;
 
     // returns theme based colors with proper overrides and defaults
     this.colors = colors;
@@ -145,7 +145,7 @@ class Card {
           data-testid="card-bg"
           x="0.5"
           y="0.5"
-          rx="${this.rx}"
+          rx="${this.border_radius}"
           height="99%"
           stroke="#E4E2E2"
           width="${this.width - 1}"

--- a/tests/renderRepoCard.test.js
+++ b/tests/renderRepoCard.test.js
@@ -334,7 +334,7 @@ describe("Test renderRepoCard", () => {
   });
   
   it("should render without rounding", () => {
-    document.body.innerHTML = renderRepoCard(data_repo.repository, { rx: "0" });
+    document.body.innerHTML = renderRepoCard(data_repo.repository, { border_radius: "0" });
     expect(document.querySelector("rect")).toHaveAttribute("rx", "0");
     document.body.innerHTML = renderRepoCard(data_repo.repository, { });
     expect(document.querySelector("rect")).toHaveAttribute("rx", "4.5");

--- a/tests/renderRepoCard.test.js
+++ b/tests/renderRepoCard.test.js
@@ -332,4 +332,11 @@ describe("Test renderRepoCard", () => {
     );
     expect(queryByTestId(document.body, "badge")).toHaveTextContent("模板");
   });
+  
+  it("should render without rounding", () => {
+    document.body.innerHTML = renderRepoCard(data_repo.repository, { rx: "0" });
+    expect(document.querySelector("rect")).toHaveAttribute("rx", "0");
+    document.body.innerHTML = renderRepoCard(data_repo.repository, { });
+    expect(document.querySelector("rect")).toHaveAttribute("rx", "4.5");
+  });
 });

--- a/tests/renderStatsCard.test.js
+++ b/tests/renderStatsCard.test.js
@@ -262,4 +262,11 @@ describe("Test renderStatsCard", () => {
       ).textContent,
     ).toBe("参与项目数:");
   });
+
+  it("should render without rounding", () => {
+    document.body.innerHTML = renderStatsCard(stats, { rx: "0" });
+    expect(document.querySelector("rect")).toHaveAttribute("rx", "0");
+    document.body.innerHTML = renderStatsCard(stats, { });
+    expect(document.querySelector("rect")).toHaveAttribute("rx", "4.5");
+  });
 });

--- a/tests/renderStatsCard.test.js
+++ b/tests/renderStatsCard.test.js
@@ -264,7 +264,7 @@ describe("Test renderStatsCard", () => {
   });
 
   it("should render without rounding", () => {
-    document.body.innerHTML = renderStatsCard(stats, { rx: "0" });
+    document.body.innerHTML = renderStatsCard(stats, { border_radius: "0" });
     expect(document.querySelector("rect")).toHaveAttribute("rx", "0");
     document.body.innerHTML = renderStatsCard(stats, { });
     expect(document.querySelector("rect")).toHaveAttribute("rx", "4.5");

--- a/tests/renderTopLanguages.test.js
+++ b/tests/renderTopLanguages.test.js
@@ -225,7 +225,7 @@ describe("Test renderTopLanguages", () => {
   });
 
   it("should render without rounding", () => {
-    document.body.innerHTML = renderTopLanguages(langs, { rx: "0" });
+    document.body.innerHTML = renderTopLanguages(langs, { border_radius: "0" });
     expect(document.querySelector("rect")).toHaveAttribute("rx", "0");
     document.body.innerHTML = renderTopLanguages(langs, { });
     expect(document.querySelector("rect")).toHaveAttribute("rx", "4.5");

--- a/tests/renderTopLanguages.test.js
+++ b/tests/renderTopLanguages.test.js
@@ -223,4 +223,11 @@ describe("Test renderTopLanguages", () => {
       "最常用的语言",
     );
   });
+
+  it("should render without rounding", () => {
+    document.body.innerHTML = renderTopLanguages(langs, { rx: "0" });
+    expect(document.querySelector("rect")).toHaveAttribute("rx", "0");
+    document.body.innerHTML = renderTopLanguages(langs, { });
+    expect(document.querySelector("rect")).toHaveAttribute("rx", "4.5");
+  });
 });

--- a/tests/renderWakatimeCard.test.js
+++ b/tests/renderWakatimeCard.test.js
@@ -28,7 +28,7 @@ describe("Test Render Wakatime Card", () => {
   });
 
   it("should render without rounding", () => {
-    document.body.innerHTML = renderWakatimeCard(wakaTimeData.data, { rx: "0" });
+    document.body.innerHTML = renderWakatimeCard(wakaTimeData.data, { border_radius: "0" });
     expect(document.querySelector("rect")).toHaveAttribute("rx", "0");
     document.body.innerHTML = renderWakatimeCard(wakaTimeData.data, { });
     expect(document.querySelector("rect")).toHaveAttribute("rx", "4.5");

--- a/tests/renderWakatimeCard.test.js
+++ b/tests/renderWakatimeCard.test.js
@@ -26,4 +26,11 @@ describe("Test Render Wakatime Card", () => {
         .textContent,
     ).toBe("本周没有编程活动");
   });
+
+  it("should render without rounding", () => {
+    document.body.innerHTML = renderWakatimeCard(wakaTimeData.data, { rx: "0" });
+    expect(document.querySelector("rect")).toHaveAttribute("rx", "0");
+    document.body.innerHTML = renderWakatimeCard(wakaTimeData.data, { });
+    expect(document.querySelector("rect")).toHaveAttribute("rx", "4.5");
+  });
 });


### PR DESCRIPTION
Cards are rounded by default which looks kinda ugly when you have two adjacent cards with a dark theme and a light background.  I added support for a parameter which allows users to control the rounding used by the card (and had it default to the original 4.5).  I added implementation, tests, and readme docs but feel free to ping me if I missed anything.  

![image](https://user-images.githubusercontent.com/1759360/106311922-833f1f80-622b-11eb-8f13-6bb922cee7ac.png)
