### PR TITLE
Add Atom one dark theme

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -297,7 +297,7 @@ const themes = {
   atom_one_dark: {
     title_color: '61afef',
     icon_color: '98c379',
-    text_color: 'f9fafa',
+    text_color: 'e3e5e8',
     bg_color: '282c34',
 };
 

--- a/themes/index.js
+++ b/themes/index.js
@@ -294,6 +294,11 @@ const themes = {
     text_color: "FFFFFF",
     bg_color: "2C2F33",
   },
+  atom_one_dark: {
+    title_color: '61afef',
+    icon_color: '98c379',
+    text_color: 'f9fafa',
+    bg_color: '282c34',
 };
 
 module.exports = themes;


### PR DESCRIPTION
Adds theme from https://marketplace.visualstudio.com/items?itemName=akamud.vscode-theme-onedark 

Current "onedark" theme shows the alt colors (red, orange) whereas this shows the primary shades of blue which looks nicer 😎