### PR TITLE
Add neon_blurange theme

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -360,6 +360,12 @@ const themes = {
     icon_color: "ebbcba",
     text_color: "e0def4",
     bg_color: "191724",
+  },
+  "neon_blurange":{
+    title_color: "FB750B",
+    icon_color: "25FB88",
+    text_color: "C7CCFF",
+    bg_color: "030D6B"
   }
 };
 


### PR DESCRIPTION
## Description

- I have read the [Themes Contribution Section](https://github.com/anuraghazra/github-readme-stats/blob/master/CONTRIBUTING.md#themes-contribution) in the `CONTRIBUTION.md`.
- This theme has passed the AA contrast ratio.
- This theme is not one of the color combinations of any VS Code themes. However, I would love to be given a chance to contribute this theme to your repo. Many thanks for considering my request 😊

## Screenshot
![neon_blurange theme](https://user-images.githubusercontent.com/45172775/179603004-af25b80e-cbda-4894-befd-669c73abade9.JPG)

