### PR TITLE
Add aci theme

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -318,6 +318,12 @@ const themes = {
     text_color: "0088ff",
     bg_color: "193549",
   },
+  aci: {
+    title_color: "a4ccd8",
+    icon_color: "a4ccd8",
+    text_color: "a4ccd8",
+    bg_color: "0d1927",
+  },
 };
 
 module.exports = themes;


### PR DESCRIPTION
A double complementary color scheme inspired from the aci theme in [gogh](https://mayccoll.github.io/Gogh/).
Colors:
title_color: #a4ccd8
text_color: #a4ccd8
icon_color: #a4ccd8
bg_color: #0d1927

Images:
[Demo](https://camo.githubusercontent.com/2e0fb8bc339c38f407dceab84eebaed0642ad85a99fc5d9702b33e0c965a986d/68747470733a2f2f6769746875622d726561646d652d73746174732e76657263656c2e6170702f6170693f757365726e616d653d53726972616d2d626236332673686f775f69636f6e733d74727565267468656d653d73796e74687761766526626f726465725f7261646975733d30267469746c655f636f6c6f723d61346363643826746578745f636f6c6f723d6134636364382669636f6e5f636f6c6f723d6134636364382662675f636f6c6f723d30643139323726637573746f6d5f7469746c653d476974687562207374617473)
[Used in my profile](https://github.com/Sriram-bb63/Sriram-bb63/blob/main/README.md)