### PR TITLE
Add cocoa default color

### DIFF
--- a/src/common/languageColors.json
+++ b/src/common/languageColors.json
@@ -80,6 +80,7 @@
     "Clojure": "#db5855",
     "Closure Templates": "#0d948f",
     "Cloud Firestore Security Rules": "#FFA000",
+    "Cocoa" : "FB0008"
     "CodeQL": "#140f46",
     "CoffeeScript": "#244776",
     "ColdFusion": "#ed2cd6",
@@ -178,7 +179,7 @@
     "Groovy Server Pages": "#4298b8",
     "HAProxy": "#106da9",
     "HLSL": "#aace60",
-    "HTML": "#e34c26",
+    "HTML": "#C53B00",
     "HTML+ECR": "#2e1052",
     "HTML+EEX": "#6e4a7e",
     "HTML+ERB": "#701516",

--- a/src/common/languageColors.json
+++ b/src/common/languageColors.json
@@ -179,7 +179,7 @@
     "Groovy Server Pages": "#4298b8",
     "HAProxy": "#106da9",
     "HLSL": "#aace60",
-    "HTML": "#C53B00",
+    "HTML": "#E34C26",
     "HTML+ECR": "#2e1052",
     "HTML+EEX": "#6e4a7e",
     "HTML+ERB": "#701516",


### PR DESCRIPTION
cocoa default color is gray which is ugly in any theme especially for those who work Ios dev. (first commit i accidentally delete html but restored again)