### PR TITLE
fix: prevent errors from being cached

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -89,6 +89,7 @@ export default async (req, res) => {
       }),
     );
   } catch (err) {
+    res.setHeader("Cache-Control", `no-store`); // Don't cache error responses.
     return res.send(renderError(err.message, err.secondaryMessage));
   }
 };

--- a/api/pin.js
+++ b/api/pin.js
@@ -75,6 +75,7 @@ export default async (req, res) => {
       }),
     );
   } catch (err) {
+    res.setHeader("Cache-Control", `no-store`); // Don't cache error responses.
     return res.send(renderError(err.message, err.secondaryMessage));
   }
 };

--- a/api/top-langs.js
+++ b/api/top-langs.js
@@ -76,6 +76,7 @@ export default async (req, res) => {
       }),
     );
   } catch (err) {
+    res.setHeader("Cache-Control", `no-store`); // Don't cache error responses.
     return res.send(renderError(err.message, err.secondaryMessage));
   }
 };

--- a/api/wakatime.js
+++ b/api/wakatime.js
@@ -78,6 +78,7 @@ export default async (req, res) => {
       }),
     );
   } catch (err) {
+    res.setHeader("Cache-Control", `no-store`); // Don't cache error responses.
     return res.send(renderError(err.message, err.secondaryMessage));
   }
 };


### PR DESCRIPTION
This PR makes sure that errors are not cached. Doing this will prevent people from seeing the `max_retries` error longer than is needed.