### PR TITLE
Fixed bug where wakatime api returns undefined languages

### DIFF
--- a/src/cards/wakatime-card.js
+++ b/src/cards/wakatime-card.js
@@ -123,7 +123,7 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
   } = options;
 
   const shouldHideLangs = Array.isArray(hide) && hide.length > 0;
-  if (shouldHideLangs) {
+  if (shouldHideLangs && languages !== undefined) {
     const languagesToHide = new Set(hide.map((lang) => lowercaseTrim(lang)));
     languages = languages.filter(
       (lang) => !languagesToHide.has(lowercaseTrim(lang.name)),
@@ -138,7 +138,7 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
 
   const lheight = parseInt(line_height, 10);
 
-  langsCount = clampValue(parseInt(langs_count), 1, langs_count);
+  const langsCount = clampValue(parseInt(langs_count), 1, langs_count);
 
   // returns theme based colors with proper overrides and defaults
   const {

--- a/tests/renderWakatimeCard.test.js
+++ b/tests/renderWakatimeCard.test.js
@@ -46,4 +46,12 @@ describe("Test Render Wakatime Card", () => {
     document.body.innerHTML = renderWakatimeCard(wakaTimeData.data, {});
     expect(document.querySelector("rect")).toHaveAttribute("rx", "4.5");
   });
+
+  it('should show "no coding activitiy this week" message when there hasn not been activity', () => {
+    document.body.innerHTML = renderWakatimeCard({
+      ...wakaTimeData.data,
+      languages: undefined
+    }, {});
+    expect(document.querySelector(".stat").textContent).toBe("No coding activity this week")
+  })
 });


### PR DESCRIPTION
Fixes: #1396 

For some reason the wakatime API returns "undefined" for languages in this particular case. This change prevents error in that case and normal "No coding activity this week" message is shown. Also added a test case to validate this.

The particular example case also has hide_title=true and layout=compact, so the card will be just empty. Without those it will be like this:
![Screenshot 2021-10-21 at 16 53 53](https://user-images.githubusercontent.com/15167296/138292540-05e5db9a-e812-4c1e-a87e-b348d5199136.png)
