### PR TITLE
Cleanup Tests and Warnings in them

### DIFF
--- a/tests/renderStatsCard.test.js
+++ b/tests/renderStatsCard.test.js
@@ -107,15 +107,10 @@ describe("Test renderStatsCard", () => {
     const styleTag = document.querySelector("style");
     const stylesObject = cssToObject(styleTag.innerHTML);
 
-    const headerClassStyles = stylesObject[".header"];
-    const statClassStyles = stylesObject[".stat"];
-    const iconClassStyles = stylesObject[".icon"];
-
-    expect(headerClassStyles.fill).toBe(`#${customColors.title_color}`);
-    expect(statClassStyles.fill).toBe(`#${customColors.text_color}`);
-    expect(iconClassStyles.fill).toBe(`#${customColors.icon_color}`);
-    expect(queryByTestId(document.body, "card-bg")).toHaveAttribute(
-      "fill",
+    expectColors(stylesObject,
+      `#${customColors.title_color}`,
+      `#${customColors.text_color}`,
+      `#${customColors.icon_color}`,
       "#252525",
     );
   });
@@ -129,17 +124,11 @@ describe("Test renderStatsCard", () => {
     const styleTag = document.querySelector("style");
     const stylesObject = cssToObject(styleTag.innerHTML);
 
-    const headerClassStyles = stylesObject[".header"];
-    const statClassStyles = stylesObject[".stat"];
-    const iconClassStyles = stylesObject[".icon"];
-
-    expect(headerClassStyles.fill).toBe("#5a0");
-    expect(statClassStyles.fill).toBe(`#${themes.radical.text_color}`);
-    expect(iconClassStyles.fill).toBe(`#${themes.radical.icon_color}`);
-    expect(queryByTestId(document.body, "card-bg")).toHaveAttribute(
-      "fill",
-      `#${themes.radical.bg_color}`,
-    );
+    expectColors(stylesObject,
+      "#5a0",
+      `#${themes.radical.text_color}`,
+      `#${themes.radical.icon_color}`,
+      `#${themes.radical.bg_color}`);
   });
 
   it("should render with all the themes", () => {
@@ -151,17 +140,11 @@ describe("Test renderStatsCard", () => {
       const styleTag = document.querySelector("style");
       const stylesObject = cssToObject(styleTag.innerHTML);
 
-      const headerClassStyles = stylesObject[".header"];
-      const statClassStyles = stylesObject[".stat"];
-      const iconClassStyles = stylesObject[".icon"];
-
-      expect(headerClassStyles.fill).toBe(`#${themes[name].title_color}`);
-      expect(statClassStyles.fill).toBe(`#${themes[name].text_color}`);
-      expect(iconClassStyles.fill).toBe(`#${themes[name].icon_color}`);
-      expect(queryByTestId(document.body, "card-bg")).toHaveAttribute(
-        "fill",
-        `#${themes[name].bg_color}`,
-      );
+      expectColors(stylesObject,
+        `#${themes[name].title_color}`,
+        `#${themes[name].text_color}`,
+        `#${themes[name].icon_color}`,
+        `#${themes[name].bg_color}`);
     });
   });
 
@@ -175,18 +158,26 @@ describe("Test renderStatsCard", () => {
     const styleTag = document.querySelector("style");
     const stylesObject = cssToObject(styleTag.innerHTML);
 
+    expectColors(stylesObject,
+      `#${themes.default.title_color}`,
+      `#${themes.default.text_color}`,
+      `#${themes.radical.icon_color}`,
+      `#${themes.radical.bg_color}`);
+  });
+
+  function expectColors(stylesObject, headerColor, statColor, iconColor, cardColor) {
     const headerClassStyles = stylesObject[".header"];
     const statClassStyles = stylesObject[".stat"];
     const iconClassStyles = stylesObject[".icon"];
 
-    expect(headerClassStyles.fill).toBe(`#${themes.default.title_color}`);
-    expect(statClassStyles.fill).toBe(`#${themes.default.text_color}`);
-    expect(iconClassStyles.fill).toBe(`#${themes.radical.icon_color}`);
+    expect(headerClassStyles.fill).toBe(headerColor);
+    expect(statClassStyles.fill).toBe(statColor);
+    expect(iconClassStyles.fill).toBe(iconColor);
     expect(queryByTestId(document.body, "card-bg")).toHaveAttribute(
       "fill",
-      `#${themes.radical.bg_color}`,
+      cardColor,
     );
-  });
+  }
 
   it("should render icons correctly", () => {
     document.body.innerHTML = renderStatsCard(stats, {
@@ -238,27 +229,27 @@ describe("Test renderStatsCard", () => {
     );
     expect(
       document.querySelector(
-        'g[transform="translate(0, 0)"]>.stagger>.stat.bold',
+        "g[transform=\"translate(0, 0)\"]>.stagger>.stat.bold",
       ).textContent,
     ).toMatchInlineSnapshot(`"获标星数（star）:"`);
     expect(
       document.querySelector(
-        'g[transform="translate(0, 25)"]>.stagger>.stat.bold',
+        "g[transform=\"translate(0, 25)\"]>.stagger>.stat.bold",
       ).textContent,
     ).toMatchInlineSnapshot(`"累计提交数（commit） (2021):"`);
     expect(
       document.querySelector(
-        'g[transform="translate(0, 50)"]>.stagger>.stat.bold',
+        "g[transform=\"translate(0, 50)\"]>.stagger>.stat.bold",
       ).textContent,
     ).toMatchInlineSnapshot(`"拉取请求数（PR）:"`);
     expect(
       document.querySelector(
-        'g[transform="translate(0, 75)"]>.stagger>.stat.bold',
+        "g[transform=\"translate(0, 75)\"]>.stagger>.stat.bold",
       ).textContent,
     ).toMatchInlineSnapshot(`"指出问题数（issue）:"`);
     expect(
       document.querySelector(
-        'g[transform="translate(0, 100)"]>.stagger>.stat.bold',
+        "g[transform=\"translate(0, 100)\"]>.stagger>.stat.bold",
       ).textContent,
     ).toMatchInlineSnapshot(`"参与项目数:"`);
   });

--- a/tests/renderTopLanguages.test.js
+++ b/tests/renderTopLanguages.test.js
@@ -1,6 +1,5 @@
 require("@testing-library/jest-dom");
 const cssToObject = require("css-to-object");
-const fetchTopLanguages = require("../src/fetchers/top-languages-fetcher");
 const renderTopLanguages = require("../src/cards/top-languages-card");
 
 const { queryByTestId, queryAllByTestId } = require("@testing-library/dom");
@@ -233,7 +232,7 @@ describe("Test renderTopLanguages", () => {
   });
 
   it("should render langs with specified langs_count", async () => {
-    options = {
+    let options = {
       langs_count: 1,
     };
     document.body.innerHTML = renderTopLanguages(langs, { ...options });
@@ -243,7 +242,7 @@ describe("Test renderTopLanguages", () => {
   });
 
   it("should render langs with specified langs_count even when hide is set", async () => {
-    options = {
+    let options = {
       hide: ["HTML"],
       langs_count: 2,
     };

--- a/tests/retryer.test.js
+++ b/tests/retryer.test.js
@@ -39,10 +39,8 @@ describe("Test Retryer", () => {
   });
 
   it("retryer should throw error if maximum retries reached", async () => {
-    let res;
-
     try {
-      res = await retryer(fetcherFail, {});
+      await retryer(fetcherFail, {});
     } catch (err) {
       expect(fetcherFail).toBeCalledTimes(8);
       expect(err.message).toBe("Maximum retries exceeded");

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -22,8 +22,8 @@ describe("Test utils.js", () => {
   });
 
   it("should test encodeHTML", () => {
-    expect(encodeHTML(`<html>hello world<,.#4^&^@%!))`)).toBe(
-      "&#60;html&#62;hello world&#60;,.#4^&#38;^@%!))",
+    expect(encodeHTML(`<html lang="">hello world<,.#4^&^@%!))`)).toBe(
+      "&#60;html lang=\"\"&#62;hello world&#60;,.#4^&#38;^@%!))",
     );
   });
 
@@ -32,7 +32,7 @@ describe("Test utils.js", () => {
     expect(
       queryByTestId(document.body, "message").children[0],
     ).toHaveTextContent(/Something went wrong/gim);
-    expect(queryByTestId(document.body, "message").children[1]).toBeEmpty(2);
+    expect(queryByTestId(document.body, "message").children[1]).toBeEmptyDOMElement();
 
     // Secondary message
     document.body.innerHTML = renderError(


### PR DESCRIPTION
# Description
I've cleanuped the tests a bit and fixed some warnings. Jest only spitted out the warning that `toBeEmpty()` is deprecated and `toBeDOMElement()` should be used instead, but i also refactored other tests in this PR. Mainly `renderStatsCard.test.js`, because it had multiple duplicate code-fragments that should be refactored for faster readability.

### Code
- Exchanged deprecated method
- Added `expectColors()` to avoid duplicate code fragments
- Removed unused imports
- Removed unused variables

## Types of changes
- Enhancement
- Refactor

## Reference
[toBeDOMElement](https://github.com/testing-library/jest-dom#tobeemptydomelement)