### PR TITLE
Add prettier check to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,5 +25,9 @@ jobs:
           npm install
           npm run test
 
+      - name: Run Prettier
+        run: |
+          npm run prettier:check:ci
+
       - name: Code Coverage
         uses: codecov/codecov-action@v1

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "test:watch": "jest --watch",
     "theme-readme-gen": "node scripts/generate-theme-doc",
     "preview-theme": "node scripts/preview-theme",
-    "generate-langs-json": "node scripts/generate-langs-json"
+    "generate-langs-json": "node scripts/generate-langs-json",
+    "prettier:check:ci": "./node_modules/.bin/prettier --check .",
+    "prettier:format": "./node_modules/.bin/prettier --write ."
   },
   "author": "Anurag Hazra",
   "license": "MIT",

--- a/scripts/generate-langs-json.js
+++ b/scripts/generate-langs-json.js
@@ -1,26 +1,30 @@
-const fs = require('fs');
-const jsYaml = require('js-yaml');
-const axios = require('axios');
+const fs = require("fs");
+const jsYaml = require("js-yaml");
+const axios = require("axios");
 
-const LANGS_FILEPATH = "./src/common/languageColors.json"
+const LANGS_FILEPATH = "./src/common/languageColors.json";
 
 //Retrieve languages from github linguist repository yaml file
 //@ts-ignore
-axios.get("https://raw.githubusercontent.com/github/linguist/master/lib/linguist/languages.yml")
-.then((response) => {
+axios
+  .get(
+    "https://raw.githubusercontent.com/github/linguist/master/lib/linguist/languages.yml",
+  )
+  .then((response) => {
+    //and convert them to a JS Object
+    const languages = jsYaml.load(response.data);
 
-  //and convert them to a JS Object
-  const languages = jsYaml.load(response.data);
+    const languageColors = {};
 
-  const languageColors = {};
+    //Filter only language colors from the whole file
+    Object.keys(languages).forEach((lang) => {
+      languageColors[lang] = languages[lang].color;
+    });
 
-  //Filter only language colors from the whole file
-  Object.keys(languages).forEach((lang) => {
-    languageColors[lang] = languages[lang].color;
+    //Debug Print
+    //console.dir(languageColors);
+    fs.writeFileSync(
+      LANGS_FILEPATH,
+      JSON.stringify(languageColors, null, "    "),
+    );
   });
-
-  //Debug Print
-  //console.dir(languageColors);
-  fs.writeFileSync(LANGS_FILEPATH, JSON.stringify(languageColors, null, '    '));
-  
-});

--- a/src/calculateRank.js
+++ b/src/calculateRank.js
@@ -67,9 +67,9 @@ function calculateRank({
     if (normalizedScore < RANK_S_VALUE) return "S+";
     if (normalizedScore < RANK_DOUBLE_A_VALUE) return "S";
     if (normalizedScore < RANK_A2_VALUE) return "A++";
-    if (normalizedScore < RANK_A3_VALUE) return "A+"
+    if (normalizedScore < RANK_A3_VALUE) return "A+";
     return "B+";
-  })()
+  })();
 
   return { level, score: normalizedScore };
 }

