### PR TITLE
Feature: add transblue theme

### DIFF
--- a/api/top-langs.js
+++ b/api/top-langs.js
@@ -25,6 +25,7 @@ module.exports = async (req, res) => {
     cache_seconds,
     layout,
     langs_count,
+    count_private,
     exclude_repo,
     custom_title,
     locale,
@@ -46,6 +47,7 @@ module.exports = async (req, res) => {
   try {
     topLangs = await fetchTopLanguages(
       username,
+      parseBoolean(count_private),
       parseArray(exclude_repo),
       parseArray(hide),
     );

--- a/src/fetchers/top-languages-fetcher.js
+++ b/src/fetchers/top-languages-fetcher.js
@@ -11,7 +11,8 @@ const fetcher = (variables, token) => {
           # fetch only owner repos & not forks
           repositories(ownerAffiliations: OWNER, isFork: false, first: 100) {
             nodes {
-              name
+              name,
+              isPrivate,
               languages(first: 10, orderBy: {field: SIZE, direction: DESC}) {
                 edges {
                   size
@@ -34,7 +35,11 @@ const fetcher = (variables, token) => {
   );
 };
 
-async function fetchTopLanguages(username, exclude_repo = []) {
+async function fetchTopLanguages(
+  username,
+  count_private = false,
+  exclude_repo = [],
+) {
   if (!username) throw Error("Invalid username");
 
   const res = await retryer(fetcher, { login: username });
@@ -61,6 +66,11 @@ async function fetchTopLanguages(username, exclude_repo = []) {
     .filter((name) => {
       return !repoToHide[name.name];
     });
+
+  // filter out private repositories if needed
+  if (!count_private) {
+    repoNodes = repoNodes.filter(repo => !repo.isPrivate);
+  }
 
   repoNodes = repoNodes
     .filter((node) => {

--- a/themes/index.js
+++ b/themes/index.js
@@ -294,6 +294,12 @@ const themes = {
     text_color: "FFFFFF",
     bg_color: "2C2F33",
   },
+  transblue: {
+    title_color: "1d87da",
+    icon_color: "539bf5",
+    text_color: "539bf5",
+    bg_color: "0000",
+  },
 };
 
 module.exports = themes;


### PR DESCRIPTION
Hi @anuraghazra 👋🏻 

I have created a theme that could smoothly fit both day and night modes. Please check out this. 
Hope you enjoy it! ❤️ 

For **Default light**:
<img width="600" alt="Screen Shot 2021-05-24 at 12 35 07 AM" src="https://user-images.githubusercontent.com/37981444/119268973-e532f300-bc27-11eb-85c0-39a895785350.png">
For **Default Dark**:
<img width="600" alt="Screen Shot 2021-05-24 at 12 35 36 AM" src="https://user-images.githubusercontent.com/37981444/119268987-f7149600-bc27-11eb-9a95-19a107ccd993.png">
For **Dark Dimmed**:
<img width="600" alt="Screen Shot 2021-05-24 at 12 35 58 AM" src="https://user-images.githubusercontent.com/37981444/119268994-04318500-bc28-11eb-85c9-d7e07adb65f8.png">

It is worth mentioning that I choose exactly the GitHub title text color as `text_color`. (title_color needs a deeper color)

