### PR TITLE
feat: add INCLUDE_ORGS env variable

### DIFF
--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -77,7 +77,7 @@ const isValidHexColor = (hexColor) => {
 /**
  * Returns boolean if value is either "true" or "false" else the value as it is.
  *
- * @param {string | boolean} value The value to parse.
+ * @param {string | boolean| undefined} value The value to parse.
  * @returns {boolean | undefined } The parsed value.
  */
 const parseBoolean = (value) => {


### PR DESCRIPTION
This commit adds an INCLUDE_ORGS ENV variable that can be used to include results from organizations into the GRS cards for self-deployed Vercel instances. 

> **Warning**
> This is a hidden feature since we can not officially support this on the Public Vercel instance due to GraphQL and Vercel rate/timeout limits. You can set this env variable via Vercel's ENV variable menu (see https://vercel.com/docs/concepts/projects/environment-variables).
