### PR TITLE
Add new mono and mono_inverted themes

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -367,6 +367,18 @@ export const themes = {
     text_color: "e0def4",
     bg_color: "191724",
   },
+  mono: {
+    title_color: "000000",
+    icon_color: "000000",
+    text_color: "000000",
+    bg_color: "ffffff",
+  },
+  mono_inverted: {
+    title_color: "ffffff",
+    icon_color: "ffffff",
+    text_color: "ffffff",
+    bg_color: "000000",
+  },
 };
 
 export default themes;


### PR DESCRIPTION
I know these themes aren't the prettiest, but I figured I should make a pull request, just so there's some plain black and white options.

I plan to display these stats on an e-ink display, and these themes will allow me, and possibly others to do so.