### PR TITLE
test: replace depricated 'toBeEmpty' method with 'toBeEmptyDOMElement'

### DIFF
--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -32,7 +32,7 @@ describe("Test utils.js", () => {
     expect(
       queryByTestId(document.body, "message").children[0],
     ).toHaveTextContent(/Something went wrong/gim);
-    expect(queryByTestId(document.body, "message").children[1]).toBeEmpty(2);
+    expect(queryByTestId(document.body, "message").children[1]).toBeEmptyDOMElement(2);
 
     // Secondary message
     document.body.innerHTML = renderError(


### PR DESCRIPTION
This pull request removes the following deprecation warning:

```bash
 console.warn
      Warning: toBeEmpty has been deprecated and will be removed in future updates. Please use instead toBeEmptyDOMElement for finding empty nodes in the DOM.

      33 |       queryByTestId(document.body, "message").children[0],
      34 |     ).toHaveTextContent(/Something went wrong/gim);
    > 35 |     expect(queryByTestId(document.body, "message").children[1]).toBeEmpty(2);
         |                                                                 ^
      36 |
      37 |     // Secondary message
      38 |     document.body.innerHTML = renderError(
```