### PR TITLE
fix(style): centering rank text in the circle

### DIFF
--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -184,8 +184,8 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
         <circle class="rank-circle" cx="-10" cy="8" r="40" />
         <g class="rank-text">
           <text
-            x="${rank.level.length === 1 ? "-4" : "0"}"
-            y="0"
+            x="-5"
+            y="3"
             alignment-baseline="central"
             dominant-baseline="central"
             text-anchor="middle"


### PR DESCRIPTION
## Description

It seems that the rank text of "GitHub Stats Card" is not centering.

### Before

```js

const circle = document.querySelector(".rank-circle").getBoundingClientRect()
const text = document.querySelector(".rank-text").getBoundingClientRect()

console.log(circle.x + circle.width / 2, circle.y + circle.height / 2) // => 390 110.5
console.log(text.x + text.width / 2, text.y + text.height / 2)         // => 391 107.5
```

### After applying the changes

```js
// at https://github-readme-stats.vercel.app/api?username=anuraghazra
const circle = document.querySelector(".rank-circle").getBoundingClientRect()
const text = document.querySelector(".rank-text").getBoundingClientRect()

console.log(circle.x + circle.width / 2, circle.y + circle.height / 2) // => 390 110.5
console.log(text.x + text.width / 2, text.y + text.height / 2)         // => 390 110.5
```

### Compare

|        | length 1 | length 2 | length 3 |
|--------|---|---|---|
| before | ![length 1 (before)](https://user-images.githubusercontent.com/19568747/156602805-fee3c744-3d84-43f9-86de-4e1524db6054.png) | ![length 2 (before)](https://user-images.githubusercontent.com/19568747/156603104-1e25bbde-36b4-47ee-833a-da3d62400f53.png) | ![length 3 (before)](https://user-images.githubusercontent.com/19568747/156603146-c6c58d2e-744f-4993-a5d8-ba72e524449a.png) |
| after  | ![length 1 (after)](https://user-images.githubusercontent.com/19568747/156603301-844b70ab-5c46-43ca-8c6d-0bff551b7c11.png) | ![length 2 (after)](https://user-images.githubusercontent.com/19568747/156603349-0737101a-c690-4bca-9002-20f02e35b703.png) | ![length 3 (after)](https://user-images.githubusercontent.com/19568747/156603390-4852738d-97cf-4c03-9375-3ca93bec0557.png) |
