### PR TITLE
Add subfolder support in api_domain

### DIFF
--- a/src/fetchers/wakatime-fetcher.js
+++ b/src/fetchers/wakatime-fetcher.js
@@ -4,7 +4,7 @@ const fetchWakatimeStats = async ({ username, api_domain, range }) => {
   try {
     const { data } = await axios.get(
       `https://${
-        api_domain ? api_domain.replace(/[^a-z-.0-9]/gi, "") : "wakatime.com"
+        api_domain ? api_domain.replace(/\/$/gi, "") : "wakatime.com"
       }/api/v1/users/${username}/stats/${range || ''}?is_including_today=true`,
     );
 


### PR DESCRIPTION
As of right now an `api_domain` with a subfolder doesn't work. Some wakapi users that end up hosting their own server, may end up using a subfolder, instead of a subdomain, just like I did on mine.

So following doesn't work

```
api_domain=example.com/wakapi
```
because currently it becomes `api_domain=example.comwakapi`

giving the following output

![scrreen](https://user-images.githubusercontent.com/5643710/128685918-e4a5017c-5a7b-415f-95e8-6bfcf9f37a5f.JPG)

I already tested this on my forked repo, so I know it works. https://github.com/AlexandroPerez/github-readme-stats

I don't know if changes will need to be made to make the provided api_domain safe, but as of now it only removes a trailing `/` at the end of the value. 

Fixes #1026 