### PR TITLE
test: adds language card 'exclude_repo' test

### DIFF
--- a/tests/fetchTopLanguages.test.js
+++ b/tests/fetchTopLanguages.test.js
@@ -15,16 +15,19 @@ const data_langs = {
       repositories: {
         nodes: [
           {
+            name: "test-repo-1",
             languages: {
               edges: [{ size: 100, node: { color: "#0f0", name: "HTML" } }],
             },
           },
           {
+            name: "test-repo-2",
             languages: {
               edges: [{ size: 100, node: { color: "#0f0", name: "HTML" } }],
             },
           },
           {
+            name: "test-repo-3",
             languages: {
               edges: [
                 { size: 100, node: { color: "#0ff", name: "javascript" } },
@@ -32,6 +35,7 @@ const data_langs = {
             },
           },
           {
+            name: "test-repo-4",
             languages: {
               edges: [
                 { size: 100, node: { color: "#0ff", name: "javascript" } },
@@ -65,6 +69,24 @@ describe("FetchTopLanguages", () => {
         color: "#0f0",
         name: "HTML",
         size: 200,
+      },
+      javascript: {
+        color: "#0ff",
+        name: "javascript",
+        size: 200,
+      },
+    });
+  });
+
+  it("should fetch correct language data while excluding the 'test-repo-1' repository", async () => {
+    mock.onPost("https://api.github.com/graphql").reply(200, data_langs);
+
+    let repo = await fetchTopLanguages("anuraghazra", exclude_repo=["test-repo-1"]);
+    expect(repo).toStrictEqual({
+      HTML: {
+        color: "#0f0",
+        name: "HTML",
+        size: 100,
       },
       javascript: {
         color: "#0ff",


### PR DESCRIPTION
This pull request adds a test for the `exclude_repo` option to the language card tests. This test was not added in d4e2a1b39582951d7c301eeec8a92a1edf33d75d.