### PR TITLE
fix: fetch all repos for top languages

### DIFF
--- a/src/fetchers/top-languages-fetcher.js
+++ b/src/fetchers/top-languages-fetcher.js
@@ -43,13 +43,13 @@ const fetcher = (variables, token) => {
 async function fetchTopLanguages(username, exclude_repo = []) {
   if (!username) throw Error("Invalid username");
 
-  const page_size = 100;
-  let page_cursor = null;
+  const pageSize = 100;
+  let pageCursor = null;
 
   let repoNodes = [];
 
   while (true) {
-    const variables = { login: username, first: page_size, after: page_cursor };
+    const variables = { login: username, first: pageSize, after: pageCursor };
     const res = await retryer(fetcher, variables);
 
     if (res.data.errors) {
@@ -59,10 +59,10 @@ async function fetchTopLanguages(username, exclude_repo = []) {
 
     repoNodes = repoNodes.concat(res.data.data.user.repositories.nodes);
     if (!res.data.data.user.repositories.edges ||
-      res.data.data.user.repositories.edges.length < page_size) {
+      res.data.data.user.repositories.edges.length < pageSize) {
       break;
     }
-    page_cursor = res.data.data.user.repositories.edges[page_size - 1].cursor;
+    pageCursor = res.data.data.user.repositories.edges[pageSize - 1].cursor;
   }
 
   let repoToHide = {};

--- a/src/fetchers/top-languages-fetcher.js
+++ b/src/fetchers/top-languages-fetcher.js
@@ -6,10 +6,16 @@ const fetcher = (variables, token) => {
   return request(
     {
       query: `
-      query userInfo($login: String!) {
+      query userInfo($login: String!, $first: Int!, $after: String) {
         user(login: $login) {
           # fetch only owner repos & not forks
-          repositories(ownerAffiliations: OWNER, isFork: false, first: 100) {
+          repositories(
+            ownerAffiliations: OWNER, isFork: false, 
+            first: $first, after: $after
+          ) {
+            edges {
+              cursor
+            }
             nodes {
               name
               languages(first: 10, orderBy: {field: SIZE, direction: DESC}) {
@@ -37,14 +43,28 @@ const fetcher = (variables, token) => {
 async function fetchTopLanguages(username, exclude_repo = []) {
   if (!username) throw Error("Invalid username");
 
-  const res = await retryer(fetcher, { login: username });
+  const page_size = 100;
+  let page_cursor = null;
 
-  if (res.data.errors) {
-    logger.error(res.data.errors);
-    throw Error(res.data.errors[0].message || "Could not fetch user");
+  let repoNodes = [];
+
+  while (true) {
+    const variables = { login: username, first: page_size, after: page_cursor };
+    const res = await retryer(fetcher, variables);
+
+    if (res.data.errors) {
+      logger.error(res.data.errors);
+      throw Error(res.data.errors[0].message || "Could not fetch user");
+    }
+
+    repoNodes = repoNodes.concat(res.data.data.user.repositories.nodes);
+    if (!res.data.data.user.repositories.edges ||
+      res.data.data.user.repositories.edges.length < page_size) {
+      break;
+    }
+    page_cursor = res.data.data.user.repositories.edges[page_size - 1].cursor;
   }
 
-  let repoNodes = res.data.data.user.repositories.nodes;
   let repoToHide = {};
 
   // populate repoToHide map for quick lookup

--- a/tests/fetchTopLanguages.test.js
+++ b/tests/fetchTopLanguages.test.js
@@ -13,6 +13,12 @@ const data_langs = {
   data: {
     user: {
       repositories: {
+        edges: [
+          { cursor: "1" },
+          { cursor: "2" },
+          { cursor: "3" },
+          { cursor: "4" },
+        ],
         nodes: [
           {
             languages: {


### PR DESCRIPTION
This fixed #1177 

Before:
[![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=tc-imba&langs_count=10&layout=compact&theme=graywhite)](https://github.com/anuraghazra/github-readme-stats)

After:
[![Top Langs](https://github-readme-stats-peach-two.vercel.app/api/top-langs/?username=tc-imba&langs_count=10&layout=compact&theme=graywhite)](https://github.com/anuraghazra/github-readme-stats)

PS. I have some python repos recently but not shown in the first figure because they are not in the oldest 100 repos. In the second figure they are successfully found.