### PR TITLE
Add routes to vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,32 @@
 {
-  "redirects": [
+  "version": 2,
+  "routes": [
     {
-      "source": "/",
-      "destination": "https://github.com/anuraghazra/github-readme-stats"
+      "src": "/api(.*)",
+      "dest": "/api$1"
+    },
+    {
+      "src": "/pin(.*)",
+      "dest": "/api/pin$1"
+    },
+    {
+      "src": "/wakatime(.*)",
+      "dest": "/api/wakatime$1"
+    },
+    {
+      "src": "/top-langs(.*)",
+      "dest": "/api/top-langs$1"
+    },
+    {
+      "src": "/?(.*)",
+      "dest": "/api?$1"
+    },
+    {
+      "src": "/(.*)",
+      "status": 308,
+      "headers": {
+        "Location": "https://github.com/anuraghazra/github-readme-stats/"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

This change:
- Retains usage of `/api` so that no users are affected
- Hides vercel's 404 page
- Adds routes to `pin`, `wakatime`, `top-langs`
  and index.js without the need of `/api/` to use after `https://github-readme-stats.vercel.app/`
- Redirects all other requests to github repo `https://github.com/anuraghazra/github-readme-stats`