### PR TITLE
Add color for JSON.

### DIFF
--- a/src/common/languageColors.json
+++ b/src/common/languageColors.json
@@ -426,5 +426,6 @@
     "Zephir": "#118f9e",
     "Zig": "#ec915c",
     "ZIL": "#dc75e5",
-    "Zimpl": null
+    "Zimpl": null,
+    "JSON": "#292929"
 }


### PR DESCRIPTION
Add color for JSON.
JSON color is used by Wakatime Card.
GitHub uses the color #292929 for JSON. 