### PR TITLE
feat: Hide Wakatime languages

### DIFF
--- a/api/wakatime.js
+++ b/api/wakatime.js
@@ -3,6 +3,7 @@ const {
   renderError,
   parseBoolean,
   clampValue,
+  parseArray,
   CONSTANTS,
   isLocaleAvailable,
 } = require("../src/common/utils");
@@ -26,6 +27,7 @@ module.exports = async (req, res) => {
     locale,
     layout,
     langs_count,
+    hide,
     api_domain,
     range,
     border_radius,
@@ -58,6 +60,7 @@ module.exports = async (req, res) => {
         custom_title,
         hide_title: parseBoolean(hide_title),
         hide_border: parseBoolean(hide_border),
+        hide: parseArray(hide),
         line_height,
         title_color,
         icon_color,

--- a/src/cards/wakatime-card.js
+++ b/src/cards/wakatime-card.js
@@ -84,6 +84,15 @@ const createTextNode = ({
   `;
 };
 
+const recalculatePercentages = (languages) => {
+  let totalSum = 0;
+  languages.forEach(language => totalSum += language.percent);
+  const weight = (100 / totalSum).toFixed(2);
+  languages.forEach(language => {
+    language.percent = (language.percent * weight).toFixed(2)
+  })
+}
+
 const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
   const { languages } = stats;
   const {
@@ -105,7 +114,7 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
   } = options;
 
   let lowercase_hide = {}
-  if(hide){
+  if(Array.isArray(hide) && hide.length > 0){
     lowercase_hide = hide.map(function(lang) {
       return lang.toLowerCase().trim();
     });
@@ -115,9 +124,9 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
         languages.splice(i, 1);
       }
     }
+    recalculatePercentages(languages);
   }
 
-  // fixme calculate new percentage weight
   // fixme consider older (query) language count
   langs_count = languages ? languages.length : 0;
 

--- a/src/cards/wakatime-card.js
+++ b/src/cards/wakatime-card.js
@@ -89,9 +89,9 @@ const recalculatePercentages = (languages) => {
   languages.forEach(language => totalSum += language.percent);
   const weight = (100 / totalSum).toFixed(2);
   languages.forEach(language => {
-    language.percent = (language.percent * weight).toFixed(2)
-  })
-}
+    language.percent = (language.percent * weight).toFixed(2);
+  });
+};
 
 const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
   const { languages } = stats;
@@ -109,12 +109,13 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
     custom_title,
     locale,
     layout,
+    langs_count = languages ? languages.length : 0,
     border_radius,
     border_color,
   } = options;
 
-  let lowercase_hide = {}
-  if(Array.isArray(hide) && hide.length > 0){
+  let lowercase_hide = {};
+  if (Array.isArray(hide) && hide.length > 0) {
     lowercase_hide = hide.map(function(lang) {
       return lang.toLowerCase().trim();
     });
@@ -126,9 +127,6 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
     }
     recalculatePercentages(languages);
   }
-
-  // fixme consider older (query) language count
-  langs_count = languages ? languages.length : 0;
 
   const i18n = new I18n({
     locale,

--- a/src/cards/wakatime-card.js
+++ b/src/cards/wakatime-card.js
@@ -89,6 +89,7 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
   const {
     hide_title = false,
     hide_border = false,
+    hide,
     line_height = 25,
     title_color,
     icon_color,
@@ -99,10 +100,26 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
     custom_title,
     locale,
     layout,
-    langs_count = languages ? languages.length : 0,
     border_radius,
     border_color,
   } = options;
+
+  let lowercase_hide = {}
+  if(hide){
+    lowercase_hide = hide.map(function(lang) {
+      return lang.toLowerCase().trim();
+    });
+
+    for (let i = languages.length - 1; i >= 0; i--) {
+      if (lowercase_hide.includes(languages[i].name.toLowerCase().trim())) {
+        languages.splice(i, 1);
+      }
+    }
+  }
+
+  // fixme calculate new percentage weight
+  // fixme consider older (query) language count
+  langs_count = languages ? languages.length : 0;
 
   const i18n = new I18n({
     locale,


### PR DESCRIPTION
# Description
I've added a new query-parameter hide to hide specific languages you don't want to display. This was also requested in #1138.
Because some values will be hidden I've recalculated the percentages to correctly display the 

### Draft
This Branch is PR is currently marked as DRAFT: The reason for this is that the `langs_count` currently clashes with the `hide`-option. My code currently does not take into account the languages that have been filtered out.

### Code
- Added `hide` param in `wakatime.js` and `wakatime-card.js`
- Added a method that recalculates the percentages for each item

## Types of changes
- Enhancement
- Refactor

## Reference
The following cards are an example using this new feature.

#### Full Card
![image](https://user-images.githubusercontent.com/43741877/127174854-48bedab4-b319-4aeb-ac88-543587358367.png)
#### Javascript, Python, CSV and Testing hidden
![image](https://user-images.githubusercontent.com/43741877/127174940-30db6a35-f8f4-433c-8230-e1874f02f8ff.png)
