### PR TITLE
feat: improve background color of progress bar in wakatime card

### DIFF
--- a/src/cards/wakatime-card.js
+++ b/src/cards/wakatime-card.js
@@ -90,8 +90,7 @@ const createTextNode = ({
   index,
   percent,
   hideProgress,
-  progressBarColor,
-  progressBarBackgroundColor,
+  progressBarColor
 }) => {
   const staggerDelay = (index + 3) * 150;
 
@@ -105,7 +104,7 @@ const createTextNode = ({
         width: 220,
         // @ts-ignore
         name: label,
-        progressBarBackgroundColor,
+        progressBarBackgroundColor: '#ddd',
       });
 
   return `
@@ -266,8 +265,6 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
               percent: language.percent,
               // @ts-ignore
               progressBarColor: titleColor,
-              // @ts-ignore
-              progressBarBackgroundColor: textColor,
               hideProgress: hide_progress,
             });
           })

--- a/tests/__snapshots__/renderWakatimeCard.test.js.snap
+++ b/tests/__snapshots__/renderWakatimeCard.test.js.snap
@@ -115,7 +115,7 @@ exports[`Test Render Wakatime Card should render correctly 1`] = `
       >19 mins</text>
       
     <svg width=\\"220\\" x=\\"110\\" y=\\"4\\">
-      <rect rx=\\"5\\" ry=\\"5\\" x=\\"0\\" y=\\"0\\" width=\\"220\\" height=\\"8\\" fill=\\"#434d58\\"></rect>
+      <rect rx=\\"5\\" ry=\\"5\\" x=\\"0\\" y=\\"0\\" width=\\"220\\" height=\\"8\\" fill=\\"#ddd\\"></rect>
       <rect
           height=\\"8\\"
           fill=\\"#2f80ed\\"
@@ -137,7 +137,7 @@ exports[`Test Render Wakatime Card should render correctly 1`] = `
       >1 min</text>
       
     <svg width=\\"220\\" x=\\"110\\" y=\\"4\\">
-      <rect rx=\\"5\\" ry=\\"5\\" x=\\"0\\" y=\\"0\\" width=\\"220\\" height=\\"8\\" fill=\\"#434d58\\"></rect>
+      <rect rx=\\"5\\" ry=\\"5\\" x=\\"0\\" y=\\"0\\" width=\\"220\\" height=\\"8\\" fill=\\"#ddd\\"></rect>
       <rect
           height=\\"8\\"
           fill=\\"#2f80ed\\"


### PR DESCRIPTION
Change background color of progress bar to `#ddd` in **WakaTime card** just like language card does, which looks better.

Before:
![wakatime-before](https://user-images.githubusercontent.com/26338708/166085171-382a09da-e672-474d-bf70-45047850723f.svg)

After:
![wakatime-after](https://user-images.githubusercontent.com/26338708/166085179-8a7da84f-86bd-4a80-ae48-178e6d448d98.svg)
