### PR TITLE
Fix GitHub capitalization

### DIFF
--- a/docs/readme_kr.md
+++ b/docs/readme_kr.md
@@ -1,7 +1,7 @@
 <p align="center">
  <img width="100px" src="https://res.cloudinary.com/anuraghazra/image/upload/v1594908242/logo_ccswme.svg" align="center" alt="GitHub Readme Stats" />
  <h2 align="center">GitHub Readme Stats</h2>
- <p align="center">동적으로 생성되는 Github 사용량 통계를 여러분의 README 에 추가해보세요!</p>
+ <p align="center">동적으로 생성되는 GitHub 사용량 통계를 여러분의 README 에 추가해보세요!</p>
 </p>
   <p align="center">
     <a href="https://github.com/anuraghazra/github-readme-stats/actions">
@@ -72,7 +72,7 @@
 
 아래 코드를 복사해서 마크다운 파일에 붙여넣으면 끝이에요, 아주 간단해요!
 
-`?username=` 속성의 값을 Github 계정의 사용자 명(닉네임)으로 바꿔주세요.
+`?username=` 속성의 값을 GitHub 계정의 사용자 명(닉네임)으로 바꿔주세요.
 
 ```md
 [![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra)](https://github.com/anuraghazra/github-readme-stats)
@@ -235,7 +235,7 @@ GitHub 저장소 여분 핀을 이용하면, 6개 이상의 저장소 핀을 여
 
 # 언어 사용량 통계
 
-언어 사용량 통계 카드는 Github 사용자가 가장 많이 사용한 언어가 표시됩니다.
+언어 사용량 통계 카드는 GitHub 사용자가 가장 많이 사용한 언어가 표시됩니다.
 
 _참고:
 언어 사용량 통계는 GitHub 에서 가장 많이 사용된 언어의 표기일 뿐입니다.

--- a/docs/readme_np.md
+++ b/docs/readme_np.md
@@ -219,7 +219,7 @@ Use [show_owner](#customization) variable to include the repo's owner username
 
 टोप भाषाकार्डले github परयोग गर्नेहरुको प्रोग्रम्मिंग भाषाहरु देखाऊने गर्दछ |. 
 
-_NOTE: टोप भाषाहरुले आफ्नो सिपलाए संकेत गरेको होईन | योचै Github  Metricबाट धेरै कुन भाषा परयोग भाकोलाए संकेत गरेको हो |
+_NOTE: टोप भाषाहरुले आफ्नो सिपलाए संकेत गरेको होईन | योचै GitHub  Metricबाट धेरै कुन भाषा परयोग भाकोलाए संकेत गरेको हो |
 ### प्रयोग 
 
 कोदलाए  कपी- पेसेत  readme मा गर्नु होला र लिंक परिवतन गर्नु होला |
@@ -389,7 +389,7 @@ NOTE: Since [#58](https://github.com/anuraghazra/github-readme-stats/pull/58) we
 येदि तपाइले यो प्रोजेक्ट चलाउनु बाकोक्ष बने र मलाई अझै प्रसंसा गर्ने हो बने तपाइले थुप्रै तरिका ले गर्नु सक्नु हुने छ :-
 
 - यो प्रोजेक्टमा तपाइले प्रहयोग गर्दा मलाई क्रेडिट दिन सक्नु हुनेक्ष ।
-- तपाइले Github ReadMe Stats स्तार्रेड गर्न सक्नु हुनेक्ष  :rocket:
+- तपाइले GitHub ReadMe Stats स्तार्रेड गर्न सक्नु हुनेक्ष  :rocket:
 - [![paypal.me/anuraghazra](https://ionicabizau.github.io/badges/paypal.svg)](https://www.paypal.me/anuraghazra) - तपाइले पेपाल बाट पनि सहयोग (डक्क्षिन) गर्न सक्नु हुनेक्ष | म  ~~कोफी ~~ चिया . :tea: किन्न सक्क्षु ।
 
 धन्याबाद! :heart:

--- a/docs/readme_tr.md
+++ b/docs/readme_tr.md
@@ -73,10 +73,10 @@
 
 Alt kısımdaki kodu Kopyalayın ve yapıştırın. İşte bu kadar. Çok basit!
 
-`?username=` değerini kendi Github kullanıcı adınız ile değiştirin.
+`?username=` değerini kendi GitHub kullanıcı adınız ile değiştirin.
 
 ```md
