### PR TITLE
feat: gradient units to userSpaceOnUse

### DIFF
--- a/src/common/Card.js
+++ b/src/common/Card.js
@@ -123,8 +123,9 @@ class Card {
       ? `
         <defs>
           <linearGradient
-            id="gradient" 
+            id="gradient"
             gradientTransform="rotate(${this.colors.bgColor[0]})"
+            gradientUnits="userSpaceOnUse"
           >
             ${gradients.map((grad, index) => {
               let offset = (index * 100) / (gradients.length - 1);


### PR DESCRIPTION
Hi all,
I'm building an UI generator for stats cards recently, and I noticed that `bg_color` with gradient result is unexpected in most rotate angles, I think the point is `gradientUnits` attribute, so issue this PR for set it to `userSpaceOnUse` if its ok.

<img width="454" alt="image" src="https://user-images.githubusercontent.com/22793771/158221416-7abcd52f-2af9-4ac5-aa6b-bebc3d298331.png">
