### PR TITLE
remove lang fetch hide arg

### DIFF
--- a/api/top-langs.js
+++ b/api/top-langs.js
@@ -45,7 +45,6 @@ module.exports = async (req, res) => {
     const topLangs = await fetchTopLanguages(
       username,
       parseArray(exclude_repo),
-      parseArray(hide),
     );
 
     const cacheSeconds = clampValue(


### PR DESCRIPTION
This pull request removes the `hide` argument from the `fetchTopLanguages` call found in the `top-lang.js` file. This was done since this was leftover from 465faa7c32983bbc53080f111fa49f5a2629ecd2.
