### PR TITLE
Add transparent theme

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -360,6 +360,13 @@ const themes = {
     icon_color: "ebbcba",
     text_color: "e0def4",
     bg_color: "191724",
+  },
+  transparent: {
+    title_color: "58A8FF",
+    icon_color: "1F6FEB",
+    text_color: "929292",
+    bg_color: "00000000",
+    border_radius: 10
   }
 };
 


### PR DESCRIPTION
## Theme that adjusts to the GitHub background, so it look great with both dark and white theme.

### Light themed GitHub
<img width="555" alt="Light" src="https://user-images.githubusercontent.com/51276321/169895285-9e5204b4-1ff1-404c-ac12-e5ffebf9e2ee.png">

### Dark themed GitHub
<img width="555" alt="Dark" src="https://user-images.githubusercontent.com/51276321/169895308-ba2fb95c-7095-4452-9172-c54bad02f601.png">

