### PR TITLE
black_green theme

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -361,6 +361,12 @@ const themes = {
     text_color: "e0def4",
     bg_color: "191724",
   },
+  black_green: {
+    title_color: "1DB10D",
+    icon_color: "FFC000",
+    text_color: "1DB10D",
+    bg_color: "020201",
+  },
 };
 
 module.exports = themes;


### PR DESCRIPTION
Added black_green theme, the theme passed the [AA Contrast Ratio](https://webaim.org/resources/contrastchecker/?fcolor=1DB10D&bcolor=020201) ![Theme](https://github-readme-stats.vercel.app/api?username=anuraghazra&title_color=1DB10D&icon_color=FFC000&text_color=1DB10D&bg_color=020201&show_icons=true)