### PR TITLE
feat: add bold options

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -33,6 +33,9 @@ module.exports = async (req, res) => {
     disable_animations,
     border_radius,
     border_color,
+    label_bold,
+    value_bold,
+    rank_bold,
   } = req.query;
   let stats;
 
@@ -80,6 +83,9 @@ module.exports = async (req, res) => {
         border_color,
         locale: locale ? locale.toLowerCase() : null,
         disable_animations: parseBoolean(disable_animations),
+        label_bold: parseBoolean(label_bold),
+        value_bold: parseBoolean(value_bold),
+        rank_bold: parseBoolean(rank_bold),
       }),
     );
   } catch (err) {

--- a/api/top-langs.js
+++ b/api/top-langs.js
@@ -30,6 +30,8 @@ module.exports = async (req, res) => {
     locale,
     border_radius,
     border_color,
+    label_bold,
+    value_bold,
   } = req.query;
   let topLangs;
 
@@ -74,6 +76,8 @@ module.exports = async (req, res) => {
         border_radius,
         border_color,
         locale: locale ? locale.toLowerCase() : null,
+        label_bold: parseBoolean(label_bold),
+        value_bold: parseBoolean(value_bold),
       }),
     );
   } catch (err) {

--- a/api/wakatime.js
+++ b/api/wakatime.js
@@ -32,6 +32,8 @@ module.exports = async (req, res) => {
     range,
     border_radius,
     border_color,
+    label_bold,
+    value_bold,
   } = req.query;
 
   res.setHeader("Content-Type", "image/svg+xml");
@@ -73,6 +75,8 @@ module.exports = async (req, res) => {
         locale: locale ? locale.toLowerCase() : null,
         layout,
         langs_count,
+        label_bold: parseBoolean(label_bold),
+        value_bold: parseBoolean(value_bold),
       }),
     );
   } catch (err) {

--- a/readme.md
+++ b/readme.md
@@ -190,6 +190,9 @@ You can provide multiple comma-separated values in bg_color option to render a g
 - `line_height` - Sets the line-height between text _(number)_
 - `custom_title` - Sets a custom title for the card
 - `disable_animations` - Disables all animations in the card _(boolean)_
+- `label_bold` - _(boolean)_ Display the label as bold. Defaults to `true`
+- `value_bold` - _(boolean)_ Display the value as bold. Defaults to `false`
+- `rank_bold` - _(boolean)_ Display the rank as bold. Defaults to `true`
 
 #### Repo Card Exclusive Options:
 
@@ -204,6 +207,8 @@ You can provide multiple comma-separated values in bg_color option to render a g
 - `langs_count` - Show more languages on the card, between 1-10, defaults to 5 _(number)_
 - `exclude_repo` - Exclude specified repositories _(Comma-separated values)_
 - `custom_title` - Sets a custom title for the card
+- `label_bold` - _(boolean)_ Display the label as bold. Defaults to `false`
+- `value_bold` - _(boolean)_ Display the value as bold. Defaults to `false`
 
 > :warning: **Important:**
 > Language names should be uri-escaped, as specified in [Percent Encoding](https://en.wikipedia.org/wiki/Percent-encoding)
@@ -221,6 +226,8 @@ You can provide multiple comma-separated values in bg_color option to render a g
 - `langs_count` - Limit number of languages on the card, defaults to all reported langauges
 - `api_domain` - Set a custom API domain for the card, e.g. to use services like [Hakatime](https://github.com/mujx/hakatime) or [Wakapi](https://github.com/muety/wakapi)
 - `range` – Request a range different from your WakaTime default, e.g. `last_7_days`. See [WakaTime API docs](https://wakatime.com/developers#stats) for list of available options.
+- `label_bold` - _(boolean)_ Display the label as bold. Defaults to `true`
+- `value_bold` - _(boolean)_ Display the value as bold. Defaults to `false`
 
 ---
 

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -18,7 +18,7 @@ const createTextNode = ({
   id,
   index,
   showIcons,
-  shiftValuePos,
+  shiftValuePos
 }) => {
   const kValue = kFormatter(value);
   const staggerDelay = (index + 3) * 150;
@@ -34,9 +34,9 @@ const createTextNode = ({
   return `
     <g class="stagger" style="animation-delay: ${staggerDelay}ms" transform="translate(25, 0)">
       ${iconSvg}
-      <text class="stat bold" ${labelOffset} y="12.5">${label}:</text>
+      <text data-testid="${id}-label" class="stat-label"${labelOffset} y="12.5">${label}:</text>
       <text 
-        class="stat" 
+        class="stat-value"
         x="${(showIcons ? 140 : 120) + shiftValuePos}" 
         y="12.5" 
         data-testid="${id}"
@@ -73,6 +73,9 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     border_color,
     locale,
     disable_animations = false,
+    label_bold = true,
+    value_bold = false,
+    rank_bold = true,
   } = options;
 
   const lheight = parseInt(line_height, 10);
@@ -157,7 +160,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
         index,
         showIcons: show_icons,
         shiftValuePos:
-          (!include_all_commits ? 50 : 35) + (isLongLocale ? 50 : 0),
+          (!include_all_commits ? 50 : 35) + (isLongLocale ? 50 : 0)
       }),
     );
 
@@ -197,6 +200,9 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     iconColor,
     show_icons,
     progress,
+    label_bold,
+    value_bold,
+    rank_bold,
   });
 
   const calculateTextWidth = () => {

--- a/src/cards/top-languages-card.js
+++ b/src/cards/top-languages-card.js
@@ -23,7 +23,7 @@ const createProgressTextNode = ({ width, color, name, progress }) => {
 
   return `
     <text data-testid="lang-name" x="2" y="15" class="lang-name">${name}</text>
-    <text x="${progressTextX}" y="34" class="lang-name">${progress}%</text>
+    <text x="${progressTextX}" y="34" class="lang-value">${progress}%</text>
     ${createProgressNode({
       x: 0,
       y: 25,
@@ -42,8 +42,8 @@ const createCompactLangNode = ({ lang, totalSize }) => {
   return `
     <g>
       <circle cx="5" cy="6" r="5" fill="${color}" />
-      <text data-testid="lang-name" x="15" y="10" class='lang-name'>
-        ${lang.name} ${percentage}%
+      <text data-testid="lang-name" x="15" y="10">
+        <tspan class="lang-name">${lang.name}</tspan> <tspan class="lang-value">${percentage}%</tspan>
       </text>
     </g>
   `;
@@ -216,6 +216,8 @@ const renderTopLanguages = (topLangs, options = {}) => {
     langs_count = DEFAULT_LANGS_COUNT,
     border_radius,
     border_color,
+    label_bold = false,
+    value_bold = false,
   } = options;
 
   const i18n = new I18n({
@@ -264,7 +266,8 @@ const renderTopLanguages = (topLangs, options = {}) => {
   card.setHideBorder(hide_border);
   card.setHideTitle(hide_title);
   card.setCSS(
-    `.lang-name { font: 400 11px 'Segoe UI', Ubuntu, Sans-Serif; fill: ${colors.textColor} }`,
+    `.lang-name { font: 11px 'Segoe UI', Ubuntu, Sans-Serif; font-weight: ${label_bold ? 700 : 400}; fill: ${colors.textColor} }
+     .lang-value { font: 11px 'Segoe UI', Ubuntu, Sans-Serif; font-weight:  ${value_bold ? 700 : 400}; fill: ${colors.textColor} }`,
   );
 
   return card.render(`

--- a/src/cards/wakatime-card.js
+++ b/src/cards/wakatime-card.js
@@ -13,7 +13,7 @@ const {
 
 const noCodingActivityNode = ({ color, text }) => {
   return `
-    <text x="25" y="11" class="stat bold" fill="${color}">${text}</text>
+    <text x="25" y="11" class="stat-label" fill="${color}">${text}</text>
   `;
 };
 
@@ -77,9 +77,9 @@ const createTextNode = ({
 
   return `
     <g class="stagger" style="animation-delay: ${staggerDelay}ms" transform="translate(25, 0)">
-      <text class="stat bold" y="12.5" data-testid="${id}">${label}:</text>
+      <text class="stat-label" y="12.5" data-testid="${id}">${label}:</text>
       <text
-        class="stat"
+        class="stat-value"
         x="${hideProgress ? 170 : 350}"
         y="12.5"
       >${value}</text>
@@ -120,6 +120,8 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
     langs_count = languages ? languages.length : 0,
     border_radius,
     border_color,
+    label_bold = true,
+    value_bold = false,
   } = options;
 
   const shouldHideLangs = Array.isArray(hide) && hide.length > 0;
@@ -170,6 +172,8 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
     titleColor,
     textColor,
     iconColor,
+    label_bold,
+    value_bold,
   });
 
   let finalLayout = "";

--- a/src/getStyles.js
+++ b/src/getStyles.js
@@ -50,21 +50,28 @@ const getStyles = ({
   iconColor,
   show_icons,
   progress,
+  label_bold,
+  value_bold,
+  rank_bold
 }) => {
   return `
-    .stat {
-      font: 600 14px 'Segoe UI', Ubuntu, "Helvetica Neue", Sans-Serif; fill: ${textColor};
+    .stat-label {
+      font: 14px 'Segoe UI', Ubuntu, "Helvetica Neue", Sans-Serif; fill: ${textColor};
+      font-weight: ${label_bold ? 700 : 600};
+    }
+    .stat-value {
+      font: 14px 'Segoe UI', Ubuntu, "Helvetica Neue", Sans-Serif; fill: ${textColor};
+      font-weight: ${value_bold ? 700 : 600};
     }
     .stagger {
       opacity: 0;
       animation: fadeInAnimation 0.3s ease-in-out forwards;
     }
     .rank-text {
-      font: 800 24px 'Segoe UI', Ubuntu, Sans-Serif; fill: ${textColor}; 
+      font: 24px 'Segoe UI', Ubuntu, Sans-Serif; fill: ${textColor}; 
+      font-weight: ${rank_bold ? 800 : 600};
       animation: scaleInAnimation 0.3s ease-in-out forwards;
     }
-    
-    .bold { font-weight: 700 }
     .icon {
       fill: ${iconColor};
       display: ${!!show_icons ? "block" : "none"};

--- a/tests/__snapshots__/renderWakatimeCard.test.js.snap
+++ b/tests/__snapshots__/renderWakatimeCard.test.js.snap
@@ -17,19 +17,23 @@ exports[`Test Render Wakatime Card should render correctly 1`] = `
           }
           
     
-    .stat {
-      font: 600 14px 'Segoe UI', Ubuntu, \\"Helvetica Neue\\", Sans-Serif; fill: #333;
+    .stat-label {
+      font: 14px 'Segoe UI', Ubuntu, \\"Helvetica Neue\\", Sans-Serif; fill: #333;
+      font-weight: 700;
+    }
+    .stat-value {
+      font: 14px 'Segoe UI', Ubuntu, \\"Helvetica Neue\\", Sans-Serif; fill: #333;
+      font-weight: 600;
     }
     .stagger {
       opacity: 0;
       animation: fadeInAnimation 0.3s ease-in-out forwards;
     }
     .rank-text {
-      font: 800 24px 'Segoe UI', Ubuntu, Sans-Serif; fill: #333; 
+      font: 24px 'Segoe UI', Ubuntu, Sans-Serif; fill: #333; 
+      font-weight: 600;
       animation: scaleInAnimation 0.3s ease-in-out forwards;
     }
-    
-    .bold { font-weight: 700 }
     .icon {
       fill: #4c71f2;
       display: none;
@@ -99,9 +103,9 @@ exports[`Test Render Wakatime Card should render correctly 1`] = `
     <svg x=\\"0\\" y=\\"0\\" width=\\"100%\\">
       <g transform=\\"translate(0, 0)\\">
     <g class=\\"stagger\\" style=\\"animation-delay: NaNms\\" transform=\\"translate(25, 0)\\">
-      <text class=\\"stat bold\\" y=\\"12.5\\" data-testid=\\"Other\\">Other:</text>
+      <text class=\\"stat-label\\" y=\\"12.5\\" data-testid=\\"Other\\">Other:</text>
       <text
-        class=\\"stat\\"
+        class=\\"stat-value\\"
         x=\\"350\\"
         y=\\"12.5\\"
       >19 mins</text>
@@ -121,9 +125,9 @@ exports[`Test Render Wakatime Card should render correctly 1`] = `
     </g>
   </g><g transform=\\"translate(0, 25)\\">
     <g class=\\"stagger\\" style=\\"animation-delay: NaNms\\" transform=\\"translate(25, 0)\\">
-      <text class=\\"stat bold\\" y=\\"12.5\\" data-testid=\\"TypeScript\\">TypeScript:</text>
+      <text class=\\"stat-label\\" y=\\"12.5\\" data-testid=\\"TypeScript\\">TypeScript:</text>
       <text
-        class=\\"stat\\"
+        class=\\"stat-value\\"
         x=\\"350\\"
         y=\\"12.5\\"
       >1 min</text>
@@ -166,19 +170,23 @@ exports[`Test Render Wakatime Card should render correctly with compact layout 1
           }
           
     
-    .stat {
-      font: 600 14px 'Segoe UI', Ubuntu, \\"Helvetica Neue\\", Sans-Serif; fill: #333;
+    .stat-label {
+      font: 14px 'Segoe UI', Ubuntu, \\"Helvetica Neue\\", Sans-Serif; fill: #333;
+      font-weight: 700;
+    }
+    .stat-value {
+      font: 14px 'Segoe UI', Ubuntu, \\"Helvetica Neue\\", Sans-Serif; fill: #333;
+      font-weight: 600;
     }
     .stagger {
       opacity: 0;
       animation: fadeInAnimation 0.3s ease-in-out forwards;
     }
     .rank-text {
-      font: 800 24px 'Segoe UI', Ubuntu, Sans-Serif; fill: #333; 
+      font: 24px 'Segoe UI', Ubuntu, Sans-Serif; fill: #333; 
+      font-weight: 600;
       animation: scaleInAnimation 0.3s ease-in-out forwards;
     }
-    
-    .bold { font-weight: 700 }
     .icon {
       fill: #4c71f2;
       display: none;

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -114,6 +114,9 @@ describe("Test /api/", () => {
         icon_color: "fff",
         text_color: "fff",
         bg_color: "fff",
+        label_bold: true,
+        value_bold: true,
+        rank_bold: true,
       },
       data,
     );
@@ -131,6 +134,9 @@ describe("Test /api/", () => {
         icon_color: "fff",
         text_color: "fff",
         bg_color: "fff",
+        label_bold: true,
+        value_bold: true,
+        rank_bold: true,
       }),
     );
   });

--- a/tests/renderStatsCard.test.js
+++ b/tests/renderStatsCard.test.js
@@ -82,7 +82,7 @@ describe("Test renderStatsCard", () => {
     const stylesObject = cssToObject(styleTag.textContent);
 
     const headerClassStyles = stylesObject[".header"];
-    const statClassStyles = stylesObject[".stat"];
+    const statClassStyles = stylesObject[".stat-label"];
     const iconClassStyles = stylesObject[".icon"];
 
     expect(headerClassStyles.fill).toBe("#2f80ed");
@@ -108,7 +108,7 @@ describe("Test renderStatsCard", () => {
     const stylesObject = cssToObject(styleTag.innerHTML);
 
     const headerClassStyles = stylesObject[".header"];
-    const statClassStyles = stylesObject[".stat"];
+    const statClassStyles = stylesObject[".stat-label"];
     const iconClassStyles = stylesObject[".icon"];
 
     expect(headerClassStyles.fill).toBe(`#${customColors.title_color}`);
@@ -118,6 +118,44 @@ describe("Test renderStatsCard", () => {
       "fill",
       "#252525",
     );
+  });
+
+  it("should render items as bold properly", () => {
+    document.body.innerHTML = renderStatsCard(stats, {
+      label_bold: true,
+      value_bold: true,
+      rank_bold: true
+    });
+
+    const styleTag = document.querySelector("style");
+    const stylesObject = cssToObject(styleTag.innerHTML);
+
+    const statLabelClassStyles = stylesObject[".stat-label"];
+    const statValueClassStyles = stylesObject[".stat-value"];
+    const rankTextClassStyles = stylesObject[".rank-text"];
+
+    expect(statLabelClassStyles['font-weight']).toBe("700");
+    expect(statValueClassStyles['font-weight']).toBe("700");
+    expect(rankTextClassStyles['font-weight']).toBe("800");
+  });
+
+  it("should render items without bold properly", () => {
+    document.body.innerHTML = renderStatsCard(stats, {
+      label_bold: false,
+      value_bold: false,
+      rank_bold: false
+    });
+
+    const styleTag = document.querySelector("style");
+    const stylesObject = cssToObject(styleTag.innerHTML);
+
+    const statLabelClassStyles = stylesObject[".stat-label"];
+    const statValueClassStyles = stylesObject[".stat-value"];
+    const rankTextClassStyles = stylesObject[".rank-text"];
+
+    expect(statLabelClassStyles['font-weight']).toBe("600");
+    expect(statValueClassStyles['font-weight']).toBe("600");
+    expect(rankTextClassStyles['font-weight']).toBe("600");
   });
 
   it("should render custom colors with themes", () => {
@@ -130,7 +168,7 @@ describe("Test renderStatsCard", () => {
     const stylesObject = cssToObject(styleTag.innerHTML);
 
     const headerClassStyles = stylesObject[".header"];
-    const statClassStyles = stylesObject[".stat"];
+    const statClassStyles = stylesObject[".stat-label"];
     const iconClassStyles = stylesObject[".icon"];
 
     expect(headerClassStyles.fill).toBe("#5a0");
@@ -152,7 +190,7 @@ describe("Test renderStatsCard", () => {
       const stylesObject = cssToObject(styleTag.innerHTML);
 
       const headerClassStyles = stylesObject[".header"];
-      const statClassStyles = stylesObject[".stat"];
+      const statClassStyles = stylesObject[".stat-label"];
       const iconClassStyles = stylesObject[".icon"];
 
       expect(headerClassStyles.fill).toBe(`#${themes[name].title_color}`);
@@ -176,7 +214,7 @@ describe("Test renderStatsCard", () => {
     const stylesObject = cssToObject(styleTag.innerHTML);
 
     const headerClassStyles = stylesObject[".header"];
-    const statClassStyles = stylesObject[".stat"];
+    const statClassStyles = stylesObject[".stat-label"];
     const iconClassStyles = stylesObject[".icon"];
 
     expect(headerClassStyles.fill).toBe(`#${themes.default.title_color}`);
@@ -238,27 +276,27 @@ describe("Test renderStatsCard", () => {
     );
     expect(
       document.querySelector(
-        'g[transform="translate(0, 0)"]>.stagger>.stat.bold',
+        'g[transform="translate(0, 0)"]>.stagger>.stat-label',
       ).textContent,
     ).toMatchInlineSnapshot(`"获标星数（star）:"`);
     expect(
       document.querySelector(
-        'g[transform="translate(0, 25)"]>.stagger>.stat.bold',
+        'g[transform="translate(0, 25)"]>.stagger>.stat-label',
       ).textContent,
     ).toMatchInlineSnapshot(`"累计提交数（commit） (2021):"`);
     expect(
       document.querySelector(
-        'g[transform="translate(0, 50)"]>.stagger>.stat.bold',
+        'g[transform="translate(0, 50)"]>.stagger>.stat-label',
       ).textContent,
     ).toMatchInlineSnapshot(`"拉取请求数（PR）:"`);
     expect(
       document.querySelector(
-        'g[transform="translate(0, 75)"]>.stagger>.stat.bold',
+        'g[transform="translate(0, 75)"]>.stagger>.stat-label',
       ).textContent,
     ).toMatchInlineSnapshot(`"指出问题数（issue）:"`);
     expect(
       document.querySelector(
-        'g[transform="translate(0, 100)"]>.stagger>.stat.bold',
+        'g[transform="translate(0, 100)"]>.stagger>.stat-label',
       ).textContent,
     ).toMatchInlineSnapshot(`"参与项目数:"`);
   });

--- a/tests/renderTopLanguages.test.js
+++ b/tests/renderTopLanguages.test.js
@@ -251,4 +251,36 @@ describe("Test renderTopLanguages", () => {
       options.langs_count,
     );
   });
+
+  it("should render items as bold properly", () => {
+    document.body.innerHTML = renderTopLanguages(langs, {
+      label_bold: true,
+      value_bold: true
+    });
+
+    const styleTag = document.querySelector("style");
+    const stylesObject = cssToObject(styleTag.innerHTML);
+
+    const langNameClassStyles = stylesObject[".lang-name"];
+    const langValueClassStyles = stylesObject[".lang-value"];
+
+    expect(langNameClassStyles['font-weight']).toBe("700");
+    expect(langValueClassStyles['font-weight']).toBe("700");
+  });
+
+  it("should render items without bold properly", () => {
+    document.body.innerHTML = renderTopLanguages(langs, {
+      label_bold: false,
+      value_bold: false
+    });
+
+    const styleTag = document.querySelector("style");
+    const stylesObject = cssToObject(styleTag.innerHTML);
+
+    const langNameClassStyles = stylesObject[".lang-name"];
+    const langValueClassStyles = stylesObject[".lang-value"];
+
+    expect(langNameClassStyles['font-weight']).toBe("400");
+    expect(langValueClassStyles['font-weight']).toBe("400");
+  });
 });

--- a/tests/renderWakatimeCard.test.js
+++ b/tests/renderWakatimeCard.test.js
@@ -1,4 +1,5 @@
 require("@testing-library/jest-dom");
+const cssToObject = require("css-to-object");
 const { queryByTestId } = require("@testing-library/dom");
 
 const renderWakatimeCard = require("../src/cards/wakatime-card");
@@ -33,7 +34,7 @@ describe("Test Render Wakatime Card", () => {
       "Wakatime 周统计",
     );
     expect(
-      document.querySelector('g[transform="translate(0, 0)"]>text.stat.bold')
+      document.querySelector('g[transform="translate(0, 0)"]>text.stat-label')
         .textContent,
     ).toBe("本周没有编程活动");
   });
@@ -45,5 +46,37 @@ describe("Test Render Wakatime Card", () => {
     expect(document.querySelector("rect")).toHaveAttribute("rx", "0");
     document.body.innerHTML = renderWakatimeCard(wakaTimeData.data, {});
     expect(document.querySelector("rect")).toHaveAttribute("rx", "4.5");
+  });
+
+  it("should render items as bold properly", () => {
+    document.body.innerHTML = renderWakatimeCard(wakaTimeData.data, {
+      label_bold: true,
+      value_bold: true
+    });
+
+    const styleTag = document.querySelector("style");
+    const stylesObject = cssToObject(styleTag.innerHTML);
+
+    const statLabelClassStyles = stylesObject[".stat-label"];
+    const statValueClassStyles = stylesObject[".stat-value"];
+
+    expect(statLabelClassStyles['font-weight']).toBe("700");
+    expect(statValueClassStyles['font-weight']).toBe("700");
+  });
+
+  it("should render items without bold properly", () => {
+    document.body.innerHTML = renderWakatimeCard(wakaTimeData.data, {
+      label_bold: false,
+      value_bold: false
+    });
+
+    const styleTag = document.querySelector("style");
+    const stylesObject = cssToObject(styleTag.innerHTML);
+
+    const statLabelClassStyles = stylesObject[".stat-label"];
+    const statValueClassStyles = stylesObject[".stat-value"];
+
+    expect(statLabelClassStyles['font-weight']).toBe("600");
+    expect(statValueClassStyles['font-weight']).toBe("600");
   });
 });

--- a/tests/top-langs.test.js
+++ b/tests/top-langs.test.js
@@ -99,6 +99,9 @@ describe("Test /api/top-langs", () => {
         icon_color: "fff",
         text_color: "fff",
         bg_color: "fff",
+        label_bold: true,
+        value_bold: true,
+        rank_bold: true,
       },
     };
     const res = {
@@ -118,6 +121,9 @@ describe("Test /api/top-langs", () => {
         icon_color: "fff",
         text_color: "fff",
         bg_color: "fff",
+        label_bold: true,
+        value_bold: true,
+        rank_bold: true,
       }),
     );
   });


### PR DESCRIPTION
Will resolve issue #1204

Allows bold to be set as boolean true/false. If not set, defaults to how it works currently for each card. 

Readme and Unit tests have been updated as well.

Options are as below. 

**Stats Card**

* label_bold
* value_bold
* rank_bold

**Language Card**

* label_bold
* value_bold

**Wakatime Card**

* label_bold
* value_bold



