### PR TITLE
Vercel maxDuration fix + GH Actions workflow for Vercel deployment

### DIFF
--- a/.github/workflows/deploy-prep.py
+++ b/.github/workflows/deploy-prep.py
@@ -1,0 +1,10 @@
+import os
+
+file = open('./vercel.json', 'r')
+str = file.read()
+file = open('./vercel.json', 'w')
+
+str = str.replace('"maxDuration": 10', '"maxDuration": 30')
+
+file.write(str)
+file.close()

--- a/.github/workflows/deploy-prep.yml
+++ b/.github/workflows/deploy-prep.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   config:
-    if: github.repository == ‘anuraghazra/github-readme-stats’
+    if: github.repository == 'anuraghazra/github-readme-stats'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy-prep.yml
+++ b/.github/workflows/deploy-prep.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set theme
+      - name: Deployment Prep
         run: python ./.github/workflows/deploy-prep.py
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:

--- a/.github/workflows/deploy-prep.yml
+++ b/.github/workflows/deploy-prep.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   config:
+    if: github.repository == ‘anuraghazra/github-readme-stats’
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/deploy-prep.yml
+++ b/.github/workflows/deploy-prep.yml
@@ -16,4 +16,4 @@ jobs:
         with:
           branch: vercel
           create_branch: true
-          push_options: '--force'
+          push_options: "--force"

--- a/.github/workflows/deploy-prep.yml
+++ b/.github/workflows/deploy-prep.yml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   config:

--- a/.github/workflows/deploy-prep.yml
+++ b/.github/workflows/deploy-prep.yml
@@ -1,0 +1,19 @@
+name: Deployment Prep
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  config:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set theme
+        run: python ./.github/workflows/deploy-prep.py
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: vercel
+          create_branch: true
+          push_options: '--force'

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "functions": {
     "api/*.js": {
       "memory": 128,
-      "maxDuration": 30
+      "maxDuration": 10
     }
   },
   "redirects": [

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "functions": {
     "api/*.js": {
       "memory": 128,
-      "maxDuration": 10
+      "maxDuration": 30
     }
   },
   "redirects": [


### PR DESCRIPTION
Changed default `maxDuration` to `10` so that users can easily fork and deploy to Vercel.

Also added a GH Actions workflow that changes `maxDuration` to `30` so that @anuraghazra can still have 30 for his deployment.

@anuraghazra after merging you have to change Vercel deployment branch from `master` to `vercel`.