### PR TITLE
fix: prevent npm dependency error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
-          node-version: "12.x"
+          node-version: "16.x"
 
       - name: Install & Test
         run: |


### PR DESCRIPTION
This commit fixes an npm dependency error that caused the test action to fail.
