### PR TITLE
Bump the grade lower from `A+` -> `A` and `A++` -> `A+`

### DIFF
--- a/src/calculateRank.js
+++ b/src/calculateRank.js
@@ -66,8 +66,8 @@ function calculateRank({
   const level = (() => {
     if (normalizedScore < RANK_S_VALUE) return "S+";
     if (normalizedScore < RANK_DOUBLE_A_VALUE) return "S";
-    if (normalizedScore < RANK_A2_VALUE) return "A++";
-    if (normalizedScore < RANK_A3_VALUE) return "A+";
+    if (normalizedScore < RANK_A2_VALUE) return "A+";
+    if (normalizedScore < RANK_A3_VALUE) return "A";
     return "B+";
   })();
 


### PR DESCRIPTION
Going from `A+` to `B+` for a very small amount of contributions seems a bit extreme. I'm open to opinions on the matter, but in my opinion this change makes the ranking system a bit more reasonable. To clarify, what exactly does `s` stand for?