### PR TITLE
Added "acid_green" and "sweet" to Themes

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -360,6 +360,18 @@ const themes = {
     icon_color: "ebbcba",
     text_color: "e0def4",
     bg_color: "191724",
+  },
+  "acid_green":{
+    title_color: "39D253",
+    icon_color: "1F6FEA",
+    text_color: "EBEBEC",
+    bg_color: "0D1117",
+  },
+  "sweet":{
+    title_color: "E31D44",
+    icon_color: "F8DC3C",
+    text_color: "EC7A25",
+    bg_color: "212237",
   }
 };
 


### PR DESCRIPTION
I just wanted to add two new themes for the project, named "acid green" and "sweet", located at the bottom of themes/index.js

acid_green:
![acid_green](https://user-images.githubusercontent.com/79670342/170898778-7e5367de-5b3b-4972-8a2a-25bbd7c20bcd.png)

sweet:
![sweet](https://user-images.githubusercontent.com/79670342/170898790-4f1608bf-ee89-47d0-b12a-0ca34b859967.png)

