### PR TITLE
Fix vercel deploy on free account

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "functions": {
     "api/*.js": {
       "memory": 128,
-      "maxDuration": 30
+      "maxDuration": 10
     }
   },
   "redirects": [


### PR DESCRIPTION
If you are using a free Vercel account then it will throw error while deploying. Free account supports maxDuration from 1-10