### PR TITLE
Add gruvbox_light theme

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -36,6 +36,12 @@ const themes = {
     text_color: "8ec07c",
     bg_color: "282828",
   },
+  gruvbox_light: {
+    title_color: "b57614",
+    icon_color: "af3a03",
+    text_color: "427b58",
+    bg_color: "fbf1c7",
+  },
   tokyonight: {
     title_color: "70a5fd",
     icon_color: "bf91f3",


### PR DESCRIPTION
In addition to the `gruvbox` theme (which is dark), I added `gruvbox_light`, using the same colors from the light color palette. It would be nice to rename `gruvbox` to `gruvbox_dark` but that would break things I suppose...

Note that `npm run theme-readme-gen` added more themes to the readme than just `gruvbox_light`. Was the readme maybe not re-generated after `aura_dark`, `panda`, `noctis_minimus`, and `cobalt2` were added?

Also, the contribution guidelines state:

> While creating the Pull request to add a new theme don't forget to add a screenshot of how your theme looks

Rather, one should run `npm run theme-readme-gen` to update `themes/README.md`. Should I open another PR updating the contribution guidelines or add it to this one?