--- a/src/cards/repo-card.js
+++ b/src/cards/repo-card.js
@@ -67,8 +67,8 @@ const iconWithLabel = (icon, label, testid) => {
 };
 
 /**
- * @param {import('../fetchers/types').RepositoryData} repo 
- * @param {Partial<import("./types").RepoCardOptions>} options 
+ * @param {import('../fetchers/types').RepositoryData} repo
+ * @param {Partial<import("./types").RepoCardOptions>} options
  * @returns {string}
  */
 const renderRepoCard = (repo, options = {}) => {
@@ -167,11 +167,11 @@ const renderRepoCard = (repo, options = {}) => {
   return card.render(`
     ${
       isTemplate
-        // @ts-ignore
-        ? getBadgeSVG(i18n.t("repocard.template"), colors.textColor)
+        ? // @ts-ignore
+          getBadgeSVG(i18n.t("repocard.template"), colors.textColor)
         : isArchived
-        // @ts-ignore
-        ? getBadgeSVG(i18n.t("repocard.archived"), colors.textColor)
+        ? // @ts-ignore
+          getBadgeSVG(i18n.t("repocard.archived"), colors.textColor)
         : ""
     }
 

--- a/src/fetchers/wakatime-fetcher.js
+++ b/src/fetchers/wakatime-fetcher.js
@@ -7,7 +7,7 @@ const { MissingParamError } = require("../common/utils");
  */
 const fetchWakatimeStats = async ({ username, api_domain, range }) => {
   if (!username) throw new MissingParamError(["username"]);
-  
+
   try {
     const { data } = await axios.get(
       `https://${

--- a/tests/fetchTopLanguages.test.js
+++ b/tests/fetchTopLanguages.test.js
@@ -81,7 +81,10 @@ describe("FetchTopLanguages", () => {
   it("should fetch correct language data while excluding the 'test-repo-1' repository", async () => {
     mock.onPost("https://api.github.com/graphql").reply(200, data_langs);
 
-    let repo = await fetchTopLanguages("anuraghazra", exclude_repo=["test-repo-1"]);
+    let repo = await fetchTopLanguages(
+      "anuraghazra",
+      (exclude_repo = ["test-repo-1"]),
+    );
     expect(repo).toStrictEqual({
       HTML: {
         color: "#0f0",

--- a/tests/fetchWakatime.test.js
+++ b/tests/fetchWakatime.test.js
@@ -207,7 +207,7 @@ describe("Wakatime fetcher", () => {
     mock.onGet(/\/https:\/\/wakatime\.com\/api/).reply(404, wakaTimeData);
 
     await expect(fetchWakatimeStats("noone")).rejects.toThrow(
-      "Missing params \"username\" make sure you pass the parameters in URL",
+      'Missing params "username" make sure you pass the parameters in URL',
     );
   });
 });

--- a/tests/renderWakatimeCard.test.js
+++ b/tests/renderWakatimeCard.test.js
@@ -48,10 +48,15 @@ describe("Test Render Wakatime Card", () => {
   });
 
   it('should show "no coding activitiy this week" message when there hasn not been activity', () => {
-    document.body.innerHTML = renderWakatimeCard({
-      ...wakaTimeData.data,
-      languages: undefined
-    }, {});
-    expect(document.querySelector(".stat").textContent).toBe("No coding activity this week")
-  })
+    document.body.innerHTML = renderWakatimeCard(
+      {
+        ...wakaTimeData.data,
+        languages: undefined,
+      },
+      {},
+    );
+    expect(document.querySelector(".stat").textContent).toBe(
+      "No coding activity this week",
+    );
+  });
 });

--- a/themes/index.js
+++ b/themes/index.js
@@ -355,12 +355,12 @@ const themes = {
     bg_color: "09131B",
     border_color: "0c1a25",
   },
-  "rose_pine":{
+  rose_pine: {
     title_color: "9ccfd8",
     icon_color: "ebbcba",
     text_color: "e0def4",
     bg_color: "191724",
-  }
+  },
 };
 
 module.exports = themes;


### PR DESCRIPTION
Fixes https://github.com/anuraghazra/github-readme-stats/issues/1899

### Problem

Theme preview action is not working because diff includes a change in the previous line, where we added a comma. And when you run `Hjson.parse()` in preview-theme.js, it couldn't recognize the added diff as a valid json.

<img width="300" alt="Screen Shot 2022-09-05 at 1 16 18 PM" src="https://user-images.githubusercontent.com/22325824/188498800-517700d3-5750-4879-b615-08ad2b90db01.png">
<img width="300" alt="Screen Shot 2022-09-05 at 12 57 00 PM" src="https://user-images.githubusercontent.com/22325824/188498801-25730d66-b057-4d16-b198-241fca67c9fa.png">


### Solution Approach

Ensure a trailing comma is always added in `themes/index.js`, to prevent unnecessary line diff. To do that, I saw that we already have a [prettier config](https://github.com/anuraghazra/github-readme-stats/blob/8aea1e3c353e3cf1d3704d5ce7f4b52888ddbc97/.prettierrc.json), so I make sure the CI runs that to enforce the rule (following this [guide](https://lietzau-consulting.de/2022/03/integrate-prettier-circle-ci/))

This PR is divided into 2 commits. The first adds prettier to the CI. The second are changes after `npm run prettier:format` is ran to resolve existing lintings - which includes formatting `themes/index.js` for trailing spaces.

### Previewing

I checked that this works in my fork of the project. Below are some screenshots:

<details>
<summary>Example CI error when no trailing comma added:</summary>
<br>
<img width="400" alt="Screen Shot 2022-09-05 at 1 20 37 PM" src="https://user-images.githubusercontent.com/22325824/188499589-aecb0668-097c-4490-aeb2-fd669c222178.png">
</details>


<details>
<summary>Example Theme PR submission:</summary>
<br>
<img width="400" alt="image" src="https://user-images.githubusercontent.com/22325824/188499749-9e857327-9834-4ad1-9f53-9ee25611d331.png">
<img width="400" alt="Screen Shot 2022-09-05 at 1 44 27 PM" src="https://user-images.githubusercontent.com/22325824/188499768-87af5fc6-2180-4b98-ac19-5a91c2fe889f.png">
</details>

> **Note**
> I guess the caveat here is that future contributors will now see lint errors in their CI blocking their PRs. Which they should fix by running `npm run prettier:format` manually.
