### PR TITLE
Changing GraphQL queries and strategies to get detailed information a…

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -20,7 +20,6 @@ module.exports = async (req, res) => {
     hide_rank,
     show_icons,
     count_private,
-    include_all_commits,
     line_height,
     title_color,
     icon_color,
@@ -47,11 +46,8 @@ module.exports = async (req, res) => {
   }
 
   try {
-    stats = await fetchStats(
-      username,
-      parseBoolean(count_private),
-      parseBoolean(include_all_commits),
-    );
+    stats = await fetchStats(username,
+      parseBoolean(count_private));
 
     const cacheSeconds = clampValue(
       parseInt(cache_seconds || CONSTANTS.TWO_HOURS, 10),
@@ -68,7 +64,6 @@ module.exports = async (req, res) => {
         hide_title: parseBoolean(hide_title),
         hide_border: parseBoolean(hide_border),
         hide_rank: parseBoolean(hide_rank),
-        include_all_commits: parseBoolean(include_all_commits),
         line_height,
         title_color,
         icon_color,

--- a/app.js
+++ b/app.js
@@ -1,0 +1,14 @@
+const dotenv = require('dotenv/config')
+const express = require('express')
+
+const api = require('./api/index.js')
+
+const app = express()
+
+
+app.get('/api',async function (req, res) {
+    await api(req, res);
+});
+
+
+server = app.listen("3000");

--- a/docs/readme_cn.md
+++ b/docs/readme_cn.md
@@ -157,7 +157,6 @@ dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontr
 - `hide_title` - _(boolean)_
 - `hide_rank` - _(boolean)_
 - `show_icons` - _(boolean)_
-- `include_all_commits` - 统计总提交次数而不是仅统计今年的提交次数 _(boolean)_
 - `count_private` - 统计私人提交 _(boolean)_
 - `line_height` - 设置文本之间的行高 _(number)_
 
@@ -260,7 +259,7 @@ _注意：热门语言并不表示我的技能水平或类似的水平，它是�
 
 - 包含全部提交
 
-![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra&include_all_commits=true)
+![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra)
 
 - 主题
 

--- a/docs/readme_de.md
+++ b/docs/readme_de.md
@@ -148,7 +148,6 @@ Du kannst mehrere, mit Kommas separierte, Werte in der bg_color Option angeben, 
 - `hide_title` - _(boolean)_
 - `hide_rank` - _(boolean)_
 - `show_icons` - _(boolean)_
-- `include_all_commits` - Zähle alle Beiträge anstatt nur das aktuelle Jahr _(boolean)_
 - `count_private` - Zähle private Beiträge _(boolean)_
 - `line_height` - Legt die Zeilenhöhe zwischen Text fest _(Zahl)_
 
@@ -280,7 +279,7 @@ Du kannst die `&layout=compact` Option nutzen, um das Karten Design zu ändern.
 
 - Alle Beiträge anzeigen
 
-![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra&include_all_commits=true)
+![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra)
 
 - Erscheinungsbild/Themes
 

--- a/docs/readme_es.md
+++ b/docs/readme_es.md
@@ -161,7 +161,6 @@ Puedes pasar mútliples valores separados por coma en la opción `bg_color` para
 - `hide_title` - _(booleano)_
 - `hide_rank` - _(booleano)_
 - `show_icons` - _(booleano)_
-- `include_all_commits` - Cuenta el total de commits en lugar de solo los commits del año actual _(boolean)_
 - `count_private` - Cuenta los commits privadas _(boolean)_
 - `line_height` - Establece el alto de línea entre texto _(número)_
 - `custom_title` - Establece un título personalizado
@@ -313,7 +312,7 @@ cambia el valor del parámetro `?username=` a tu username en [Wakatime](https://
 
 - Incluyendo todos los commits
 
-![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra&include_all_commits=true)
+![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra)
 
 - Temas
 

--- a/docs/readme_fr.md
+++ b/docs/readme_fr.md
@@ -157,7 +157,6 @@ Vous pouvez fournir plusieurs valeurs (suivie d'une virgule) dans l'option bg_co
 -   `hide_title` - Masquer le titre _(boolean)_
 -   `hide_rank` - Masquer le rang _(boolean)_
 -   `show_icons` - Afficher les icônes _(boolean)_
--   `include_all_commits` - Compter le total de commits au lieu de ne compter que les commits de l'année en cours _(boolean)_
 -   `count_private` - Compter les commits privés _(boolean)_
 -   `line_height` - Fixer la hauteur de la ligne entre les textes _(number)_
 
@@ -260,7 +259,7 @@ Vous pouvez utiliser l'option `&layout=compact` pour changer le style de la cart
 
 - Inclure tous les commits
 
-![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra&include_all_commits=true)
+![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra)
 
 - Thèmes
 

--- a/docs/readme_it.md
+++ b/docs/readme_it.md
@@ -157,7 +157,6 @@ Puoi fornire valori separati da virgola nel parametro bg_color per creare un gra
 - `hide_title` - Nasconde il titolo _(booleano)_
 - `hide_rank` - Nasconde il punteggio _(booleano)_
 - `show_icons` - Mostra le icone _(booleano)_
-- `include_all_commits` - Mostra tutti i commit e non solo quelli dell'anno corrente _(booleano)_
 - `count_private` - Include i contributi privati _(booleano)_
 - `line_height` - Specifica il valore dell'altezza di riga _(numero)_
 
@@ -258,7 +257,7 @@ Puoi utilizzare l'opzione `&layout=compact` per cambiare l'aspetto della card.
 
 - Includere tutti i commit
 
-![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra&include_all_commits=true)
+![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra)
 
 - Temi
 

--- a/docs/readme_ja.md
+++ b/docs/readme_ja.md
@@ -158,7 +158,6 @@ bg_color オプションで複数のカンマ区切りの値を指定してグ�
 - `hide_title` - _(boolean)_
 - `hide_rank` - _(boolean)_
 - `show_icons` - _(boolean)_
-- `include_all_commits` - 今年度のコミット数だけでなく、コミット数の総数をカウントする _(boolean)_
 - `count_private` - プライベートリポジトリへのコミットをカウントする _(boolean)_
 - `line_height` - テキストの行の高さ _(number)_
 - `custom_title` - タイトル文字列を変更する
@@ -266,7 +265,7 @@ _NOTE: Top languages は、ユーザのスキルレベルを示すものでは�
 
 - コミット数の総数をカウントする
 
-![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra&include_all_commits=true)
+![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra)
 
 - テーマの変更
 

--- a/docs/readme_kr.md
+++ b/docs/readme_kr.md
@@ -173,7 +173,6 @@ dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontr
 - `hide_title` - 타이틀 표시 여부 _(boolean)_
 - `hide_rank` - 랭크 표시 여부 _(boolean)_
 - `show_icons` - 아이콘 표시 여부 _(boolean)_
-- `include_all_commits` - 올해가 아닌 전체 연도에 대한 커밋 포함 여부 _(boolean)_
 - `count_private` - 비공개 기여도 포함 여부 _(boolean)_
 - `line_height` - 텍스트 간 줄 높이 설정(자간) _(number)_
 - `custom_title` - 카드의 타이틀 값 설정
@@ -327,7 +326,7 @@ _참고:
 
 - 전체 커밋 포함 시
 
-![Anurag 님의 GitHub 사용량 통계](https://github-readme-stats.vercel.app/api?username=anuraghazra&include_all_commits=true)
+![Anurag 님의 GitHub 사용량 통계](https://github-readme-stats.vercel.app/api?username=anuraghazra)
 
 - 테마들
 

--- a/docs/readme_nl.md
+++ b/docs/readme_nl.md
@@ -161,7 +161,6 @@ Je kan meerdere komma verdeelde waarden in de bg_color optie geven om een kleure
 - `hide_title` - _(boolean)_
 - `hide_rank` - _(boolean)_
 - `show_icons` - _(boolean)_
-- `include_all_commits` - Tel alle commits inplaats van alleen de commits van het huidige jaar _(boolean)_
 - `count_private` - Tel privé commits mee _(boolean)_
 - `line_height` - Stel de lijn-hoogte tussen text in _(nummer)_
 - `custom_title` - Stel een aangepaste titel voor je kaart in
@@ -308,7 +307,7 @@ Verander de `?username=` waarde naar je [Wakatime](https://wakatime.com) gebruik
 
 - Voeg alle commits toe
 
-![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra&include_all_commits=true)
+![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra)
 
 - Thema\'s
 

--- a/docs/readme_np.md
+++ b/docs/readme_np.md
@@ -157,7 +157,6 @@ You can provide multiple comma-separated values in bg_color option to render a g
 - `hide_title` - _(boolean)_
 - `hide_rank` - _(boolean)_
 - `show_icons` - _(boolean)_
-- `include_all_commits` - Count total commits instead of just the current year commits _(boolean)_
 - `count_private` - Count private commits _(boolean)_
 - `line_height` - Sets the line-height between text _(number)_
 - `custom_title` - Sets a custom title for the card
@@ -302,7 +301,7 @@ Change the `?username=` value to your [Wakatime](https://wakatime.com) username.
 
 - सबै कमितहरु 
 
-![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra&include_all_commits=true)
+![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra)
 
 - थेम्स 
 

--- a/docs/readme_pt-BR.md
+++ b/docs/readme_pt-BR.md
@@ -150,7 +150,6 @@ Personalize a aparência do seu `Stats Card` ou `Repo Card` da maneira que desej
 - `hide_title` - Ocutar o título _(boolean)_
 - `hide_rank` - Ocultar a classificação _(boolean)_
 - `show_icons` - Mostrar ícones _(boolean)_
-- `include_all_commits` - Contabiliza todos os commits ao invés de apenas os atual ano _(boolean)_
 - `count_private` - Contabiliza commits privados _(boolean)_
 - `line_height` - Define a altura do espaçamento entre o texto _(number)_
 
@@ -269,7 +268,7 @@ Altere o valor de `?username=` para o seu username do Wakatime.
 
 - Incluir todos os commits
 
-![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra&include_all_commits=true)
+![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra)
 
 - Temas
 

--- a/docs/readme_tr.md
+++ b/docs/readme_tr.md
@@ -162,7 +162,6 @@ bg_color içerisinde birden fazla rengi gradient olarak göstermek için virgül
 - `hide_title` - _(boolean)_
 - `hide_rank` - _(boolean)_ Sıralamayı gizler ve kartın genişliğini otomatik olarak tekrar düzenler
 - `show_icons` - _(boolean)_
-- `include_all_commits` - _(boolean)_ Sadece bu yılın değil tüm zamanlarda yaptığınız commit sayısını gösterir
 - `count_private` - _(boolean)_ Özel depolarda yaptığınız commitleri gösterir
 - `line_height` - _(number)_ Satır arası yüksekliği belirler
 - `custom_title` - Kart için istediğiniz bir başlığı belirler
@@ -313,7 +312,7 @@ Endpoint: `api/top-langs?username=mustafacagri`
 
 - Tüm commitler dahil
 
-![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra&include_all_commits=true)
+![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra)
 
 - Temalar
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "dependencies": {
     "dotenv": "^8.2.0",
     "emoji-name-map": "^1.2.8",
+    "express": "^4.17.1",
     "github-username-regex": "^1.0.0",
     "prettier": "^2.1.2",
     "word-wrap": "^1.2.3"

--- a/readme.md
+++ b/readme.md
@@ -180,8 +180,7 @@ You can provide multiple comma-separated values in bg_color option to render a g
 - `hide_title` - _(boolean)_
 - `hide_rank` - _(boolean)_ hides the rank and automatically resizes the card width
 - `show_icons` - _(boolean)_
-- `include_all_commits` - Count total commits instead of just the current year commits _(boolean)_
-- `count_private` - Count private commits _(boolean)_
+- `count_private` - Count private commits _(boolean)
 - `line_height` - Sets the line-height between text _(number)_
 - `custom_title` - Sets a custom title for the card
 - `disable_animations` - Disables all animations in the card _(boolean)_
@@ -338,7 +337,7 @@ Change the `?username=` value to your [Wakatime](https://wakatime.com) username.
 
 - Include All Commits
 
-![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra&include_all_commits=true)
+![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra)
 
 - Themes
 

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -61,7 +61,6 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     hide_title = false,
     hide_border = false,
     hide_rank = false,
-    include_all_commits = false,
     line_height = 25,
     title_color,
     icon_color,
@@ -105,9 +104,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     },
     commits: {
       icon: icons.commits,
-      label: `${i18n.t("statcard.commits")}${
-        include_all_commits ? "" : ` (${new Date().getFullYear()})`
-      }`,
+      label: `${i18n.t("statcard.commits")}`,
       value: totalCommits,
       id: "commits",
     },
@@ -143,8 +140,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
         ...STATS[key],
         index,
         showIcons: show_icons,
-        shiftValuePos:
-          (!include_all_commits ? 50 : 20) + (isLongLocale ? 50 : 0),
+        shiftValuePos: 20 + (isLongLocale ? 50 : 0),
       }),
     );
 

--- a/src/common/retryer.js
+++ b/src/common/retryer.js
@@ -1,6 +1,6 @@
 const { logger, CustomError } = require("../common/utils");
 
-const retryer = async (fetcher, variables, retries = 0) => {
+const retryer = async (fetcher, variables, query, retries = 0) => {
   if (retries > 7) {
     throw new CustomError("Maximum retries exceeded", CustomError.MAX_RETRY);
   }
@@ -9,7 +9,8 @@ const retryer = async (fetcher, variables, retries = 0) => {
     let response = await fetcher(
       variables,
       process.env[`PAT_${retries + 1}`],
-      retries,
+      query,
+      retries
     );
 
     // prettier-ignore
@@ -21,7 +22,7 @@ const retryer = async (fetcher, variables, retries = 0) => {
       logger.log(`PAT_${retries + 1} Failed`);
       retries++;
       // directly return from the function
-      return retryer(fetcher, variables, retries);
+      return retryer(fetcher, variables, query, retries);
     }
 
     // finally return the response
@@ -35,7 +36,7 @@ const retryer = async (fetcher, variables, retries = 0) => {
       logger.log(`PAT_${retries + 1} Failed`);
       retries++;
       // directly return from the function
-      return retryer(fetcher, variables, retries);
+      return retryer(fetcher, variables, query, retries);
     }
   }
 };

--- a/src/fetchers/stats-fetcher.js
+++ b/src/fetchers/stats-fetcher.js
@@ -6,41 +6,54 @@ const githubUsernameRegex = require("github-username-regex");
 
 require("dotenv").config();
 
-const fetcher = (variables, token) => {
-  return request(
-    {
-      query: `
+const yearsOfContribFetcher = `
       query userInfo($login: String!) {
         user(login: $login) {
-          name
-          login
           contributionsCollection {
-            totalCommitContributions
-            restrictedContributionsCount
-          }
-          repositoriesContributedTo(first: 1, contributionTypes: [COMMIT, ISSUE, PULL_REQUEST, REPOSITORY]) {
-            totalCount
-          }
-          pullRequests(first: 1) {
-            totalCount
-          }
-          issues(first: 1) {
-            totalCount
-          }
-          followers {
-            totalCount
-          }
-          repositories(first: 100, ownerAffiliations: OWNER, orderBy: {direction: DESC, field: STARGAZERS}) {
-            totalCount
-            nodes {
-              stargazers {
-                totalCount
-              }
-            }
+            contributionYears
           }
         }
       }
-      `,
+      `;
+const queryParts = {
+  yearTemplate: `
+  year_{year}: contributionsCollection(from: "{year}-01-01T00:00:00Z", to: "{next_year}-01-01T00:00:00Z") {
+    totalCommitContributions
+    totalRepositoryContributions
+    restrictedContributionsCount
+    commitContributionsByRepository{
+      repository{
+        name
+        stargazers{
+          totalCount
+        }
+      }
+    }
+  }
+  `,
+  query: `
+    query userInfo($login: String!) {
+    user(login: $login) {
+      name
+      login
+      {contributionsCollection}
+      pullRequests(first: 1) {
+        totalCount
+      }
+      issues(first: 1) {
+        totalCount
+      }
+      followers {
+        totalCount
+      }
+    }
+  }`
+
+}
+const fetcher = (variables, token, query) => {
+  return request(
+    {
+      query: query,
       variables,
     },
     {
@@ -49,45 +62,18 @@ const fetcher = (variables, token) => {
   );
 };
 
-// https://github.com/anuraghazra/github-readme-stats/issues/92#issuecomment-661026467
-// https://github.com/anuraghazra/github-readme-stats/pull/211/
-const totalCommitsFetcher = async (username) => {
-  if (!githubUsernameRegex.test(username)) {
-    logger.log("Invalid username");
-    return 0;
-  }
+function buildQuery(contributionYears) {
+  var buildedQuery = "";
+  contributionYears.forEach(element => {
+    // some crash happens before 2014
+    if (element > 2013)
+      buildedQuery += queryParts.yearTemplate.replace(/\{year\}/g, element).replace(/\{next_year\}/g, element + 1);
+  });
+  buildedQuery = queryParts.query.replace(/\{contributionsCollection\}/g, buildedQuery);
+  return buildedQuery;
+}
 
-  // https://developer.github.com/v3/search/#search-commits
-  const fetchTotalCommits = (variables, token) => {
-    return axios({
-      method: "get",
-      url: `https://api.github.com/search/commits?q=author:${variables.login}`,
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/vnd.github.cloak-preview",
-        Authorization: `bearer ${token}`,
-      },
-    });
-  };
-
-  try {
-    let res = await retryer(fetchTotalCommits, { login: username });
-    if (res.data.total_count) {
-      return res.data.total_count;
-    }
-  } catch (err) {
-    logger.log(err);
-    // just return 0 if there is something wrong so that
-    // we don't break the whole app
-    return 0;
-  }
-};
-
-async function fetchStats(
-  username,
-  count_private = false,
-  include_all_commits = false,
-) {
+async function fetchStats(username, count_private) {
   if (!username) throw Error("Invalid username");
 
   const stats = {
@@ -95,13 +81,25 @@ async function fetchStats(
     totalPRs: 0,
     totalCommits: 0,
     totalIssues: 0,
+    totalRepos: 0,
     totalStars: 0,
     contributedTo: 0,
     rank: { level: "C", score: 0 },
   };
 
-  let res = await retryer(fetcher, { login: username });
+  let yearsOfContributions = await retryer(fetcher, { login: username }, yearsOfContribFetcher);
 
+  if (yearsOfContributions.data.errors) {
+    logger.error(res.data.errors);
+    throw new CustomError(
+      res.data.errors[0].message || "Could not fetch user",
+      CustomError.USER_NOT_FOUND,
+    );
+  }
+  let years = yearsOfContributions.data.data.user.contributionsCollection.contributionYears;
+  let buildedQuery = buildQuery(years);
+
+  let res = await retryer(fetcher, { login: username }, buildedQuery);
   if (res.data.errors) {
     logger.error(res.data.errors);
     throw new CustomError(
@@ -113,33 +111,39 @@ async function fetchStats(
   const user = res.data.data.user;
 
   stats.name = user.name || user.login;
-  stats.totalIssues = user.issues.totalCount;
 
-  // normal commits
-  stats.totalCommits = user.contributionsCollection.totalCommitContributions;
 
-  // if include_all_commits then just get that,
-  // since totalCommitsFetcher already sends totalCommits no need to +=
-  if (include_all_commits) {
-    stats.totalCommits = await totalCommitsFetcher(username);
-  }
+  // total commits
+  let repoStars = [];
+  years.forEach(element => {
+    let yearContributionCollection = user["year_" + element];
+    if (yearContributionCollection) {
+      stats.totalCommits += yearContributionCollection.totalCommitContributions;
+      stats.totalRepos += yearContributionCollection.totalRepositoryContributions;
+      // if count_private then add private commits to totalCommits so far.
+      if (count_private) {
+        stats.totalCommits += yearContributionCollection.restrictedContributionsCount;
+      }
+      let repo = yearContributionCollection.commitContributionsByRepository.map(m => m.repository);
 
-  // if count_private then add private commits to totalCommits so far.
-  if (count_private) {
-    stats.totalCommits +=
-      user.contributionsCollection.restrictedContributionsCount;
-  }
+      repoStars = repoStars.concat(repo).filter((item, index, self) =>
+        index === self.findIndex((t) => (
+          t.name === item.name
+        ))
+      );
+    }
+  });
 
+  repoStars.forEach(f => {
+    stats.totalStars += f.stargazers.totalCount;
+  });
+  stats.contributedTo = repoStars.length;
   stats.totalPRs = user.pullRequests.totalCount;
-  stats.contributedTo = user.repositoriesContributedTo.totalCount;
-
-  stats.totalStars = user.repositories.nodes.reduce((prev, curr) => {
-    return prev + curr.stargazers.totalCount;
-  }, 0);
+  stats.totalIssues = user.issues.totalCount;
 
   stats.rank = calculateRank({
     totalCommits: stats.totalCommits,
-    totalRepos: user.repositories.totalCount,
+    totalRepos: stats.totalRepos,
     followers: user.followers.totalCount,
     contributions: stats.contributedTo,
     stargazers: stats.totalStars,
@@ -148,6 +152,8 @@ async function fetchStats(
   });
 
   return stats;
+
+
 }
 
 module.exports = fetchStats;

--- a/tests/renderStatsCard.test.js
+++ b/tests/renderStatsCard.test.js
@@ -245,7 +245,7 @@ describe("Test renderStatsCard", () => {
       document.querySelector(
         'g[transform="translate(0, 25)"]>.stagger>.stat.bold',
       ).textContent,
-    ).toMatchInlineSnapshot(`"累计提交数（commit） (2021):"`);
+    ).toMatchInlineSnapshot(`"累计提交数（commit）:"`);
     expect(
       document.querySelector(
         'g[transform="translate(0, 50)"]>.stagger>.stat.bold',

--- a/tests/retryer.test.js
+++ b/tests/retryer.test.js
@@ -13,7 +13,7 @@ const fetcherFail = jest.fn(() => {
   );
 });
 
-const fetcherFailOnSecondTry = jest.fn((_vars, _token, retries) => {
+const fetcherFailOnSecondTry = jest.fn((_vars, _token, query, retries) => {
   return new Promise((res, rej) => {
     // faking rate limit
     if (retries < 1) {
@@ -25,14 +25,14 @@ const fetcherFailOnSecondTry = jest.fn((_vars, _token, retries) => {
 
 describe("Test Retryer", () => {
   it("retryer should return value and have zero retries on first try", async () => {
-    let res = await retryer(fetcher, {});
+    let res = await retryer(fetcher, {}, "");
 
     expect(fetcher).toBeCalledTimes(1);
     expect(res).toStrictEqual({ data: "ok" });
   });
 
   it("retryer should return value and have 2 retries", async () => {
-    let res = await retryer(fetcherFailOnSecondTry, {});
+    let res = await retryer(fetcherFailOnSecondTry, {}, "");
 
     expect(fetcherFailOnSecondTry).toBeCalledTimes(2);
     expect(res).toStrictEqual({ data: "ok" });
@@ -42,7 +42,7 @@ describe("Test Retryer", () => {
     let res;
 
     try {
-      res = await retryer(fetcherFail, {});
+      res = await retryer(fetcherFail, {}, "");
     } catch (err) {
       expect(fetcherFail).toBeCalledTimes(8);
       expect(err.message).toBe("Maximum retries exceeded");


### PR DESCRIPTION
Improvements described at #1043 

You can check it out: https://github-readme-stats-silk-xi.vercel.app/

Changes:
* Get all years that user has some data
```graphql
query userInfo($login: String!) {
        user(login: $login) {
          contributionsCollection {
            contributionYears
          }
        }
      }
```
* Build one query to gather all user information.
```graphql
year_2021: contributionsCollection(from: "2021-01-01T00:00:00Z", to: "2022-01-01T00:00:00Z") {
      totalCommitContributions
      totalRepositoryContributions
      restrictedContributionsCount
      commitContributionsByRepository {
        repository {
          name
          stargazers {
            totalCount
          }
        }
      }
    }
```
From this query get repositories contributedTo, stars, totalCommits, createdRepos and private commit

* New parameter at `retryer.js` to accept a query.
* Updated the tests
* Updated docs

If it makes sense, accept.