### PR TITLE
docs: add discussion button to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -32,6 +32,8 @@
     <a href="https://github.com/anuraghazra/github-readme-stats/issues/new/choose">Report Bug</a>
     ·
     <a href="https://github.com/anuraghazra/github-readme-stats/issues/new/choose">Request Feature</a>
+    ·
+    <a href="https://github.com/anuraghazra/github-readme-stats/discussions">Ask Question</a>
   </p>
   <p align="center">
     <a href="/docs/readme_fr.md">Français </a>


### PR DESCRIPTION
This commit adds a link to the discussion page to make sure people ask questions there instead of opening issues.