### PR TITLE
feat: Exclude archived repositories for top languages

### DIFF
--- a/api/top-langs.js
+++ b/api/top-langs.js
@@ -26,6 +26,7 @@ module.exports = async (req, res) => {
     layout,
     langs_count,
     exclude_repo,
+    exclude_archived,
     custom_title,
     locale,
     border_radius,
@@ -45,6 +46,7 @@ module.exports = async (req, res) => {
     const topLangs = await fetchTopLanguages(
       username,
       parseArray(exclude_repo),
+      parseBoolean(exclude_archived),
     );
 
     const cacheSeconds = clampValue(

--- a/tests/fetchTopLanguages.test.js
+++ b/tests/fetchTopLanguages.test.js
@@ -42,6 +42,18 @@ const data_langs = {
               ],
             },
           },
+          {
+            name: "test-archived-repo-4",
+            isArchived: true,
+            languages: {
+              edges: [
+                {
+                  size: 100,
+                  node: { color: "#0fff", name: "javascript" },
+                },
+              ],
+            },
+          },
         ],
       },
     },
@@ -73,7 +85,7 @@ describe("FetchTopLanguages", () => {
       javascript: {
         color: "#0ff",
         name: "javascript",
-        size: 200,
+        size: 300,
       },
     });
   });
@@ -81,7 +93,32 @@ describe("FetchTopLanguages", () => {
   it("should fetch correct language data while excluding the 'test-repo-1' repository", async () => {
     mock.onPost("https://api.github.com/graphql").reply(200, data_langs);
 
-    let repo = await fetchTopLanguages("anuraghazra", exclude_repo=["test-repo-1"]);
+    let repo = await fetchTopLanguages(
+      "anuraghazra",
+      (exclude_repo = ["test-repo-1"]),
+    );
+    expect(repo).toStrictEqual({
+      HTML: {
+        color: "#0f0",
+        name: "HTML",
+        size: 100,
+      },
+      javascript: {
+        color: "#0ff",
+        name: "javascript",
+        size: 300,
+      },
+    });
+  });
+
+  it("should fetch correct language data while excluding archived repositories", async () => {
+    mock.onPost("https://api.github.com/graphql").reply(200, data_langs);
+
+    let repo = await fetchTopLanguages(
+      "anuraghazra",
+      (exclude_repo = ["test-repo-1"]),
+      (exclude_archived = true),
+    );
     expect(repo).toStrictEqual({
       HTML: {
         color: "#0f0",


### PR DESCRIPTION
Default to `false` if the query is not passed.

## Motivation

I often compete in various coding challenges, hackathons, etc., where I collaborate with people who use languages that are out of my scope. Often this repositories are marked as archived to filter them all at once. 

## Change

Adds `exclude_archived` as query for top languages. It defaults to false, which means it won't affect users who do not query for it.

## TODO

- [ ] Do we think tests are good enough?
- [ ] Update readme.md with new behavior

