### PR TITLE
Custom Cards

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -48,23 +48,12 @@ export default async (req, res) => {
   }
 
   try {
-    const stats = {
-      totalStars: req.query.totalStars,
-      totalCommits: req.query.totalCommits,
-      totalIssues: req.query.totalIssues,
-      totalPRs: req.query.totalPRs,
-      contributedTo: req.query.contributedTo,
-      rank: {
-        level: req.query.level || 'S',
-        score: req.query.score || 10
-      },
-      starsTitle: req.query.starsTitle,
-      commitsTitle: req.query.commitsTitle,
-      issuesTitle: req.query.issuesTitle,
-      PRsTitle: req.query.PRsTitle,
-      contribsTitle: req.query.contribsTitle,
-      title: req.query.title,
-    };
+    const stats = await fetchStats(
+      username,
+      parseBoolean(count_private),
+      parseBoolean(include_all_commits),
+      parseArray(exclude_repo),
+    );
 
     const cacheSeconds = clampValue(
       parseInt(cache_seconds || CONSTANTS.FOUR_HOURS, 10),

--- a/api/index.js
+++ b/api/index.js
@@ -48,12 +48,20 @@ export default async (req, res) => {
   }
 
   try {
-    const stats = await fetchStats(
-      username,
-      parseBoolean(count_private),
-      parseBoolean(include_all_commits),
-      parseArray(exclude_repo),
-    );
+    const stats = {
+      req.query.totalStars,
+      req.query.totalCommits,
+      req.query.totalIssues,
+      req.query.totalPRs,
+      req.query.contributedTo,
+      req.query.rank,
+      req.query.starsTitle,
+      req.query.commitsTitle,
+      req.query.issuesTitle,
+      req.query.PRsTitle,
+      req.query.contribsTitle,
+      req.query.title,
+    };
 
     const cacheSeconds = clampValue(
       parseInt(cache_seconds || CONSTANTS.FOUR_HOURS, 10),

--- a/api/index.js
+++ b/api/index.js
@@ -49,19 +49,19 @@ export default async (req, res) => {
 
   try {
     const stats = {
-      req.query.totalStars,
-      req.query.totalCommits,
-      req.query.totalIssues,
-      req.query.totalPRs,
-      req.query.contributedTo,
-      req.query.rank,
-      req.query.starsTitle,
-      req.query.commitsTitle,
-      req.query.issuesTitle,
-      req.query.PRsTitle,
-      req.query.contribsTitle,
-      req.query.title,
-    };
+      totalStars,
+      totalCommits,
+      totalIssues,
+      totalPRs,
+      contributedTo,
+      rank,
+      starsTitle,
+      commitsTitle,
+      issuesTitle,
+      PRsTitle,
+      contribsTitle,
+      title,
+    } = req.query;
 
     const cacheSeconds = clampValue(
       parseInt(cache_seconds || CONSTANTS.FOUR_HOURS, 10),

--- a/api/index.js
+++ b/api/index.js
@@ -49,19 +49,19 @@ export default async (req, res) => {
 
   try {
     const stats = {
-      totalStars,
-      totalCommits,
-      totalIssues,
-      totalPRs,
-      contributedTo,
-      rank,
-      starsTitle,
-      commitsTitle,
-      issuesTitle,
-      PRsTitle,
-      contribsTitle,
-      title,
-    } = req.query;
+      totalStars: req.query.totalStars,
+      totalCommits: req.query.totalCommits,
+      totalIssues: req.query.totalIssues,
+      totalPRs: req.query.totalPRs,
+      contributedTo: req.query.contributedTo,
+      rank: req.query.rank,
+      starsTitle: req.query.starsTitle,
+      commitsTitle: req.query.commitsTitle,
+      issuesTitle: req.query.issuesTitle,
+      PRsTitle: req.query.PRsTitle,
+      contribsTitle: req.query.contribsTitle,
+      title: req.query.title,
+    };
 
     const cacheSeconds = clampValue(
       parseInt(cache_seconds || CONSTANTS.FOUR_HOURS, 10),

--- a/api/index.js
+++ b/api/index.js
@@ -55,8 +55,8 @@ export default async (req, res) => {
       totalPRs: req.query.totalPRs,
       contributedTo: req.query.contributedTo,
       rank: {
-        level: req.query.level,
-        score: req.query.score
+        level: req.query.level || 'S',
+        score: req.query.score || 10
       },
       starsTitle: req.query.starsTitle,
       commitsTitle: req.query.commitsTitle,

--- a/api/index.js
+++ b/api/index.js
@@ -54,7 +54,10 @@ export default async (req, res) => {
       totalIssues: req.query.totalIssues,
       totalPRs: req.query.totalPRs,
       contributedTo: req.query.contributedTo,
-      rank: req.query.rank,
+      rank: {
+        level: req.query.level,
+        score: req.query.score
+      },
       starsTitle: req.query.starsTitle,
       commitsTitle: req.query.commitsTitle,
       issuesTitle: req.query.issuesTitle,

--- a/api/wild/index.js
+++ b/api/wild/index.js
@@ -1,11 +1,11 @@
-import { renderStatsCard } from "../src/cards/stats-card.js";
+import { renderStatsCard } from "../../src/cards/stats-card.js";
 import {
   clampValue,
   CONSTANTS,
   parseArray,
   parseBoolean,
   renderError,
-} from "../src/common/utils.js";
+} from "../../src/common/utils.js";
 
 export default async (req, res) => {
   const {

--- a/api/wild/index.js
+++ b/api/wild/index.js
@@ -1,5 +1,4 @@
 import { renderStatsCard } from "../src/cards/stats-card.js";
-import { blacklist } from "../src/common/blacklist.js";
 import {
   clampValue,
   CONSTANTS,
@@ -7,20 +6,15 @@ import {
   parseBoolean,
   renderError,
 } from "../src/common/utils.js";
-import { fetchStats } from "../src/fetchers/stats-fetcher.js";
-import { isLocaleAvailable } from "../src/translations.js";
 
 export default async (req, res) => {
   const {
-    username,
     hide,
     hide_title,
     hide_border,
     card_width,
     hide_rank,
     show_icons,
-    count_private,
-    include_all_commits,
     line_height,
     title_color,
     ring_color,
@@ -30,22 +24,12 @@ export default async (req, res) => {
     bg_color,
     theme,
     cache_seconds,
-    exclude_repo,
     custom_title,
-    locale,
     disable_animations,
     border_radius,
     border_color,
   } = req.query;
   res.setHeader("Content-Type", "image/svg+xml");
-
-  if (blacklist.includes(username)) {
-    return res.send(renderError("Something went wrong"));
-  }
-
-  if (locale && !isLocaleAvailable(locale)) {
-    return res.send(renderError("Something went wrong", "Language not found"));
-  }
 
   try {
     const stats = {
@@ -87,7 +71,6 @@ export default async (req, res) => {
         hide_border: parseBoolean(hide_border),
         card_width: parseInt(card_width, 10),
         hide_rank: parseBoolean(hide_rank),
-        include_all_commits: parseBoolean(include_all_commits),
         line_height,
         title_color,
         ring_color,
@@ -99,7 +82,6 @@ export default async (req, res) => {
         custom_title,
         border_radius,
         border_color,
-        locale: locale ? locale.toLowerCase() : null,
         disable_animations: parseBoolean(disable_animations),
       }),
     );

--- a/api/wild/index.js
+++ b/api/wild/index.js
@@ -1,0 +1,110 @@
+import { renderStatsCard } from "../src/cards/stats-card.js";
+import { blacklist } from "../src/common/blacklist.js";
+import {
+  clampValue,
+  CONSTANTS,
+  parseArray,
+  parseBoolean,
+  renderError,
+} from "../src/common/utils.js";
+import { fetchStats } from "../src/fetchers/stats-fetcher.js";
+import { isLocaleAvailable } from "../src/translations.js";
+
+export default async (req, res) => {
+  const {
+    username,
+    hide,
+    hide_title,
+    hide_border,
+    card_width,
+    hide_rank,
+    show_icons,
+    count_private,
+    include_all_commits,
+    line_height,
+    title_color,
+    ring_color,
+    icon_color,
+    text_color,
+    text_bold,
+    bg_color,
+    theme,
+    cache_seconds,
+    exclude_repo,
+    custom_title,
+    locale,
+    disable_animations,
+    border_radius,
+    border_color,
+  } = req.query;
+  res.setHeader("Content-Type", "image/svg+xml");
+
+  if (blacklist.includes(username)) {
+    return res.send(renderError("Something went wrong"));
+  }
+
+  if (locale && !isLocaleAvailable(locale)) {
+    return res.send(renderError("Something went wrong", "Language not found"));
+  }
+
+  try {
+    const stats = {
+      totalStars: req.query.totalStars,
+      totalCommits: req.query.totalCommits,
+      totalIssues: req.query.totalIssues,
+      totalPRs: req.query.totalPRs,
+      contributedTo: req.query.contributedTo,
+      rank: {
+        level: req.query.level || 'S',
+        score: req.query.score || 10
+      },
+      starsTitle: req.query.starsTitle,
+      commitsTitle: req.query.commitsTitle,
+      issuesTitle: req.query.issuesTitle,
+      PRsTitle: req.query.PRsTitle,
+      contribsTitle: req.query.contribsTitle,
+      title: req.query.title,
+    };
+
+    const cacheSeconds = clampValue(
+      parseInt(cache_seconds || CONSTANTS.FOUR_HOURS, 10),
+      CONSTANTS.FOUR_HOURS,
+      CONSTANTS.ONE_DAY,
+    );
+
+    res.setHeader(
+      "Cache-Control",
+      `max-age=${
+        cacheSeconds / 2
+      }, s-maxage=${cacheSeconds}, stale-while-revalidate=${CONSTANTS.ONE_DAY}`,
+    );
+
+    return res.send(
+      renderStatsCard(stats, {
+        hide: parseArray(hide),
+        show_icons: parseBoolean(show_icons),
+        hide_title: parseBoolean(hide_title),
+        hide_border: parseBoolean(hide_border),
+        card_width: parseInt(card_width, 10),
+        hide_rank: parseBoolean(hide_rank),
+        include_all_commits: parseBoolean(include_all_commits),
+        line_height,
+        title_color,
+        ring_color,
+        icon_color,
+        text_color,
+        text_bold: parseBoolean(text_bold),
+        bg_color,
+        theme,
+        custom_title,
+        border_radius,
+        border_color,
+        locale: locale ? locale.toLowerCase() : null,
+        disable_animations: parseBoolean(disable_animations),
+      }),
+    );
+  } catch (err) {
+    res.setHeader("Cache-Control", `no-cache, no-store, must-revalidate`); // Don't cache error responses.
+    return res.send(renderError(err.message, err.secondaryMessage));
+  }
+};

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -77,12 +77,15 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     totalIssues = "203",
     totalPRs = "127",
     contributedTo = "232",
-    rank = "S",
-    starsTitle = "Total Stars:",
-    commitsTitle = "Total Commits:",
-    issuesTitle = "Total Issues:",
-    PRsTitle = "Total PRs:",
-    contribsTitle = "Total Contributions:",
+    rank = {
+      level: "S",
+      score: 90
+    },
+    starsTitle = "Total Stars",
+    commitsTitle = "Total Commits",
+    issuesTitle = "Total Issues",
+    PRsTitle = "Total PRs",
+    contribsTitle = "Total Contributions",
     title = "Your GitHub Stats",
   } = stats;
   const {

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -79,7 +79,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     contributedTo = "232",
     rank = {
       level: "S",
-      score: 90
+      score: 10
     },
     starsTitle = "Total Stars",
     commitsTitle = "Total Commits",

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -76,26 +76,6 @@ const createTextNode = ({
  */
 const renderStatsCard = (stats = {}, options = { hide: [] }) => {
   const {
-    name = "GitHub User",
-    totalStars = "2018",
-    totalCommits = "29019",
-    totalIssues = "203",
-    totalPRs = "127",
-    contributedTo = "232",
-    rank = {
-      level: "S",
-      score: 10
-    },
-    starsTitle = i18n.t("statcard.totalstars"),
-    commitsTitle = `${i18n.t("statcard.commits")}${
-        include_all_commits ? "" : ` (${new Date().getFullYear()})`
-      }`,
-    issuesTitle = i18n.t("statcard.issues"),
-    PRsTitle = i18n.t("statcard.prs"),
-    contribsTitle = i18n.t("statcard.contribs") + " (last year)",
-    title = i18n.t("statcard.title"),
-  } = stats;
-  const {
     hide = [],
     show_icons = false,
     hide_title = false,
@@ -117,6 +97,26 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     locale,
     disable_animations = false,
   } = options;
+  const {
+    name = "GitHub User",
+    totalStars = "2018",
+    totalCommits = "29019",
+    totalIssues = "203",
+    totalPRs = "127",
+    contributedTo = "232",
+    rank = {
+      level: "S",
+      score: 10
+    },
+    starsTitle = i18n.t("statcard.totalstars"),
+    commitsTitle = `${i18n.t("statcard.commits")}${
+        include_all_commits ? "" : ` (${new Date().getFullYear()})`
+      }`,
+    issuesTitle = i18n.t("statcard.issues"),
+    PRsTitle = i18n.t("statcard.prs"),
+    contribsTitle = i18n.t("statcard.contribs") + " (last year)",
+    title = i18n.t("statcard.title"),
+  } = stats;
 
   const lheight = parseInt(String(line_height), 10);
 

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -36,10 +36,10 @@ const createTextNode = ({
   bold,
 }) => {
   let kValue
-  if(isNaN(value)){
-    kValue = value
+  if (isNaN(value)) {
+    kValue = value;
   } else {
-    kValue = kFormatter(value)
+    kValue = kFormatter(value);
   }
   const staggerDelay = (index + 3) * 150;
 
@@ -86,12 +86,14 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
       level: "S",
       score: 10
     },
-    starsTitle = "Total Stars",
-    commitsTitle = "Total Commits",
-    issuesTitle = "Total Issues",
-    PRsTitle = "Total PRs",
-    contribsTitle = "Total Contributions",
-    title = "Your GitHub Stats",
+    starsTitle = i18n.t("statcard.totalstars"),
+    commitsTitle = `${i18n.t("statcard.commits")}${
+        include_all_commits ? "" : ` (${new Date().getFullYear()})`
+      }`,
+    issuesTitle = i18n.t("statcard.issues"),
+    PRsTitle = i18n.t("statcard.prs"),
+    contribsTitle = i18n.t("statcard.contribs") + " (last year)",
+    title = i18n.t("statcard.title"),
   } = stats;
   const {
     hide = [],
@@ -222,7 +224,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
   });
 
   const calculateTextWidth = () => {
-    return measureText(title);
+    return measureText(custom_title ? custom_title : title);
   };
 
   /*
@@ -304,9 +306,6 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
   const labels = Object.keys(STATS)
     .filter((key) => !hide.includes(key))
     .map((key) => {
-      if (key === "commits") {
-        return commitsTitle;
-      }
       return `${STATS[key].label}: ${STATS[key].value}`;
     })
     .join(", ");

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -35,7 +35,12 @@ const createTextNode = ({
   shiftValuePos,
   bold,
 }) => {
-  const kValue = kFormatter(value);
+  let kValue
+  if(isNaN(value)){
+    kValue = value
+  } else {
+    kValue = kFormatter(value)
+  }
   const staggerDelay = (index + 3) * 150;
 
   const labelOffset = showIcons ? `x="25"` : "";

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -78,6 +78,12 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     totalPRs,
     contributedTo,
     rank,
+    starsTitle,
+    commitsTitle,
+    issuesTitle,
+    PRsTitle,
+    contribsTitle,
+    title,
   } = stats;
   const {
     hide = [],
@@ -128,33 +134,31 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
   const STATS = {
     stars: {
       icon: icons.star,
-      label: i18n.t("statcard.totalstars"),
+      label: starsTitle,
       value: totalStars,
       id: "stars",
     },
     commits: {
       icon: icons.commits,
-      label: `${i18n.t("statcard.commits")}${
-        include_all_commits ? "" : ` (${new Date().getFullYear()})`
-      }`,
+      label: commitsTitle,
       value: totalCommits,
       id: "commits",
     },
     prs: {
       icon: icons.prs,
-      label: i18n.t("statcard.prs"),
+      label: PRsTitle,
       value: totalPRs,
       id: "prs",
     },
     issues: {
       icon: icons.issues,
-      label: i18n.t("statcard.issues"),
+      label: issuesTitle,
       value: totalIssues,
       id: "issues",
     },
     contribs: {
       icon: icons.contribs,
-      label: i18n.t("statcard.contribs") + " (last year)",
+      label: contribsTitle,
       value: contributedTo,
       id: "contribs",
     },
@@ -210,7 +214,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
   });
 
   const calculateTextWidth = () => {
-    return measureText(custom_title ? custom_title : i18n.t("statcard.title"));
+    return measureText(title);
   };
 
   /*
@@ -230,7 +234,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
 
   const card = new Card({
     customTitle: custom_title,
-    defaultTitle: i18n.t("statcard.title"),
+    defaultTitle: title,
     width,
     height,
     border_radius,
@@ -293,9 +297,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     .filter((key) => !hide.includes(key))
     .map((key) => {
       if (key === "commits") {
-        return `${i18n.t("statcard.commits")} ${
-          include_all_commits ? "" : `in ${new Date().getFullYear()}`
-        } : ${totalStars}`;
+        return commitsTitle;
       }
       return `${STATS[key].label}: ${STATS[key].value}`;
     })

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -98,7 +98,7 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     disable_animations = false,
   } = options;
   
-  const name = stats.name || "GitHub User",
+  const name = stats.name || "GitHub User"
   
   const apostrophe = ["x", "s"].includes(name.slice(-1).toLocaleLowerCase())
     ? ""

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -97,8 +97,19 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     locale,
     disable_animations = false,
   } = options;
+  
+  const name = stats.name || "GitHub User",
+  
+  const apostrophe = ["x", "s"].includes(name.slice(-1).toLocaleLowerCase())
+    ? ""
+    : "s";
+  
+  const i18n = new I18n({
+    locale,
+    translations: statCardLocales({ name, apostrophe }),
+  });
+  
   const {
-    name = "GitHub User",
     totalStars = "2018",
     totalCommits = "29019",
     totalIssues = "203",
@@ -131,14 +142,6 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
       ring_color,
       theme,
     });
-
-  const apostrophe = ["x", "s"].includes(name.slice(-1).toLocaleLowerCase())
-    ? ""
-    : "s";
-  const i18n = new I18n({
-    locale,
-    translations: statCardLocales({ name, apostrophe }),
-  });
 
   // Meta data for creating text nodes with createTextNode function
   const STATS = {

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -71,19 +71,19 @@ const createTextNode = ({
  */
 const renderStatsCard = (stats = {}, options = { hide: [] }) => {
   const {
-    name,
-    totalStars,
-    totalCommits,
-    totalIssues,
-    totalPRs,
-    contributedTo,
-    rank,
-    starsTitle,
-    commitsTitle,
-    issuesTitle,
-    PRsTitle,
-    contribsTitle,
-    title,
+    name = "GitHub User",
+    totalStars = "2018",
+    totalCommits = "29019",
+    totalIssues = "203",
+    totalPRs = "127",
+    contributedTo = "232",
+    rank = "S",
+    starsTitle = "Total Stars:",
+    commitsTitle = "Total Commits:",
+    issuesTitle = "Total Issues:",
+    PRsTitle = "Total PRs:",
+    contribsTitle = "Total Contributions:",
+    title = "Your GitHub Stats",
   } = stats;
   const {
     hide = [],

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "functions": {
     "api/*.js": {
       "memory": 128,
-      "maxDuration": 30
+      "maxDuration": 10
     }
   },
   "redirects": [


### PR DESCRIPTION
# Custom Cards
![wild](https://user-images.githubusercontent.com/62234360/212464498-22fc8738-8ad9-4bf7-b0bb-6366f32920ef.svg)

This PR adds an option to generate custom cards in addition to the GitHub Stats cards. Right now only stats can be generated, but options will be soon added for lanaguage/wakatime and repo cards!

## API Usage
Main endpoint is `https://{VERCEL_URL}/api/wild`. The following options aren't used:
- `username`
- `exclude_repo`
- `locale`
- `count_private`
- `include_all_commits`

In addition, the following new options are added (through query params):
- `totalStars`
- `totalCommits`
- `totalPRs`
- `totalIssues`
- `contributedTo`
- `level` (for rank level)
- `score` (for rank score)
- `starsTitle`
- `commitsTitle`
- `issuesTitle`
- `PRsTitle`
- `contribsTitle`
- `title` (main title)

All added options are optional (default to normal titles and random values), and all previous options are required as was previously.

You may use the `https://github-readme-stats.zohan.tech` deployment to test this PR, but it will constantly be updated as I make changes (so may have errors at some point).

## Changelog
- `./vercel.json` - Changed `maxDuration`; ignore for now (used for testing), will revert before PR is published.
- `./src/cards/stats-card.js`
  - Restructured `kFormatter` to allow `NaN` values too
  - Replaced i18n titles with generic ones and added title as parameters for the `renderStatsCard()` function
  - Replaced specific logic for commits (line 295 old 311 new) with generic logic that is used for all other lines (didn't understand why this was needed - see #2407)
- Added `./api/wild/index.js` - Adds an API endpoint for custom cards like shown above

## To Do
- [ ] Add other card types like language/wakatime and repo cards
- [ ] Add updates to README
- [ ] Add tests
- [ ] Ensure that changing `renderStatsCard()` doesn't affect anything else (other tests, etc)