### PR TITLE
ci: prevent certain actions from running on forks

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -5,6 +5,7 @@ on:
 jobs:
   e2eTests:
     if:
+      github.repository == 'anuraghazra/github-readme-stats' &&
       github.event_name == 'deployment_status' &&
       github.event.deployment_status.state == 'success'
     name: Perform 2e2 tests

--- a/.github/workflows/empty-issues-closer.yaml
+++ b/.github/workflows/empty-issues-closer.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   closeEmptyIssuesAndTemplates:
+    if: github.repository == 'anuraghazra/github-readme-stats'
     name: Close empty issues
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -4,6 +4,7 @@ on:
 
 jobs:
   triage:
+    if: github.repository == 'anuraghazra/github-readme-stats'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v4

--- a/.github/workflows/stale-theme-pr-closer.yaml
+++ b/.github/workflows/stale-theme-pr-closer.yaml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   closeOldThemePrs:
+    if: github.repository == 'anuraghazra/github-readme-stats'
     name: Close stale 'invalid' theme PRs
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/top-issues-dashboard.yml
+++ b/.github/workflows/top-issues-dashboard.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   showAndLabelTopIssues:
+    if: github.repository == 'anuraghazra/github-readme-stats'
     name: Update top issues Dashboard.
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Prevent some actions from running on forks since they are not needed. I left the theme preview/doc, test and e2e actions enabled, as they might be people in development. We can also disable the e2e action if you think it is unnecessary (see https://github.com/anuraghazra/github-readme-stats/issues/2465).