### PR TITLE
Ranking System v1

### DIFF
--- a/src/calculateRank.js
+++ b/src/calculateRank.js
@@ -1,19 +1,5 @@
-// https://stackoverflow.com/a/5263759/10629172
-function normalcdf(mean, sigma, to) {
-  var z = (to - mean) / Math.sqrt(2 * sigma * sigma);
-  var t = 1 / (1 + 0.3275911 * Math.abs(z));
-  var a1 = 0.254829592;
-  var a2 = -0.284496736;
-  var a3 = 1.421413741;
-  var a4 = -1.453152027;
-  var a5 = 1.061405429;
-  var erf =
-    1 - ((((a5 * t + a4) * t + a3) * t + a2) * t + a1) * t * Math.exp(-z * z);
-  var sign = 1;
-  if (z < 0) {
-    sign = -1;
-  }
-  return (1 / 2) * (1 + sign * erf);
+function expsf(lambda, to) {
+  return Math.exp(-lambda * to);
 }
 
 function calculateRank({
@@ -25,21 +11,14 @@ function calculateRank({
   issues,
   stargazers,
 }) {
-  const COMMITS_OFFSET = 1.65;
-  const CONTRIBS_OFFSET = 1.65;
-  const ISSUES_OFFSET = 1;
-  const STARS_OFFSET = 0.75;
-  const PRS_OFFSET = 0.5;
-  const FOLLOWERS_OFFSET = 0.45;
-  const REPO_OFFSET = 1;
-
-  const ALL_OFFSETS =
-    CONTRIBS_OFFSET +
-    ISSUES_OFFSET +
-    STARS_OFFSET +
-    PRS_OFFSET +
-    FOLLOWERS_OFFSET +
-    REPO_OFFSET;
+  // value of statistics should be equal to 1 / <average number per user> (see https://en.wikipedia.org/wiki/Exponential_distribution#Mean,_variance,_moments_and_median)
+  const COMMITS_VALUE = 1 / 10000;
+  const CONTRIBS_VALUE = 1 / 1000;
+  const ISSUES_VALUE = 1 / 100;
+  const STARS_VALUE = 1 / 50;
+  const PRS_VALUE = 1 / 300;
+  const FOLLOWERS_VALUE = 1 / 25;
+  const REPO_VALUE = 1 / 20;
 
   const RANK_S_VALUE = 1;
   const RANK_DOUBLE_A_VALUE = 25;
@@ -47,47 +26,27 @@ function calculateRank({
   const RANK_A3_VALUE = 60;
   const RANK_B_VALUE = 100;
 
-  const TOTAL_VALUES =
-    RANK_S_VALUE + RANK_A2_VALUE + RANK_A3_VALUE + RANK_B_VALUE;
-
-  // prettier-ignore
-  const score = (
-    totalCommits * COMMITS_OFFSET +
-    contributions * CONTRIBS_OFFSET +
-    issues * ISSUES_OFFSET +
-    stargazers * STARS_OFFSET +
-    prs * PRS_OFFSET +
-    followers * FOLLOWERS_OFFSET + 
-    totalRepos * REPO_OFFSET 
-  ) / 100;
-
-  const normalizedScore = normalcdf(score, TOTAL_VALUES, ALL_OFFSETS) * 100;
+  const normalizedScore = (expsf(COMMITS_VALUE, totalCommits) +
+                           expsf(CONTRIBS_VALUE, contributions) +
+                           expsf(ISSUES_VALUE, issues) +
+                           expsf(STARS_VALUE, stargazers) +
+                           expsf(PRS_VALUE, prs) +
+                           expsf(FOLLOWERS_VALUE, followers) +
+                           expsf(REPO_VALUE, totalRepos)) / 7 * 100
 
   let level = "";
 
   if (normalizedScore < RANK_S_VALUE) {
     level = "S+";
-  }
-  if (
-    normalizedScore >= RANK_S_VALUE &&
-    normalizedScore < RANK_DOUBLE_A_VALUE
-  ) {
+  } else if (normalizedScore < RANK_DOUBLE_A_VALUE) {
     level = "S";
-  }
-  if (
-    normalizedScore >= RANK_DOUBLE_A_VALUE &&
-    normalizedScore < RANK_A2_VALUE
-  ) {
+  } else if (normalizedScore < RANK_A2_VALUE) {
     level = "A++";
-  }
-  if (normalizedScore >= RANK_A2_VALUE && normalizedScore < RANK_A3_VALUE) {
+  } else if (normalizedScore < RANK_A3_VALUE) {
     level = "A+";
-  }
-  if (normalizedScore >= RANK_A3_VALUE && normalizedScore < RANK_B_VALUE) {
+  } else {
     level = "B+";
   }
 
   return { level, score: normalizedScore };
 }
-
-module.exports = calculateRank;

--- a/src/calculateRank.js
+++ b/src/calculateRank.js
@@ -12,13 +12,13 @@ function calculateRank({
   stargazers,
 }) {
   // value of statistics should be equal to 1 / <average number per user> (see https://en.wikipedia.org/wiki/Exponential_distribution#Mean,_variance,_moments_and_median)
-  const COMMITS_VALUE = 1 / 10000;
-  const CONTRIBS_VALUE = 1 / 1000;
-  const ISSUES_VALUE = 1 / 100;
-  const STARS_VALUE = 1 / 400;
-  const PRS_VALUE = 1 / 300;
-  const FOLLOWERS_VALUE = 1 / 100;
-  const REPO_VALUE = 1 / 20;
+  const COMMITS_LAMBDA = 1 / 10000;
+  const CONTRIBS_LAMBDA = 1 / 1000;
+  const ISSUES_LAMBDA = 1 / 100;
+  const STARS_LAMBDA = 1 / 400;
+  const PRS_LAMBDA = 1 / 300;
+  const FOLLOWERS_LAMBDA = 1 / 100;
+  const REPO_LAMBDA = 1 / 20;
 
   const RANK_S_VALUE = 1;
   const RANK_DOUBLE_A_VALUE = 25;
@@ -27,13 +27,13 @@ function calculateRank({
   const RANK_B_VALUE = 100;
 
   const normalizedScore = 700 / (
-      1 / expsf(COMMITS_VALUE, totalCommits) +
-      1 / expsf(CONTRIBS_VALUE, contributions) +
-      1 / expsf(ISSUES_VALUE, issues) +
-      1 / expsf(STARS_VALUE, stargazers) +
-      1 / expsf(PRS_VALUE, prs) +
-      1 / expsf(FOLLOWERS_VALUE, followers) +
-      1 / expsf(REPO_VALUE, totalRepos))
+      1 / expsf(COMMITS_LAMBDA, totalCommits) +
+      1 / expsf(CONTRIBS_LAMBDA, contributions) +
+      1 / expsf(ISSUES_LAMBDA, issues) +
+      1 / expsf(STARS_LAMBDA, stargazers) +
+      1 / expsf(PRS_LAMBDA, prs) +
+      1 / expsf(FOLLOWERS_LAMBDA, followers) +
+      1 / expsf(REPO_LAMBDA, totalRepos))
 
   let level = "";
 

--- a/src/calculateRank.js
+++ b/src/calculateRank.js
@@ -1,5 +1,5 @@
-function expsf(lambda, to) {
-  return Math.exp(-lambda * to);
+function expsf(lambda, x) {
+  return Math.exp(-lambda * x);
 }
 
 function calculateRank({

--- a/src/calculateRank.js
+++ b/src/calculateRank.js
@@ -26,13 +26,14 @@ function calculateRank({
   const RANK_A3_VALUE = 60;
   const RANK_B_VALUE = 100;
 
-  const normalizedScore = (expsf(COMMITS_VALUE, totalCommits) +
-                           expsf(CONTRIBS_VALUE, contributions) +
-                           expsf(ISSUES_VALUE, issues) +
-                           expsf(STARS_VALUE, stargazers) +
-                           expsf(PRS_VALUE, prs) +
-                           expsf(FOLLOWERS_VALUE, followers) +
-                           expsf(REPO_VALUE, totalRepos)) / 7 * 100
+  const normalizedScore = 700 / (
+      1 / expsf(COMMITS_VALUE, totalCommits) +
+      1 / expsf(CONTRIBS_VALUE, contributions) +
+      1 / expsf(ISSUES_VALUE, issues) +
+      1 / expsf(STARS_VALUE, stargazers) +
+      1 / expsf(PRS_VALUE, prs) +
+      1 / expsf(FOLLOWERS_VALUE, followers) +
+      1 / expsf(REPO_VALUE, totalRepos))
 
   let level = "";
 

--- a/src/calculateRank.js
+++ b/src/calculateRank.js
@@ -50,3 +50,5 @@ function calculateRank({
 
   return { level, score: normalizedScore };
 }
+
+module.exports = calculateRank;

--- a/src/calculateRank.js
+++ b/src/calculateRank.js
@@ -15,9 +15,9 @@ function calculateRank({
   const COMMITS_VALUE = 1 / 10000;
   const CONTRIBS_VALUE = 1 / 1000;
   const ISSUES_VALUE = 1 / 100;
-  const STARS_VALUE = 1 / 50;
+  const STARS_VALUE = 1 / 400;
   const PRS_VALUE = 1 / 300;
-  const FOLLOWERS_VALUE = 1 / 25;
+  const FOLLOWERS_VALUE = 1 / 100;
   const REPO_VALUE = 1 / 20;
 
   const RANK_S_VALUE = 1;

--- a/tests/calculateRank.test.js
+++ b/tests/calculateRank.test.js
@@ -15,4 +15,32 @@ describe("Test calculateRank", () => {
       }),
     ).toStrictEqual({ level: "A+", score: 46.164852607446775 });
   });
+  
+  it("should be able to get B+ rank", () => {
+    expect(
+      calculateRank({
+        totalCommits: 0,
+        totalRepos: 0,
+        followers: 0,
+        contributions: 0,
+        stargazers: 0,
+        prs: 0,
+        issues: 0,
+      }),
+    ).toStrictEqual({ level: "B+", score: 100 });
+  });
+  
+  it("should be able to get S+ rank for Linus Torvalds", () => {
+    expect(
+      calculateRank({
+        totalCommits: 2700,
+        totalRepos: 2,
+        followers: 132000,
+        contributions: 2700,
+        stargazers: 109100,
+        prs: 71,
+        issues: 2,
+      }),
+    ).toStrictEqual({ level: "S+", score: 50.069648962437896 });
+  });
 });

--- a/tests/calculateRank.test.js
+++ b/tests/calculateRank.test.js
@@ -13,7 +13,7 @@ describe("Test calculateRank", () => {
         prs: 300,
         issues: 200,
       }),
-    ).toStrictEqual({ level: "A+", score: 46.164852607446775 });
+    ).toStrictEqual({ level: "A++", score: 37.035320318128086 });
   });
   
   it("new user gets B+ rank", () => {

--- a/tests/calculateRank.test.js
+++ b/tests/calculateRank.test.js
@@ -41,6 +41,6 @@ describe("Test calculateRank", () => {
         prs: 71,
         issues: 2,
       }),
-    ).toStrictEqual({ level: "S+", score: 50.069648962437896 });
+    ).toStrictEqual({ level: "S+", score: 0 });
   });
 });

--- a/tests/calculateRank.test.js
+++ b/tests/calculateRank.test.js
@@ -16,7 +16,7 @@ describe("Test calculateRank", () => {
     ).toStrictEqual({ level: "A+", score: 46.164852607446775 });
   });
   
-  it("should be able to get B+ rank", () => {
+  it("new user gets B+ rank", () => {
     expect(
       calculateRank({
         totalCommits: 0,
@@ -30,7 +30,7 @@ describe("Test calculateRank", () => {
     ).toStrictEqual({ level: "B+", score: 100 });
   });
   
-  it("should be able to get S+ rank for Linus Torvalds", () => {
+  it("Linus Torvalds gets S+ rank", () => {
     expect(
       calculateRank({
         totalCommits: 2700,

--- a/tests/calculateRank.test.js
+++ b/tests/calculateRank.test.js
@@ -13,6 +13,6 @@ describe("Test calculateRank", () => {
         prs: 300,
         issues: 200,
       }),
-    ).toStrictEqual({ level: "A+", score: 49.16605417270399 });
+    ).toStrictEqual({ level: "A+", score: 46.164852607446775 });
   });
 });


### PR DESCRIPTION
Usage of normal distribution is not justified at all and as its' support is `(-inf; inf)` you get some problems (e.g. #883 #455). Exponential distribution's support is `[0; inf)` which means if we will calculate survival function (same as `1 - cdf` (https://en.wikipedia.org/wiki/Survival_function#Definition)) then for all zeros we will get a person with a score equal to a 100 which makes a lot of sense. Also in practice exponential distribution is quite accurate showing activity of a person. See example below:

This is the real activity distribution histogram (taken from https://movespring.com/blog/how-to-set-a-goal-for-your-next-activity-or-step-challenge-5f74c65ac49982000764facf):
![image](https://user-images.githubusercontent.com/9883873/112026405-38fd5f00-8b47-11eb-9b76-885ab2c15fc2.png)
This is the exponential distribution histogram with different parameters:
![image](https://user-images.githubusercontent.com/9883873/112026889-b45f1080-8b47-11eb-966d-75e76109a92c.png)


Here is one more example with real distribution (as blue) and fitted exponential distribution (as red):
![image](https://user-images.githubusercontent.com/9883873/112026766-97c2d880-8b47-11eb-8f3c-5fea1f76405e.png)


Next step is to restore parameters of exponential distribution for real distribution. In my opinion Method of Moments (https://en.wikipedia.org/wiki/Method_of_moments_(statistics)) is the easiest to understand and comes from a single property we would like to have: expectation over our parameterized distribution would be equal to expectation of the real distribution. (see `*_VALUE` variables in code). As expectation of exponential distribution with parameter `\lambda` is equal to `1 / \lambda` then if we have an expectation (which is equal to an average over users) of real distribution then the restored `\lambda = 1 / expectation`.

Now we have 7 distributions over different aspects of Github Profile: Commits, Contributions, Issues, PRs, Stars, Followers, Repositories. We can understand how "good" a Github Profile in each aspect by calculating survival function over each of these 7 distributions in the points corresponding to Github Profile stats (the lesser value the better). To get a single number from 7 numbers we can have for example an average of these numbers but that wouldn't be good as a person who is great in one aspect and bad in others (e.g. Linus Torvalds with only 2 repositories and low stats in PRs and Issues and a ton of stars and followers) will never get an S+ rank so we need to have an aggregate functions which would stimulate low values at least in one aspect. One of such functions is `min(...)` over 7 aspects but this doesn't encourage you to develop any aspects except the only one you are best in, so we will use harmonic average (https://en.wikipedia.org/wiki/Harmonic_mean) which fits our needs (as it almost equal to `min(...)` for values much less than 1 and also has a non-zero gradient over each variable).

As you can see from tests:
1. A decent user (400 stars and 100 followers) has an A++ rank
2. Newly created account has lowest possible score = 100
3. Linus Torvalds has highest possible score = 0 (this wasn't intended I just realized it when ran a script)
![image](https://user-images.githubusercontent.com/9883873/112032769-cc399300-8b4d-11eb-997e-9e38f2242ae7.png)
 

**IMPORTANT NOTICE**
Current values are not set to be equal to `1 / <average stat over users>` as I couldn't find any official (and even unofficial) statistics referring to these. So they are just set to what I see as an average Github User.

