### PR TITLE
feat: fix 'include_all_commits' inner card margin

### DIFF
--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -185,8 +185,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
         ...STATS[key],
         index,
         showIcons: show_icons,
-        shiftValuePos:
-          (!include_all_commits ? 79.01 : 35) + (isLongLocale ? 50 : 0),
+        shiftValuePos: 79.01 + (isLongLocale ? 50 : 0),
         bold: text_bold,
       }),
     );


### PR DESCRIPTION
This PR makes sure the inner card margin when `include_all_commits` is enabled is still correct now that #2274 was merged.