### PR TITLE
VS Code 2077 and GH's Dark Dimmed themes

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -367,6 +367,13 @@ const themes = {
     text_color: "adbac7",
     bg_color: "22272e",
     border_color: "373e47",
+  },
+  "2077": {
+    title_color: "f72876",
+    icon_color: "df1d55",
+    text_color: "09ddff",
+    bg_color: "030d22",
+    border_color: "f7d401"
   }
 };
 

--- a/themes/index.js
+++ b/themes/index.js
@@ -360,6 +360,13 @@ const themes = {
     icon_color: "ebbcba",
     text_color: "e0def4",
     bg_color: "191724",
+  },
+  github_dark_dimmed: {
+    title_color: "aab7c3",
+    icon_color: "66717d",
+    text_color: "adbac7",
+    bg_color: "22272e",
+    border_color: "373e47",
   }
 };
 


### PR DESCRIPTION
Card theme based on Github's Dark Dimmed theme using all neutral colors and a theme based on the VS Code theme "2077" (originally based on the game Cyberpunk 2077)

### Github Dark Dimmed
![darkdimmed](https://user-images.githubusercontent.com/30541051/166155929-3b95dff5-2420-41f7-bb17-8ddee77e3dbc.png)

### 2077
![2077](https://user-images.githubusercontent.com/30541051/166156492-fd202260-d0bf-4db0-85cf-c1ea534bbb09.png)

