### PR TITLE
ci: fix theme readme generation action

### DIFF
--- a/scripts/push-theme-readme.sh
+++ b/scripts/push-theme-readme.sh
@@ -9,6 +9,6 @@ git config --global user.name "GitHub Readme Stats Bot"
 git branch -d $BRANCH_NAME || true
 git checkout -b $BRANCH_NAME
 git add --all
-git commit --message "docs(theme): Auto update theme readme" || exit 0
+git commit --no-verify --message "docs(theme): Auto update theme readme"
 git remote add origin-$BRANCH_NAME https://${PERSONAL_TOKEN}@github.com/${GH_REPO}.git
 git push --force --quiet --set-upstream origin-$BRANCH_NAME $BRANCH_NAME


### PR DESCRIPTION
This PRs fixes an error in the [.github/workflows/generate-theme-doc.yml](https://github.com/anuraghazra/github-readme-stats/actions/runs/3505274321/jobs/5871478737) GitHub action which occurred because npm is not installed in the container that runs this action.

```bash
+ git commit --message 'docs(theme): Auto update theme readme'
.husky/pre-commit: 4: npm: not found
husky - pre-commit hook exited with code 127 (error)
husky - command not found in PATH=/usr/lib/git-core:/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ exit 0
```