### PR TITLE
fix: improve error caching behavoir

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -89,7 +89,7 @@ export default async (req, res) => {
       }),
     );
   } catch (err) {
-    res.setHeader("Cache-Control", `no-store`); // Don't cache error responses.
+    res.setHeader("Cache-Control", `no-cache, no-store, must-revalidate`); // Don't cache error responses.
     return res.send(renderError(err.message, err.secondaryMessage));
   }
 };

--- a/api/pin.js
+++ b/api/pin.js
@@ -75,7 +75,7 @@ export default async (req, res) => {
       }),
     );
   } catch (err) {
-    res.setHeader("Cache-Control", `no-store`); // Don't cache error responses.
+    res.setHeader("Cache-Control", `no-cache, no-store, must-revalidate`); // Don't cache error responses.
     return res.send(renderError(err.message, err.secondaryMessage));
   }
 };

--- a/api/top-langs.js
+++ b/api/top-langs.js
@@ -76,7 +76,7 @@ export default async (req, res) => {
       }),
     );
   } catch (err) {
-    res.setHeader("Cache-Control", `no-store`); // Don't cache error responses.
+    res.setHeader("Cache-Control", `no-cache, no-store, must-revalidate`); // Don't cache error responses.
     return res.send(renderError(err.message, err.secondaryMessage));
   }
 };

--- a/api/wakatime.js
+++ b/api/wakatime.js
@@ -78,7 +78,7 @@ export default async (req, res) => {
       }),
     );
   } catch (err) {
-    res.setHeader("Cache-Control", `no-store`); // Don't cache error responses.
+    res.setHeader("Cache-Control", `no-cache, no-store, must-revalidate`); // Don't cache error responses.
     return res.send(renderError(err.message, err.secondaryMessage));
   }
 };

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -180,7 +180,7 @@ describe("Test /api/", () => {
 
     expect(res.setHeader.mock.calls).toEqual([
       ["Content-Type", "image/svg+xml"],
-      ["Cache-Control", `no-store`],
+      ["Cache-Control", `no-cache, no-store, must-revalidate`],
     ]);
   });
 


### PR DESCRIPTION
This commit ensures that the cache is not cached when the GraphQL limit is hit in all browsers (see https://stackoverflow.com/a/2068407/8135687 and https://github.com/anuraghazra/github-readme-stats/issues/1471#issuecomment-1282630614).