### PR TITLE
fix: text overlapped on zh-tw locale

### DIFF
--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -170,6 +170,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     "pl",
     "de",
     "nl",
+    "zh-tw",
   ];
   const isLongLocale = longLocales.includes(locale) === true;
 


### PR DESCRIPTION
###  Description

Text is overlapping when locale is zh-tw.

**Before**
![](https://github-readme-stats.vercel.app/api?username=kurt-liao&show-icons=true&locale=zh-tw)


**After**
![](https://github-readme-stats-kurt-liao.vercel.app/api?username=kurt-liao&locale=zh-tw)

### What did I do

Add `zh-tw` into `longLocales` array