### PR TITLE
build: fix wakatime json import bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "prettier": "^2.1.2"
       },
       "engines": {
-        "node": ">=13"
+        "node": "16.17.1"
       }
     },
     "node_modules/@actions/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,9 +32,6 @@
         "lodash.snakecase": "^4.1.1",
         "parse-diff": "^0.7.0",
         "prettier": "^2.1.2"
-      },
-      "engines": {
-        "node": "16.17.1"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "Anurag Hazra",
   "license": "MIT",
   "engines": {
-    "node": ">=13"
+    "node": "16.17.1"
   },
   "devDependencies": {
     "@actions/core": "^1.2.4",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,6 @@
   },
   "author": "Anurag Hazra",
   "license": "MIT",
-  "engines": {
-    "node": "16.17.1"
-  },
   "devDependencies": {
     "@actions/core": "^1.2.4",
     "@actions/github": "^4.0.0",

--- a/src/cards/wakatime-card.js
+++ b/src/cards/wakatime-card.js
@@ -11,6 +11,7 @@ import {
 } from "../common/utils.js";
 import { getStyles } from "../getStyles.js";
 import { wakatimeCardLocales } from "../translations.js";
+
 /**
  * @param {{color: string, text: string}} param0
  */

--- a/src/cards/wakatime-card.js
+++ b/src/cards/wakatime-card.js
@@ -2,7 +2,6 @@
 import { Card } from "../common/Card.js";
 import { createProgressNode } from "../common/createProgressNode.js";
 import { I18n } from "../common/I18n.js";
-import languageColors from "../common/languageColors.json" assert { type: "json" };
 import {
   clampValue,
   flexLayout,
@@ -11,6 +10,17 @@ import {
 } from "../common/utils.js";
 import { getStyles } from "../getStyles.js";
 import { wakatimeCardLocales } from "../translations.js";
+
+/** Import language colors.
+ *
+ * @description Here we use the workaround found in
+ * https://stackoverflow.com/questions/66726365/how-should-i-import-json-in-node
+ * since vercel is using v16.14.0 which does not yet support json imports without the
+ * --experimental-json-modules flag.
+ */
+import { createRequire } from "module";
+const require = createRequire(import.meta.url);
+const languageColors = require("../common/languageColors.json"); // now works
 
 /**
  * @param {{color: string, text: string}} param0


### PR DESCRIPTION
This PR adds a workaround for importing the `languageColors` JSON file. This needed to be done since Vercel uses v16.4, which does not support JSON file importing without the `experimental-json-modules` flag. See https://simonplend.com/import-json-in-es-modules/ for more information. The workaround can be found [here](https://stackoverflow.com/questions/66726365/how-should-i-import-json-in-node).