### PR TITLE
Change maxDuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "functions": {
     "api/*.js": {
       "memory": 128,
-      "maxDuration": 30
+      "maxDuration": 10
     }
   },
   "redirects": [


### PR DESCRIPTION
If maxDuration is higher than 10 it will not allow deployment with the free plan.

Lowering this value will allow people to deploy it.