### PR TITLE
Fix NaN and undefined for empty profiles

### DIFF
--- a/src/calculateRank.js
+++ b/src/calculateRank.js
@@ -65,10 +65,10 @@ function calculateRank({
 
   const level = (() => {
     if (normalizedScore < RANK_S_VALUE) return "S+";
-    if (normalizedScore >= RANK_S_VALUE && normalizedScore < RANK_DOUBLE_A_VALUE) return "S";
-    if (normalizedScore >= RANK_DOUBLE_A_VALUE && normalizedScore < RANK_A2_VALUE) return "A++";
-    if (normalizedScore >= RANK_A2_VALUE && normalizedScore < RANK_A3_VALUE) return "A+"
-    if (normalizedScore >= RANK_A3_VALUE && normalizedScore < RANK_B_VALUE)  return "B+"
+    if (normalizedScore < RANK_DOUBLE_A_VALUE) return "S";
+    if (normalizedScore < RANK_A2_VALUE) return "A++";
+    if (normalizedScore < RANK_A3_VALUE) return "A+"
+    return "B+";
   })()
 
   return { level, score: normalizedScore };

--- a/src/fetchers/stats-fetcher.js
+++ b/src/fetchers/stats-fetcher.js
@@ -86,15 +86,16 @@ const totalCommitsFetcher = async (username) => {
 
   try {
     let res = await retryer(fetchTotalCommits, { login: username });
-    if (res.data.total_count) {
+    let total_count = res.data.total_count;
+    if (!!total_count && !isNaN(total_count)) {
       return res.data.total_count;
     }
   } catch (err) {
     logger.log(err);
-    // just return 0 if there is something wrong so that
-    // we don't break the whole app
-    return 0;
   }
+  // just return 0 if there is something wrong so that
+  // we don't break the whole app
+  return 0;
 };
 
 /**


### PR DESCRIPTION
On new/empty GitHub profiles, the card would previously appear like this with `include_all_commits` enabled...
```
https://github-readme-stats.vercel.app/api?username=USERNAME&include_all_commits=true
```
![before](https://user-images.githubusercontent.com/21128619/186296408-e2627dc7-8983-4592-8b16-c745bd5ba24b.png)
And now it has the same behaviour as without `include_all_commits`... 
![after](https://user-images.githubusercontent.com/21128619/186296434-012cf993-6022-4bbb-b8e6-eb712adedc89.png)

