### PR TITLE
docs: add `npm install` step to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,7 @@ _(make sure you already have a [vercel](https://vercel.com/) account)_
 
 1. Install [Vercel CLI](https://vercel.com/download)
 1. Fork the repository and clone the code to your local machine
+1. Run `npm install` in the repository root
 1. Run the command "vercel" in the root and follow the steps there
 1. Create a `.env` file in the root of the directory
 1. In the .env file add a new variable named "PAT_1" with your [github Personal access token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token)


### PR DESCRIPTION
This resolves #1012 - the `npm install` step was not in the docs and is required after cloning the repo (obv. while this is normal for node-based projects, since it was not in the steps I was assuming that e.g. the `vercel` or `vercel dev` steps would have automatically installed any required dependencies - and in any event it is I think definitely a required step.) 