### PR TITLE
fix: return "" instead of return undefined

### DIFF
--- a/src/common/Card.js
+++ b/src/common/Card.js
@@ -94,7 +94,7 @@ class Card {
   }
 
   renderGradient() {
-    if (typeof this.colors.bgColor !== "object") return;
+    if (typeof this.colors.bgColor !== "object") return "";
 
     const gradients = this.colors.bgColor.slice(1);
     return typeof this.colors.bgColor === "object"


### PR DESCRIPTION
the function renderGradient returns  undefined if colors.bgColor !== "object"

which may render "undefined" into SVG

and actually, it has already done so