### PR TITLE
Add support for EXCLUDE_REPO env variable

### DIFF
--- a/src/fetchers/top-languages-fetcher.js
+++ b/src/fetchers/top-languages-fetcher.js
@@ -1,4 +1,4 @@
-const { request, logger } = require("../common/utils");
+const { request, logger, parseArray } = require("../common/utils");
 const retryer = require("../common/retryer");
 require("dotenv").config();
 
@@ -46,6 +46,8 @@ async function fetchTopLanguages(username, exclude_repo = []) {
 
   let repoNodes = res.data.data.user.repositories.nodes;
   let repoToHide = {};
+
+  exclude_repo.push(parseArray(process.env.EXCLUDE_REPO));
 
   // populate repoToHide map for quick lookup
   // while filtering out


### PR DESCRIPTION
This addition allows the user to exclude repositories from their top languages via environment variables, working basically like a hidden `exclude_repo=repo1,repo2` parameter.

It follows the same syntax: comma separated values, stored in an `EXCLUDE_REPO` variable.

When deploying your own instance, this allows you to include private repositories in the "Top Languages" card, while excluding some of them without the need to expose their name in your README (as they would have to be specified in the card url).