### PR TITLE
Theme matching GitHub Dark theme

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -263,6 +263,12 @@ const themes = {
     text_color: "d9c8a9",
     bg_color: "402b23",
   },
+  github_dark: {
+    title_color: "56A1F7",
+    icon_color: "56A1F7",
+    text_color: "8B949E",
+    bg_color: "0D1117",
+  },
 };
 
 module.exports = themes;


### PR DESCRIPTION
Think it might be useful to have a theme using the same colours as the GitHub Dark mode. 
The only problem is the white borders that I can't change.

![theme-screenshot](https://raw.githubusercontent.com/maximecharriere/share/master/img/github-readme-stats_github-dark-theme.png)