### PR TITLE
Add orange_github_dark theme

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -375,9 +375,9 @@ export const themes = {
     bg_color: "170F0C",
   },
   orange_github_dark: {
-    title_color: "F78E1AFF",
+    title_color: "D17918",
     text_color: "FFF",
-    icon_color: "F78E1AFF",
+    icon_color: "D17918",
     border_color: "FFF",
     bg_color: "0D1117",
   },

--- a/themes/index.js
+++ b/themes/index.js
@@ -374,6 +374,13 @@ export const themes = {
     border_color: "170F0C",
     bg_color: "170F0C",
   },
+  orange_github_dark: {
+    title_color: "F78E1AFF",
+    text_color: "FFF",
+    icon_color: "F78E1AFF",
+    border_color: "FFF",
+    bg_color: "0D1117",
+  },
 };
 
 export default themes;


### PR DESCRIPTION
The background color of Github dark theme and white, orange contrast for text and icons