### PR TITLE
added github_dimmed theme

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -286,6 +286,12 @@ const themes = {
     icon_color: "1F6FEB",
     text_color: "C3D1D9",
     bg_color: "0D1117"
+  },
+  github_dimmed: {
+    title_color: "539BF5",
+    icon_color: "1F6FEB",
+    text_color: "ADBAC7",
+    bg_color: "22272E"
   }
 };
 


### PR DESCRIPTION
Github recently came out with their dark dimmed theme so I made a theme using the same colors.

![github_dimmed](https://user-images.githubusercontent.com/41274792/113654888-d936a600-9666-11eb-81d4-488b39c98e74.png)