### PR TITLE
feat: threshold for wakatime duration

### DIFF
--- a/api/wakatime.js
+++ b/api/wakatime.js
@@ -30,6 +30,7 @@ module.exports = async (req, res) => {
     range,
     border_radius,
     border_color,
+    min_seconds,
   } = req.query;
 
   res.setHeader("Content-Type", "image/svg+xml");
@@ -70,6 +71,7 @@ module.exports = async (req, res) => {
         locale: locale ? locale.toLowerCase() : null,
         layout,
         langs_count,
+        min_seconds,
       }),
     );
   } catch (err) {

--- a/docs/readme_de.md
+++ b/docs/readme_de.md
@@ -175,6 +175,7 @@ Du kannst mehrere, mit Kommas separierte, Werte in der bg_color Option angeben, 
 - `custom_title` - Legt einen benutzerdefinierten Titel fest
 - `layout` - Wechselt zwischen zwei verschiedenen Layouts: `default` & `compact`
 - `langs_count` - Begrenzt die Anzahl der angezeigten Sprachen auf der Karte
+- `min_seconds` - Begrenzt die Dauer, ab der eine Sprache auf der Karte angezeigt wird
 - `api_domain` - Legt eine benutzerdefinierte API Domain fest, z.B. für [Hakatime](https://github.com/mujx/hakatime) oder [Wakapi](https://github.com/muety/wakapi)
 - `range` – Fragt eine eine Zeitspanne an, als die standardmäßig in WakaTime hinterlegte, z.B. `last_7_days`. Siehe [WakaTime API Dokumentation](https://wakatime.com/developers#stats).
 

--- a/readme.md
+++ b/readme.md
@@ -213,6 +213,7 @@ You can provide multiple comma-separated values in bg_color option to render a g
 - `custom_title` - Sets a custom title for the card
 - `layout` - Switch between two available layouts `default` & `compact`
 - `langs_count` - Limit number of languages on the card, defaults to all reported langauges
+- `min_seconds` - Threshold above which to show a language on the card
 - `api_domain` - Set a custom API domain for the card, e.g. to use services like [Hakatime](https://github.com/mujx/hakatime) or [Wakapi](https://github.com/muety/wakapi)
 - `range` – Request a range different from your WakaTime default, e.g. `last_7_days`. See [WakaTime API docs](https://wakatime.com/developers#stats) for list of available options.
 

--- a/src/cards/wakatime-card.js
+++ b/src/cards/wakatime-card.js
@@ -102,6 +102,7 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
     langs_count = languages ? languages.length : 0,
     border_radius,
     border_color,
+    min_seconds = 180
   } = options;
 
   const i18n = new I18n({
@@ -132,6 +133,7 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
   const statItems = languages
     ? languages
         .filter((language) => language.hours || language.minutes)
+        .filter((language) => language.total_seconds >= min_seconds)
         .slice(0, langsCount)
         .map((language) => {
           return createTextNode({

--- a/tests/__snapshots__/renderWakatimeCard.test.js.snap
+++ b/tests/__snapshots__/renderWakatimeCard.test.js.snap
@@ -120,29 +120,6 @@ exports[`Test Render Wakatime Card should render correctly 1`] = `
     </svg>
   
     </g>
-  </g><g transform=\\"translate(0, 25)\\">
-    <g class=\\"stagger\\" style=\\"animation-delay: NaNms\\" transform=\\"translate(25, 0)\\">
-      <text class=\\"stat bold\\" y=\\"12.5\\">TypeScript:</text>
-      <text
-        class=\\"stat\\"
-        x=\\"350\\"
-        y=\\"12.5\\"
-        data-testid=\\"TypeScript\\"
-      >1 min</text>
-      
-    <svg width=\\"220\\" x=\\"110\\" y=\\"4\\">
-      <rect rx=\\"5\\" ry=\\"5\\" x=\\"0\\" y=\\"0\\" width=\\"220\\" height=\\"8\\" fill=\\"#333\\"></rect>
-      <rect
-          height=\\"8\\"
-          fill=\\"#2f80ed\\"
-          rx=\\"5\\" ry=\\"5\\" x=\\"0\\" y=\\"0\\" 
-          data-testid=\\"lang-progress\\"
-          width=\\"2%\\"
-      >
-      </rect>
-    </svg>
-  
-    </g>
   </g>
     </svg>
   


### PR DESCRIPTION
This introduces a parameter called `min_seconds` to wakatime cards which drops languages below the provided threshold

![image](https://user-images.githubusercontent.com/3610244/120065963-5d5c4700-c074-11eb-9894-b3772ce8d1ad.png)

### Before
![image](https://user-images.githubusercontent.com/3610244/120065922-1d955f80-c074-11eb-850c-5f39fe02a841.png)
![image](https://user-images.githubusercontent.com/3610244/120065748-479a5200-c073-11eb-9829-e2567a949e06.png)

### After
Providing `min_seconds` = 600 will drop all languages with duration below 10 minutes (600 seconds)
![image](https://user-images.githubusercontent.com/3610244/120065928-284ff480-c074-11eb-9ecf-de34996bc6a4.png)
![image](https://user-images.githubusercontent.com/3610244/120065764-51bc5080-c073-11eb-93a2-77f4f9ae8734.png)
