### PR TITLE
add "@" to start of wakatime username if not present

### DIFF
--- a/src/fetchers/wakatime-fetcher.js
+++ b/src/fetchers/wakatime-fetcher.js
@@ -9,7 +9,10 @@ import { MissingParamError } from "../common/utils.js";
  */
 const fetchWakatimeStats = async ({ username, api_domain, range }) => {
   if (!username) throw new MissingParamError(["username"]);
-
+  
+  if (username[0] !== '@'){
+    username = '@' + username;
+  }
   try {
     const { data } = await axios.get(
       `https://${


### PR DESCRIPTION
This will make Wakatime fetch work even when username is not starting with `@` as mentioned in readme.