### PR TITLE
feat(wakatime): support display only percent language

### DIFF
--- a/src/cards/wakatime-card.js
+++ b/src/cards/wakatime-card.js
@@ -143,7 +143,13 @@ const recalculatePercentages = (languages) => {
  * @returns {string}
  */
 const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
-  let { languages } = stats;
+  let languages = stats.languages?.map((language) => {
+    return {
+      ...language,
+      text: language.text || `${language.percent}%`,
+    };
+  });
+
   const {
     hide_title = false,
     hide_border = false,
@@ -194,7 +200,9 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
 
   const filteredLanguages = languages
     ? languages
-        .filter((language) => language.hours || language.minutes)
+        .filter(
+          (language) => language.hours || language.minutes || language.percent
+        )
         .slice(0, langsCount)
     : [];
 

--- a/src/fetchers/types.d.ts
+++ b/src/fetchers/types.d.ts
@@ -33,6 +33,16 @@ export type Lang = {
 
 export type TopLangData = Record<string, Lang>;
 
+export type WakaTimeLang = {
+  name: string;
+  percent: number;
+  digital?: string;
+  hours?: number;
+  minutes?: number;
+  text?: string;
+  total_seconds?: number;
+};
+
 export type WakaTimeData = {
   categories: {
     digital: string;
@@ -68,15 +78,7 @@ export type WakaTimeData = {
   is_other_usage_visible: boolean;
   is_stuck: boolean;
   is_up_to_date: boolean;
-  languages: {
-    digital: string;
-    hours: number;
-    minutes: number;
-    name: string;
-    percent: number;
-    text: string;
-    total_seconds: number;
-  }[];
+  languages: WakaTimeLang[];
   operating_systems: {
     digital: string;
     hours: number;
@@ -97,8 +99,3 @@ export type WakaTimeData = {
   writes_only: boolean;
 };
 
-export type WakaTimeLang = {
-  name: string;
-  text: string;
-  percent: number;
-};

--- a/tests/__snapshots__/renderWakatimeCard.test.js.snap
+++ b/tests/__snapshots__/renderWakatimeCard.test.js.snap
@@ -4,8 +4,8 @@ exports[`Test Render Wakatime Card should render correctly 1`] = `
 "
       <svg
         width=\\"495\\"
-        height=\\"150\\"
-        viewBox=\\"0 0 495 150\\"
+        height=\\"170\\"
+        viewBox=\\"0 0 495 170\\"
         fill=\\"none\\"
         xmlns=\\"http://www.w3.org/2000/svg\\"
       >
@@ -149,6 +149,50 @@ exports[`Test Render Wakatime Card should render correctly 1`] = `
     </svg>
   
     </g>
+  </g><g transform=\\"translate(0, 50)\\">
+    <g class=\\"stagger\\" style=\\"animation-delay: NaNms\\" transform=\\"translate(25, 0)\\">
+      <text class=\\"stat bold\\" y=\\"12.5\\" data-testid=\\"YAML\\">YAML:</text>
+      <text
+        class=\\"stat\\"
+        x=\\"350\\"
+        y=\\"12.5\\"
+      >0 secs</text>
+      
+    <svg width=\\"220\\" x=\\"110\\" y=\\"4\\">
+      <rect rx=\\"5\\" ry=\\"5\\" x=\\"0\\" y=\\"0\\" width=\\"220\\" height=\\"8\\" fill=\\"#434d58\\"></rect>
+      <rect
+          height=\\"8\\"
+          fill=\\"#2f80ed\\"
+          rx=\\"5\\" ry=\\"5\\" x=\\"0\\" y=\\"0\\" 
+          data-testid=\\"lang-progress\\"
+          width=\\"2%\\"
+      >
+      </rect>
+    </svg>
+  
+    </g>
+  </g><g transform=\\"translate(0, 75)\\">
+    <g class=\\"stagger\\" style=\\"animation-delay: NaNms\\" transform=\\"translate(25, 0)\\">
+      <text class=\\"stat bold\\" y=\\"12.5\\" data-testid=\\"Makefile\\">Makefile:</text>
+      <text
+        class=\\"stat\\"
+        x=\\"350\\"
+        y=\\"12.5\\"
+      >0.05%</text>
+      
+    <svg width=\\"220\\" x=\\"110\\" y=\\"4\\">
+      <rect rx=\\"5\\" ry=\\"5\\" x=\\"0\\" y=\\"0\\" width=\\"220\\" height=\\"8\\" fill=\\"#434d58\\"></rect>
+      <rect
+          height=\\"8\\"
+          fill=\\"#2f80ed\\"
+          rx=\\"5\\" ry=\\"5\\" x=\\"0\\" y=\\"0\\" 
+          data-testid=\\"lang-progress\\"
+          width=\\"2%\\"
+      >
+      </rect>
+    </svg>
+  
+    </g>
   </g>
     </svg>
   
@@ -161,8 +205,8 @@ exports[`Test Render Wakatime Card should render correctly with compact layout 1
 "
       <svg
         width=\\"495\\"
-        height=\\"115\\"
-        viewBox=\\"0 0 495 115\\"
+        height=\\"140\\"
+        viewBox=\\"0 0 495 140\\"
         fill=\\"none\\"
         xmlns=\\"http://www.w3.org/2000/svg\\"
       >
@@ -287,6 +331,26 @@ exports[`Test Render Wakatime Card should render correctly with compact layout 1
             fill=\\"#2b7489\\"
           />
         
+          <rect
+            mask=\\"url(#rect-mask)\\"
+            data-testid=\\"lang-progress\\"
+            x=\\"7.1145\\"
+            y=\\"0\\"
+            width=\\"0.32550000000000007\\"
+            height=\\"8\\"
+            fill=\\"#cb171e\\"
+          />
+        
+          <rect
+            mask=\\"url(#rect-mask)\\"
+            data-testid=\\"lang-progress\\"
+            x=\\"7.4399999999999995\\"
+            y=\\"0\\"
+            width=\\"0.2325\\"
+            height=\\"8\\"
+            fill=\\"#427819\\"
+          />
+        
       
     <g transform=\\"translate(25, 25)\\">
       <circle cx=\\"5\\" cy=\\"6\\" r=\\"5\\" fill=\\"#858585\\" />
@@ -299,6 +363,20 @@ exports[`Test Render Wakatime Card should render correctly with compact layout 1
       <circle cx=\\"5\\" cy=\\"6\\" r=\\"5\\" fill=\\"#2b7489\\" />
       <text data-testid=\\"lang-name\\" x=\\"15\\" y=\\"10\\" class='lang-name'>
         TypeScript - 1 min
+      </text>
+    </g>
+  
+    <g transform=\\"translate(25, 50)\\">
+      <circle cx=\\"5\\" cy=\\"6\\" r=\\"5\\" fill=\\"#cb171e\\" />
+      <text data-testid=\\"lang-name\\" x=\\"15\\" y=\\"10\\" class='lang-name'>
+        YAML - 0 secs
+      </text>
+    </g>
+  
+    <g transform=\\"translate(230, 50)\\">
+      <circle cx=\\"5\\" cy=\\"6\\" r=\\"5\\" fill=\\"#427819\\" />
+      <text data-testid=\\"lang-name\\" x=\\"15\\" y=\\"10\\" class='lang-name'>
+        Makefile - 0.05%
       </text>
     </g>
   

--- a/tests/fetchWakatime.test.js
+++ b/tests/fetchWakatime.test.js
@@ -76,6 +76,10 @@ const wakaTimeData = {
         text: "0 secs",
         total_seconds: 54.975151,
       },
+      {
+        name: "Makefile",
+        percent: 0.05,
+      },
     ],
     operating_systems: [
       {
@@ -177,6 +181,10 @@ describe("Wakatime fetcher", () => {
             "percent": 0.07,
             "text": "0 secs",
             "total_seconds": 54.975151,
+          },
+          Object {
+            "name": "Makefile",
+            "percent": 0.05,
           },
         ],
         "operating_systems": Array [


### PR DESCRIPTION
# Description

## features
WakaTime card to be able to display languages by  `.data.languages[].percent` key.

## solved issue
Current `master` code WakaTime card display lang by `.data.languages[].(hours|minutes)` only.
WakaTime each account can control stats returns value by settings.
And first setting don't return  both of `.data.languages[].(hours|minutes)` like below;


```
❯ curl 'https://wakatime.com/api/v1/users/YuseiUeno/stats/last_7_days' | jq '[ .data.languages[] | keys ] | flatten | unique | .[]'
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  1292  100  1292    0     0   1427      0 --:--:-- --:--:-- --:--:--  1426
"name"
"percent"
```

So, my card didn't display coding activity.

## note

https://wakatime.com/developers#stats

WakaTime each account can control stats returns value by settings.
[Login WakaTime](https://wakatime.com/login) and access below.
Settings > Edit profile

`Display code time publicly`:  if enabled then to return params `hours` and `minutes` and so on (first setting off)

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

- [x] tests/fetchWakatime.test.js
