### PR TITLE
Fixed word-wrap bug (1259)

### DIFF
--- a/src/cards/repo-card.js
+++ b/src/cards/repo-card.js
@@ -140,7 +140,7 @@ const renderRepoCard = (repo, options = {}) => {
   }).join("");
 
   const card = new Card({
-    defaultTitle: header,
+    defaultTitle: header.length > 35 ? `${header.slice(0, 35)}...` : header,
     titlePrefixIcon: icons.contribs,
     width: 400,
     height,

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -157,12 +157,21 @@ function getCardColors({
   return { titleColor, iconColor, textColor, bgColor, borderColor };
 }
 
-function wrapTextMultiline(text, width = 60, maxLines = 3) {
-  const wrapped = wrap(encodeHTML(text), { width })
-    .split("\n") // Split wrapped lines to get an array of lines
-    .map((line) => line.trim()); // Remove leading and trailing whitespace of each line
+function wrapTextMultiline(text, width = 59, maxLines = 3) {
+  const encoded = encodeHTML(text);
+  const isChinese = encoded.includes("，");
 
-  const lines = wrapped.slice(0, maxLines); // Only consider maxLines lines
+  let wrapped = [];
+
+  if (isChinese) {
+    wrapped = encoded.split("，"); // Chinese full punctuation
+  } else {
+    wrapped = wrap(encoded, {
+      width,
+    }).split("\n"); // Split wrapped lines to get an array of lines
+  }
+
+  const lines = wrapped.map((line) => line.trim()).slice(0, maxLines); // Only consider maxLines lines
 
   // Add "..." to the last line if the text exceeds maxLines
   if (wrapped.length > maxLines) {

--- a/tests/renderRepoCard.test.js
+++ b/tests/renderRepoCard.test.js
@@ -51,6 +51,17 @@ describe("Test renderRepoCard", () => {
     );
   });
 
+  it("should trim header", () => {
+    document.body.innerHTML = renderRepoCard({
+      ...data_repo.repository,
+      name: "some-really-long-repo-name-for-test-purposes",
+    });
+
+    expect(document.getElementsByClassName("header")[0].textContent).toBe(
+      "some-really-long-repo-name-for-test...",
+    );
+  });
+
   it("should trim description", () => {
     document.body.innerHTML = renderRepoCard({
       ...data_repo.repository,

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -117,4 +117,11 @@ describe("wrapTextMultiline", () => {
     );
     expect(multiLineText).toEqual(["Hello", "world long..."]);
   });
+  it("should wrap chinese by punctuation", () => {
+    let multiLineText = wrapTextMultiline(
+      "专门为刚开始刷题的同学准备的算法基地，没有最细只有更细，立志用动画将晦涩难懂的算法说的通俗易懂！",
+    );
+    expect(multiLineText.length).toEqual(3);
+    expect(multiLineText[0].length).toEqual(18 * 8); // &#xxxxx; x 8
+  });
 });


### PR DESCRIPTION
Fixes #1259 

Added a separate wrapping logic for chinese language, which is split from full punctuation.
![Screenshot 2021-10-08 at 17 24 43](https://user-images.githubusercontent.com/15167296/136574536-4b7b01fe-69a8-4760-9627-73fc07ae5e36.png)

Also added maximum length for repoCard header, which will now cut the header and append ".." if the header exceeds the limit of 35 characters.
![Screenshot 2021-10-08 at 17 24 48](https://user-images.githubusercontent.com/15167296/136574719-7bfb984d-1e80-4219-9d74-1b08c2bb60a9.png)

Additionally also changed default width of wrapping to 59 characters, because I noticed that with 60, this particular example description doesn't look good (word ends just at 60 characters).
![Screenshot 2021-10-08 at 17 30 44](https://user-images.githubusercontent.com/15167296/136574916-03fee089-0f92-40c0-b98c-697ee8b1d771.png)

Now it looks like this: 
![Screenshot 2021-10-08 at 17 32 32](https://user-images.githubusercontent.com/15167296/136575241-1abbd45d-48c5-429e-9439-bbdb84aa4411.png)


Also added two new test cases to verify the new functionality. Cheers!