### PR TITLE
Caching Dependencies to speed up workflows

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -8,12 +8,24 @@ jobs:
       github.event_name == 'deployment_status' &&
       github.event.deployment_status.state == 'success'
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
+
     steps:
       - uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
       - name: Install dependencies
         run: npm ci
         env:
           CI: true
+
       - name: Run end-to-end tests.
         run: npm run test:e2e
         env:

--- a/.github/workflows/generate-theme-doc.yml
+++ b/.github/workflows/generate-theme-doc.yml
@@ -10,13 +10,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
 
     steps:
-      - uses: actions/checkout@v1
-      - name: setup node
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
+          node-version: ${{ matrix.node-version }}
+          cache: npm
 
       - name: npm install, generate readme
         run: |

--- a/.github/workflows/preview-theme.yml
+++ b/.github/workflows/preview-theme.yml
@@ -11,16 +11,24 @@ on:
 jobs:
   previewTheme:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
     name: Install & Preview
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
       - uses: bahmutov/npm-install@v1
         with:
           useLockFile: false
+
       - run: npm run preview-theme
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,14 +11,18 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [16.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
-          node-version: "16.x"
+          node-version: ${{ matrix.node-version }}
+          cache: npm
 
       - name: Install & Test
         run: |


### PR DESCRIPTION
## Description
I updated workflows to apply **dependency caching**.

### About caching workflow dependencies
Jobs on GitHub-hosted runners start in a clean virtual environment and **must download dependencies each time**, causing increased network utilization, longer runtime, and increased cost. To help speed up the time it takes to recreate files like dependencies, GitHub can cache files that frequently use in workflows.

### Solutions
Node.js projects can run faster on GitHub Actions by enabling dependency caching on the [setup-node](https://github.com/actions/setup-node) action. 

The following example enables caching for a Node.js project with npm:

```yaml
steps:
- uses: actions/checkout@v3
- uses: actions/setup-node@v3
  with:
    node-version: "16.x"
    cache: npm
```

> It’s literally a one line change to pass the `cache: npm` input parameter.

## References
[actions/setup-node#caching-global-packages-data](https://github.com/actions/setup-node#caching-global-packages-data)