### PR TITLE
Add moonlight theme

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -348,6 +348,12 @@ const themes = {
     text_color: "574038",
     bg_color: "F5E1C0",
   },
+  moonlight: {
+    title_color: "ffc777",
+    icon_color: "82aaff",
+    text_color: "c8d3f5",
+    bg_color: "191a2a",
+  },
 };
 
 module.exports = themes;


### PR DESCRIPTION
This is another tweak of #1477 from Moonlight VS Code theme with different colors. This is the [demo](https://github-readme-stats.vercel.app/api?username=imaphatduc&count_private=true&show_icons=true&border_color=fca7ea&border_radius=10&bg_color=191a2a&title_color=ffc777&icon_color=82aaff&text_color=c8d3f5).