### PR TITLE
Added `format_stats` option

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -37,6 +37,7 @@ export default async (req, res) => {
     locale,
     disable_animations,
     border_radius,
+    format_stats,
     border_color,
   } = req.query;
   res.setHeader("Content-Type", "image/svg+xml");
@@ -84,6 +85,7 @@ export default async (req, res) => {
         custom_title,
         border_radius,
         border_color,
+        format_stats: parseBoolean(format_stats),
         locale: locale ? locale.toLowerCase() : null,
         disable_animations: parseBoolean(disable_animations),
       }),

--- a/readme.md
+++ b/readme.md
@@ -196,6 +196,7 @@ You can provide multiple comma-separated values in the bg_color option to render
 -   `custom_title` - Sets a custom title for the card. Default:  `<username> Github Stats`.
 -   `text_bold` - Use bold text _(boolean)_. Default: `true`.
 -   `disable_animations` - Disables all animations in the card _(boolean)_. Default: `false`.
+-   `format_stats` Formats stats with a `k` _(boolean)_. Default: `true`
 
 > Note on `hide_rank`:
 > When hide_rank=`true`, the minimum card width is 270 px + the title length and padding.

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -34,8 +34,10 @@ const createTextNode = ({
   showIcons,
   shiftValuePos,
   bold,
+  format_stats,
 }) => {
-  const kValue = kFormatter(value);
+  const kValue = format_stats ? kFormatter(value) : value;
+  console.log(kValue, format_stats);
   const staggerDelay = (index + 3) * 150;
 
   const labelOffset = showIcons ? `x="25"` : "";
@@ -95,6 +97,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     custom_title,
     border_radius,
     border_color,
+    format_stats = true,
     locale,
     disable_animations = false,
   } = options;
@@ -183,6 +186,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
         shiftValuePos:
           (!include_all_commits ? 50 : 35) + (isLongLocale ? 50 : 0),
         bold: text_bold,
+        format_stats,
       }),
     );
 

--- a/src/cards/types.d.ts
+++ b/src/cards/types.d.ts
@@ -22,6 +22,7 @@ export type StatCardOptions = CommonOptions & {
   line_height: number | string;
   custom_title: string;
   disable_animations: boolean;
+  format_stats: boolean;
 };
 
 export type RepoCardOptions = CommonOptions & {


### PR DESCRIPTION
The `format_stats` option implements the ability to remove the `k` formatting from `1.8k` -> `1878` specifically

Implements #2128 


