### PR TITLE
Add theme Aurora

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -318,6 +318,12 @@ const themes = {
     text_color: "0088ff",
     bg_color: "193549",
   },
+  aurora:{
+    title_color="00FFA5",
+    icon_color="00FFA5",
+    text_color="F8F7F9",
+    bg_color="0D1117",
+  },
 };
 
 module.exports = themes;


### PR DESCRIPTION
<p align="center"> <h1> Aurora </h1> </p>

```title_color: #00FFA5```  | ```icon_color: #00FFA5``` | ```text_color: #F8F7F9``` | ```bg_color: #0D1117```

Preview:

<img align="center" src="https://github-readme-stats.vercel.app/api?username=sanjaybaskaran01&layout=compact&show_icons=true&title_color=00FFA5&bg_color=0D1117&icon_color=00FFA5&text_color=F8F7F9&hide_border=1" />

Preferably hide border since this theme gives a floating Github stats feel when the user's github theme is set to default dark

Preview on my README.md with Github Default Dark theme

![image](https://user-images.githubusercontent.com/72266283/136948945-007b2e15-51f0-48e5-80d2-857b59cff4b3.png)

I noticed that there weren't a lot of green options available for users so I've made this theme which fit perfectly for my README.md too

