### PR TITLE
add purple_dark_accessible theme

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -361,6 +361,12 @@ export const themes = {
     text_color: "e0def4",
     bg_color: "191724",
   },
+  purple_dark_accessible: {
+    title_color: "af7aff",
+    icon_color: "af7aff",
+    text_color: "e4e4e4",
+    bg_color: "010101",
+  },
 };
 
 export default themes;


### PR DESCRIPTION
A new purple-dark theme that passes WCAG AA and WCAG AAA contrast ratio standards.
![image](https://user-images.githubusercontent.com/26192879/192187695-2ed48663-a44b-4d60-a058-da3a79f7b6ed.png)


