### PR TITLE
Add Spotify Dark/Light Themes

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -367,6 +367,18 @@ export const themes = {
     text_color: "e0def4",
     bg_color: "191724",
   },
+    spotify_dark: {
+    title_color: "1dd65f",
+    icon_color: "1dd65f",
+    text_color: "f0f8ff",
+    bg_color: "161b22",
+  },
+  spotify_light: {
+    title_color: "1dd65f",
+    icon_color: "1dd65f",
+    text_color: "161b22",
+    bg_color: "f0f8ff",
+  },
 };
 
 export default themes;


### PR DESCRIPTION
The Dark Theme looks like this:

![Spotify Dark Theme](https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&title_color=1dd65f&icon_color=1dd65f&text_color=f0f8ff&bg_color=161b22&cache_seconds=86400)

And the Light Theme looks like this:

![Spotify Light Theme](https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&title_color=1dd65f&icon_color=1dd65f&text_color=161b22&bg_color=f0f8ff&cache_seconds=86400)