### PR TITLE
fix(stats-fetcher): user's overall commits

### DIFF
--- a/tests/fetchStats.test.js
+++ b/tests/fetchStats.test.js
@@ -13,6 +13,7 @@ const data_stats = {
       contributionsCollection: {
         totalCommitContributions: 100,
         restrictedContributionsCount: 50,
+        contributionYears: [2022, 2021, 2020, 2019, 2018, 2017, 2016],
       },
       pullRequests: { totalCount: 300 },
       openIssues: { totalCount: 100 },
@@ -185,13 +186,9 @@ describe("Test fetchStats", () => {
   });
 
   it("should fetch total commits", async () => {
-    mock
-      .onGet("https://api.github.com/search/commits?q=author:anuraghazra")
-      .reply(200, { total_count: 1000 });
-
     let stats = await fetchStats("anuraghazra", true, true);
     const rank = calculateRank({
-      totalCommits: 1050,
+      totalCommits: 1050, // (100 + 50) * 7
       totalRepos: 5,
       followers: 100,
       contributions: 61,
@@ -212,10 +209,6 @@ describe("Test fetchStats", () => {
   });
 
   it("should exclude stars of the `test-repo-1` repository", async () => {
-    mock
-      .onGet("https://api.github.com/search/commits?q=author:anuraghazra")
-      .reply(200, { total_count: 1000 });
-
     let stats = await fetchStats("anuraghazra", true, true, ["test-repo-1"]);
     const rank = calculateRank({
       totalCommits: 1050,


### PR DESCRIPTION
1. precise overall public commits (formerly exaggerated or decreased)
2. precise overall private commits (formerly only the recent year)
1+2. precise overall commits including private commits

|current|my fork|
|-------|-------|
|![torvalds_curr]|![torvalds_my]|
|![tiwai_curr]|![tiwai_my]|
|![jhedberg_curr]|![jhedberg_my]|
|![Icenowy_curr]|![Icenowy_my]|

[torvalds_curr]: https://github-readme-stats.vercel.app/api?username=torvalds&include_all_commits=true&count_private=true
[tiwai_curr]: https://github-readme-stats.vercel.app/api?username=tiwai&include_all_commits=true&count_private=true
[jhedberg_curr]: https://github-readme-stats.vercel.app/api?username=jhedberg&include_all_commits=true&count_private=true
[Icenowy_curr]: https://github-readme-stats.vercel.app/api?username=Icenowy&include_all_commits=true&count_private=true
[torvalds_my]: https://github-readme-stats-rongronggg9.vercel.app/api?username=torvalds&include_all_commits=true&count_private=true
[tiwai_my]: https://github-readme-stats-rongronggg9.vercel.app/api?username=tiwai&include_all_commits=true&count_private=true
[jhedberg_my]: https://github-readme-stats-rongronggg9.vercel.app/api?username=jhedberg&include_all_commits=true&count_private=true
[Icenowy_my]: https://github-readme-stats-rongronggg9.vercel.app/api?username=Icenowy&include_all_commits=true&count_private=true

context: https://github.com/anuraghazra/github-readme-stats/issues/564#issuecomment-1083765940
The search API is entirely unreliable and we should never use it. Though using such a traversal could potentially cause rate limits, we should still get rid of using the search API. Why? **Almost all Linux kernel contributors could never use this project as you have already seen above. It is absolutely unacceptable, isn't it?** If we need to avoid being rate limited, we should consider using a database to cache users' commits in the past years.

Even I and @anuraghazra are affected:
|current|my fork|
|-------|-------|
|![Rongronggg9_curr]|![Rongronggg9_my]|
|![anuraghazra_curr]|![anuraghazra_my]|

[Rongronggg9_curr]: https://github-readme-stats.vercel.app/api?username=Rongronggg9&include_all_commits=true&count_private=true
[anuraghazra_curr]: https://github-readme-stats.vercel.app/api?username=anuraghazra&include_all_commits=true&count_private=true
[Rongronggg9_my]: https://github-readme-stats-rongronggg9.vercel.app/api?username=Rongronggg9&include_all_commits=true&count_private=true
[anuraghazra_my]: https://github-readme-stats-rongronggg9.vercel.app/api?username=anuraghazra&include_all_commits=true&count_private=true

If you want to check if you are affected, my deployment is https://github-readme-stats-rongronggg9.vercel.app/api

Close #518
Close #564
Close #1061
Close #1234
Close #1515

May influence #1260, #1455