### PR TITLE
Fix non-capitalised stars stat text

### DIFF
--- a/src/translations.js
+++ b/src/translations.js
@@ -34,7 +34,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       cn: "获标星数（star）",
       cs: "Celkem hvězd",
       de: "Insgesamt erhaltene Sterne",
-      en: "Total stars received",
+      en: "Total Stars Received",
       bn: "সর্বমোট Stars",
       es: "Estrellas totales",
       fr: "Total d'étoiles",


### PR DESCRIPTION
The changes from commit d790404c766d2b62c6911bd2d1f88e59d4420aac failed to capitalise the text for the total stars stat. This ruins consistency compared to the text from other stats, and makes it look out of place.