### PR TITLE
Fix wakatime card translations server error

### DIFF
--- a/api/wakatime.js
+++ b/api/wakatime.js
@@ -5,8 +5,8 @@ const {
   clampValue,
   parseArray,
   CONSTANTS,
-  isLocaleAvailable,
 } = require("../src/common/utils");
+const { isLocaleAvailable } = require("../src/translations");
 const { fetchWakatimeStats } = require("../src/fetchers/wakatime-fetcher");
 const wakatimeCard = require("../src/cards/wakatime-card");
 


### PR DESCRIPTION
- closes #1362 
- This PR fixes the bug shown in this issue: #1362 
- There was a simple error when importing the function `isLocaleAvailable`, and it was fixed by changing the file from which the function is imported.