### PR TITLE
build: pin node version to >=13 (#1900)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   },
   "author": "Anurag Hazra",
   "license": "MIT",
+  "engines": {
+    "node": ">=13"
+  },
   "devDependencies": {
     "@actions/core": "^1.2.4",
     "@actions/github": "^4.0.0",


### PR DESCRIPTION
This PR pins the node version to >=13 since node 12 is now end of life (see https://vercel.com/changelog/node-js-12-is-being-deprecated).