-[![Anurag'nın Github İstatistikleri](https://github-readme-stats.vercel.app/api?username=anuraghazra)](https://github.com/anuraghazra/github-readme-stats)
+[![Anurag'nın GitHub İstatistikleri](https://github-readme-stats.vercel.app/api?username=anuraghazra)](https://github.com/anuraghazra/github-readme-stats)
 ```
 _Not: Şu sıralamalar mevcut: S+ (en üst 1%), S (en üst 25%), A++ (en üst 45%), A+ (en üst 60%), and B+ (herkes).
 Buradaki değerler [cumulative distribution function](https://en.wikipedia.org/wiki/Cumulative_distribution_function) ile hesaplanırken; commitler, katkılar, hatalar, yıldızlar, çekme istekleri, takipçiler ve sahip olunan depolar (repository) göz önünde bulundurulamaktadır.
@@ -199,7 +199,7 @@ bg_color içerisinde birden fazla rengi gradient olarak göstermek için virgül
 
 # GitHub Ekstra Pinler
 
-Github ekstra pinler profilinize 6'dan fazla repoyu / depoyu profilinizde pinleyebilirsiniz.
+GitHub ekstra pinler profilinize 6'dan fazla repoyu / depoyu profilinizde pinleyebilirsiniz.
 
 Hey! Artık 6 pin ile kısıtlı kalmayacaksınız!
 
@@ -225,7 +225,7 @@ Endpoint: `api/pin?username=mustafacagri&repo=github-readme-stats`
 
 En çok kullanılan diller kartı kullanıcının en çok kullandığı dilleri gösterir.
 
-_NOTE: En çok kullanılan dillerde yer alan bilgiler sizin yeteneğinizi ve benzeri şeyleri göstermek. Bu, kodlarınızda en çok kullandığınız dilleri gösteren bir Github metriğidir. Ayrıca, github-readme-stats'ın yeni özelliğidir.
+_NOTE: En çok kullanılan dillerde yer alan bilgiler sizin yeteneğinizi ve benzeri şeyleri göstermek. Bu, kodlarınızda en çok kullandığınız dilleri gösteren bir GitHub metriğidir. Ayrıca, github-readme-stats'ın yeni özelliğidir.
 
 ### Kullanım
 
@@ -365,7 +365,7 @@ Genellikle resimleri yan yana düzenleyemezsiniz. Bunu yapmak için şu yaklaş�
 
 #### [@codeSTACKr'ın Yayınladığı Video Eğitimine Göz Atın](https://youtu.be/n6d4KHSKqGk?t=107)
 
-Github API saatte sadece 5.000 isteğe izin verdiği için `https://github-readme-stats.vercel.app/api` adresindeki API'm bu limite muhtemelen takılmış olabilir. Eğer projeyi kendi Vercel sunucunuzda yayınlarsanız, böyle bir sorun yaşamayabilirsiniz. Deploy butonuna tıkla ve deploy başlasın!
+GitHub API saatte sadece 5.000 isteğe izin verdiği için `https://github-readme-stats.vercel.app/api` adresindeki API'm bu limite muhtemelen takılmış olabilir. Eğer projeyi kendi Vercel sunucunuzda yayınlarsanız, böyle bir sorun yaşamayabilirsiniz. Deploy butonuna tıkla ve deploy başlasın!
 
 
 NOT: [#58](https://github.com/anuraghazra/github-readme-stats/pull/58) geliştirmesi sonrasında anlamadığımız bir şekilde 5.000 istek limitine takılmıyoruz :)
@@ -378,9 +378,9 @@ NOT: [#58](https://github.com/anuraghazra/github-readme-stats/pull/58) geliştir
 1. [vercel.com](https://vercel.com/) adresine gidin
 1. `Log in`'e tıklayın
    ![](https://files.catbox.moe/tct1wg.png)
-1. `Continue with GitHub`'e basarak Github ile giriş yapın
+1. `Continue with GitHub`'e basarak GitHub ile giriş yapın
    ![](https://files.catbox.moe/btd78j.jpeg)
-1. Github'a giriş yapın ve eğer çıkarsa tüm repolara izin verin.
+1. GitHub'a giriş yapın ve eğer çıkarsa tüm repolara izin verin.
 1. Bu repoyu fork'layın
 1. [Vercel dashboard](https://vercel.com/dashboard)'unuza geri dönün.
 1. `Import Project`'i seçin.

--- a/readme.md
+++ b/readme.md
@@ -150,7 +150,7 @@ Use `&theme=THEME_NAME` parameter like so :
 
 #### All inbuilt themes
 
-Github readme stats comes with several built-in themes (e.g. `dark`, `radical`, `merko`, `gruvbox`, `tokyonight`, `onedark`, `cobalt`, `synthwave`, `highcontrast`, `dracula`).
+GitHub readme stats comes with several built-in themes (e.g. `dark`, `radical`, `merko`, `gruvbox`, `tokyonight`, `onedark`, `cobalt`, `synthwave`, `highcontrast`, `dracula`).
 
 <img src="https://res.cloudinary.com/anuraghazra/image/upload/v1595174536/grs-themes_l4ynja.png" alt="GitHub Readme Stats Themes" width="600px"/>
 
@@ -193,7 +193,7 @@ You can provide multiple comma-separated values in the bg_color option to render
 -   `count_private` - Count private commits _(boolean)_. Default: `false`.
 -   `line_height` - Sets the line height between text _(number)_. Default: `25`.
 -   `exclude_repo` - Exclude stars from specified repositories _(Comma-separated values)_. Default: `[] (blank array)`.
--   `custom_title` - Sets a custom title for the card. Default:  `<username> Github Stats`.
+-   `custom_title` - Sets a custom title for the card. Default:  `<username> GitHub Stats`.
 -   `text_bold` - Use bold text _(boolean)_. Default: `true`.
 -   `disable_animations` - Disables all animations in the card _(boolean)_. Default: `false`.
 

--- a/scripts/helpers.js
+++ b/scripts/helpers.js
@@ -30,7 +30,7 @@ export const getRepoInfo = (ctx) => {
 /**
  * Retrieve github token and throw error if it is not found.
  *
- * @returns {string} Github token.
+ * @returns {string} GitHub token.
  */
 export const getGithubToken = () => {
   const token = getInput("github_token") || process.env.GITHUB_TOKEN;

--- a/scripts/preview-theme.js
+++ b/scripts/preview-theme.js
@@ -92,7 +92,7 @@ const isPreviewComment = (inputs, comment) => {
  * @param {number} issueNumber Issue number.
  * @param {string} repo Repository name.
  * @param {string} owner Owner of the repository.
- * @returns {Object} The Github comment object.
+ * @returns {Object} The GitHub comment object.
  */
 const findComment = async (octokit, issueNumber, owner, repo, commenter) => {
   const parameters = {

--- a/scripts/push-theme-readme.sh
+++ b/scripts/push-theme-readme.sh
@@ -5,7 +5,7 @@ set -e
 export BRANCH_NAME=updated-theme-readme
 git --version
 git config --global user.email "no-reply@githubreadmestats.com"
-git config --global user.name "Github Readme Stats Bot"
+git config --global user.name "GitHub Readme Stats Bot"
 git branch -d $BRANCH_NAME || true
 git checkout -b $BRANCH_NAME
 git add --all

--- a/src/fetchers/repo-fetcher.js
+++ b/src/fetchers/repo-fetcher.js
@@ -6,7 +6,7 @@ import { MissingParamError, request } from "../common/utils.js";
  * Repo data fetcher.
  *
  * @param {import('Axios').AxiosRequestHeaders} variables Fetcher variables.
- * @param {string} token Github token.
+ * @param {string} token GitHub token.
  * @returns {Promise<import('Axios').AxiosResponse>} The response.
  */
 const fetcher = (variables, token) => {
@@ -56,8 +56,8 @@ const urlExample = "/api/pin?username=USERNAME&amp;repo=REPO_NAME";
 /**
  * Fetch repository data.
  *
- * @param {string} username Github username.
- * @param {string} reponame Github repository name.
+ * @param {string} username GitHub username.
+ * @param {string} reponame GitHub repository name.
  * @returns {Promise<import("./types").RepositoryData>} Repository data.
  */
 async function fetchRepo(username, reponame) {

--- a/src/fetchers/stats-fetcher.js
+++ b/src/fetchers/stats-fetcher.js
@@ -18,7 +18,7 @@ dotenv.config();
  * Stats fetcher object.
  *
  * @param {import('axios').AxiosRequestHeaders} variables Fetcher variables.
- * @param {string} token Github token.
+ * @param {string} token GitHub token.
  * @returns {Promise<import('../common/types').StatsFetcherResponse>} Stats fetcher response.
  */
 const fetcher = (variables, token) => {
@@ -66,7 +66,7 @@ const fetcher = (variables, token) => {
  * Fetch first 100 repositories for a given username.
  *
  * @param {import('axios').AxiosRequestHeaders} variables Fetcher variables.
- * @param {string} token Github token.
+ * @param {string} token GitHub token.
  * @returns {Promise<import('../common/types').StatsFetcherResponse>} Repositories fetcher response.
  */
 const repositoriesFetcher = (variables, token) => {
@@ -101,10 +101,10 @@ const repositoriesFetcher = (variables, token) => {
 /**
  * Fetch all the commits for all the repositories of a given username.
  *
- * @param {*} username Github username.
+ * @param {*} username GitHub username.
  * @returns {Promise<number>} Total commits.
  *
- * @description Done like this because the Github API does not provide a way to fetch all the commits. See
+ * @description Done like this because the GitHub API does not provide a way to fetch all the commits. See
  * #92#issuecomment-661026467 and #211 for more information.
  */
 const totalCommitsFetcher = async (username) => {
@@ -143,7 +143,7 @@ const totalCommitsFetcher = async (username) => {
 /**
  * Fetch all the stars for all the repositories of a given username.
  *
- * @param {string} username Github username.
+ * @param {string} username GitHub username.
  * @param {array} repoToHide Repositories to hide.
  * @returns {Promise<number>} Total stars.
  */
@@ -183,7 +183,7 @@ const totalStarsFetcher = async (username, repoToHide) => {
 /**
  * Fetch stats for a given username.
  *
- * @param {string} username Github username.
+ * @param {string} username GitHub username.
  * @param {boolean} count_private Include private contributions.
  * @param {boolean} include_all_commits Include all commits.
  * @returns {Promise<import("./types").StatsData>} Stats data.

--- a/src/fetchers/top-languages-fetcher.js
+++ b/src/fetchers/top-languages-fetcher.js
@@ -15,7 +15,7 @@ dotenv.config();
  * Top languages fetcher object.
  *
  * @param {import('Axios').AxiosRequestHeaders} variables Fetcher variables.
- * @param {string} token Github token.
+ * @param {string} token GitHub token.
  * @returns {Promise<import('../common/types').StatsFetcherResponse>} Languages fetcher response.
  */
 const fetcher = (variables, token) => {
@@ -53,7 +53,7 @@ const fetcher = (variables, token) => {
 /**
  * Fetch top languages for a given username.
  *
- * @param {string} username Github username.
+ * @param {string} username GitHub username.
  * @param {string[]} exclude_repo List of repositories to exclude.
  * @returns {Promise<import("./types").TopLangData>} Top languages data.
  */

--- a/src/translations.js
+++ b/src/translations.js
@@ -37,7 +37,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       sk: `GitHub štatistiky používateľa ${encodedName}`,
       tr: `${encodedName} Hesabının GitHub Yıldızları`,
       pl: `Statystyki GitHub użytkownika ${encodedName}`,
-      uz: `${encodedName}ning Github'dagi statistikasi`,
+      uz: `${encodedName}ning GitHub'dagi statistikasi`,
       vi: `Thống Kê GitHub ${encodedName}`,
       se: `GitHubstatistik för ${encodedName}`,
     },


### PR DESCRIPTION
Just a quick commit to fix the capitalization of "GitHub" throughout the repo (mostly docs and comments).