### PR TITLE
Added arduino_light Theme

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -294,6 +294,12 @@ const themes = {
     text_color: "FFFFFF",
     bg_color: "2C2F33",
   },
+  arduino_light: {
+    title_color: "04646C",
+    icon_color: "14A4A4",
+    text_color: "000000",
+    bg_color: "D0FFFF",
+  },
 };
 
 module.exports = themes;


### PR DESCRIPTION
Added "Arduino Light" Theme inspired by Arduino IDE Theme.

Demo:
![image](https://user-images.githubusercontent.com/83153460/124458496-ab1e4a80-ddaa-11eb-86c1-2ddf02cb70b0.png)