### PR TITLE
to contribute a new theme "for-dark-or-light-any-theme"

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -288,6 +288,12 @@ const themes = {
     text_color: "C3D1D9",
     bg_color: "0D1117",
   },
+  "for-dark-or-light-any-theme": {
+    title_color: "FA8C00",
+    icon_color: "CC5160",
+    text_color: "949CA5",
+    bg_color: "00000000",
+  },
 };
 
 module.exports = themes;


### PR DESCRIPTION
want to add this theme "for-dark-or-light-any-theme" as many people face a bit of irritating when GitHub theme does not fit and seems adaptive with cards. I made this so that, it can be used in any theme of GitHub and it will be fit in.