### PR TITLE
Accurate GitHub Dark Theme

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -360,6 +360,13 @@ const themes = {
     icon_color: "ebbcba",
     text_color: "e0def4",
     bg_color: "191724",
+  },
+  accurate_github_dark: {
+    title_color: "c9d1d9",
+    icon_color: "8b949e",
+    text_color: "8b949e",
+    bg_color: "0d1117",
+    border_color: "30363d",
   }
 };
 


### PR DESCRIPTION
This adds a more accurate GitHub dark theme. The other one is nice, but doesn't really fit as well as this one.

![image](https://user-images.githubusercontent.com/42325132/188285726-d71a454f-6f59-4094-9efc-10ae5ccdb2b4.png)
