### PR TITLE
fix: custom wakatime api url with subpath as api_domain

### DIFF
--- a/src/fetchers/wakatime-fetcher.js
+++ b/src/fetchers/wakatime-fetcher.js
@@ -4,7 +4,7 @@ const fetchWakatimeStats = async ({ username, api_domain, range }) => {
   try {
     const { data } = await axios.get(
       `https://${
-        api_domain ? api_domain.replace(/[^a-z-.0-9]/gi, "") : "wakatime.com"
+        api_domain ? decodeURIComponent(api_domain).replace(/[^a-z-./0-9]/gi, "") : "wakatime.com"
       }/api/v1/users/${username}/stats/${range || ''}?is_including_today=true`,
     );
 


### PR DESCRIPTION
Allow the value of `api_domain` parameter to be HTML entity encoded string, so that API URL with subpath could be accepted not just domain.

as I mentioned in the corresponding issue, custom wakapi instance usually under a subpath, this change is necessary for it to work.

Fixes anuraghazra/github-readme-stats#1026