### PR TITLE
refactor: remove unused dotenv calls

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,4 +1,3 @@
-import * as dotenv from "dotenv";
 import { renderStatsCard } from "../src/cards/stats-card.js";
 import { blacklist } from "../src/common/blacklist.js";
 import {
@@ -10,8 +9,6 @@ import {
 } from "../src/common/utils.js";
 import { fetchStats } from "../src/fetchers/stats-fetcher.js";
 import { isLocaleAvailable } from "../src/translations.js";
-
-dotenv.config();
 
 export default async (req, res) => {
   const {

--- a/api/top-langs.js
+++ b/api/top-langs.js
@@ -1,4 +1,3 @@
-import * as dotenv from "dotenv";
 import { renderTopLanguages } from "../src/cards/top-languages-card.js";
 import { blacklist } from "../src/common/blacklist.js";
 import {
@@ -10,8 +9,6 @@ import {
 } from "../src/common/utils.js";
 import { fetchTopLanguages } from "../src/fetchers/top-languages-fetcher.js";
 import { isLocaleAvailable } from "../src/translations.js";
-
-dotenv.config();
 
 export default async (req, res) => {
   const {

--- a/api/wakatime.js
+++ b/api/wakatime.js
@@ -1,4 +1,3 @@
-import * as dotenv from "dotenv";
 import { renderWakatimeCard } from "../src/cards/wakatime-card.js";
 import {
   clampValue,
@@ -9,8 +8,6 @@ import {
 } from "../src/common/utils.js";
 import { fetchWakatimeStats } from "../src/fetchers/wakatime-fetcher.js";
 import { isLocaleAvailable } from "../src/translations.js";
-
-dotenv.config();
 
 export default async (req, res) => {
   const {

--- a/src/fetchers/stats-fetcher.js
+++ b/src/fetchers/stats-fetcher.js
@@ -1,6 +1,5 @@
 // @ts-check
 import axios from "axios";
-import * as dotenv from "dotenv";
 import githubUsernameRegex from "github-username-regex";
 import { calculateRank } from "../calculateRank.js";
 import { retryer } from "../common/retryer.js";
@@ -11,8 +10,6 @@ import {
   request,
   wrapTextMultiline,
 } from "../common/utils.js";
-
-dotenv.config();
 
 /**
  * Stats fetcher object.

--- a/src/fetchers/top-languages-fetcher.js
+++ b/src/fetchers/top-languages-fetcher.js
@@ -1,5 +1,4 @@
 // @ts-check
-import * as dotenv from "dotenv";
 import { retryer } from "../common/retryer.js";
 import {
   CustomError,
@@ -8,8 +7,6 @@ import {
   request,
   wrapTextMultiline,
 } from "../common/utils.js";
-
-dotenv.config();
 
 /**
  * Top languages fetcher object.


### PR DESCRIPTION
This Pull request removes all occurrences of the dotenv package in the `src` folder. As explained in the Vercel documentation vercel ignores dot files (see https://github.com/vercel/vercel/discussions/3962#discussioncomment-4277). It instead loads the env variables defined in the Vercel instance. As a result, we can therefore remove dotenv. I tried to use a `.env` file, and it broke the app since then the vercel env variables won't be loaded anymore. Dotenv is now only used in the `scripts` folder.
