### PR TITLE
fix: fixed the broken progress bar in compact layout when langs_count is specified

### DIFF
--- a/src/cards/wakatime-card.js
+++ b/src/cards/wakatime-card.js
@@ -154,13 +154,14 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
     width = width + 50;
     height = 90 + Math.round(filteredLanguages.length / 2) * 25;
 
+    const totalPercentage = filteredLanguages.reduce((acc, language) => acc + language.percent, 0)
     // progressOffset holds the previous language's width and used to offset the next language
     // so that we can stack them one after another, like this: [--][----][---]
     let progressOffset = 0;
     const compactProgressBar = filteredLanguages
       .map((language) => {
         // const progress = (width * lang.percent) / 100;
-        const progress = ((width - 25) * language.percent) / 100;
+        const progress = ((width - 25) * language.percent) / totalPercentage;
 
         const languageColor = languageColors[language.name] || "#858585";
 

--- a/tests/__snapshots__/renderWakatimeCard.test.js.snap
+++ b/tests/__snapshots__/renderWakatimeCard.test.js.snap
@@ -258,7 +258,7 @@ exports[`Test Render Wakatime Card should render correctly with compact layout 1
             data-testid=\\"lang-progress\\"
             x=\\"0\\"
             y=\\"0\\"
-            width=\\"6.6495\\"
+            width=\\"434.60784313725486\\"
             height=\\"8\\"
             fill=\\"#858585\\"
           />
@@ -266,9 +266,9 @@ exports[`Test Render Wakatime Card should render correctly with compact layout 1
           <rect
             mask=\\"url(#rect-mask)\\"
             data-testid=\\"lang-progress\\"
-            x=\\"6.6495\\"
+            x=\\"434.60784313725486\\"
             y=\\"0\\"
-            width=\\"0.465\\"
+            width=\\"30.392156862745097\\"
             height=\\"8\\"
             fill=\\"#2b7489\\"
           />


### PR DESCRIPTION
As https://github.com/anuraghazra/github-readme-stats/pull/560#issuecomment-756473202 mentioned, wakatime's progress bar (in compact layout) brokes when `langs_count` is specified.

This can be fixed in a similar way to https://github.com/anuraghazra/github-readme-stats/blob/master/src/cards/top-languages-card.js#L107

|Before|After|
|------|------|
|![localhost_3000_api_wakatime_username=Amabel theme=vue layout=compact langs_count=6 (1)](https://user-images.githubusercontent.com/12688422/121794823-60476200-cc46-11eb-96ef-dc14c6761284.png)|![localhost_3000_api_wakatime_username=Amabel theme=vue layout=compact langs_count=6 (2)](https://user-images.githubusercontent.com/12688422/121794832-705f4180-cc46-11eb-8915-80a301c056fc.png)|
