### PR TITLE
fix: fix repoContrib confusion (#2269)

### DIFF
--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -154,7 +154,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     },
     contribs: {
       icon: icons.contribs,
-      label: i18n.t("statcard.contribs"),
+      label: i18n.t("statcard.contribs") + " (last year)",
       value: contributedTo,
       id: "contribs",
     },
@@ -186,7 +186,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
         index,
         showIcons: show_icons,
         shiftValuePos:
-          (!include_all_commits ? 50 : 35) + (isLongLocale ? 50 : 0),
+          (!include_all_commits ? 79.01 : 35) + (isLongLocale ? 50 : 0),
         bold: text_bold,
       }),
     );

--- a/tests/renderStatsCard.test.js
+++ b/tests/renderStatsCard.test.js
@@ -344,7 +344,7 @@ describe("Test renderStatsCard", () => {
       document.querySelector(
         'g[transform="translate(0, 100)"]>.stagger>.stat.bold',
       ).textContent,
-    ).toMatchInlineSnapshot(`"参与项目数:"`);
+    ).toMatchInlineSnapshot(`"参与项目数 (last year):"`);
   });
 
   it("should render without rounding", () => {


### PR DESCRIPTION
This commit prevents confusion about the Contributed to stat. Currently, only the last year's results are shown, but it looks like it is the all-time contribution count (see #2269). This commit adds a ' (last year)' suffix to prevent this confusion from happening.


#### Old card

[![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra)](https://github.com/anuraghazra/github-readme-stats)

```md
[![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra)](https://github.com/anuraghazra/github-readme-stats)
```

#### New card

[![Anurag's GitHub stats](https://github-readme-stats-git-fixrepo-7dd470-github-readme-stats-team.vercel.app/api?username=anuraghazra)](https://github.com/anuraghazra/github-readme-stats)

```md
[![Anurag's GitHub stats](https://github-readme-stats-git-fixrepo-7dd470-github-readme-stats-team.vercel.app/api?username=anuraghazra)](https://github.com/anuraghazra/github-readme-stats)
```
