### PR TITLE
japanese translation fix

### DIFF
--- a/src/translations.js
+++ b/src/translations.js
@@ -170,7 +170,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       fr: "Contribué à",
       hu: "Hozzájárulások",
       it: "Ha contribuito a",
-      ja: "コントリビュートしたリポジトリ",
+      ja: "貢献したリポジトリ",
       kr: "전체 기여도",
       nl: "Bijgedragen aan",
       "pt-pt": "Contribuiu em",


### PR DESCRIPTION
I checked in Safari, Chrome, Firefox it was all same, "Contribute" 's , Japanese translation was too long to so text was overlap the numbers. its fixed by changing shorter word.

<img width="393" alt="Screen Shot 2022-05-23 at 13 05 58" src="https://user-images.githubusercontent.com/76992231/169744054-9f3f71a9-521d-4a68-8f85-61ab5e28e0a0.png">

