### PR TITLE
GRS as an npm module!

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npm test
 npx lint-staged

--- a/api/index.js
+++ b/api/index.js
@@ -1,4 +1,4 @@
-import { generateStatsCard } from "../src/generators/stats-card.js";
+import generateStatsCard from "../src/generators/stats-card.js";
 import { renderError } from "../src/common/utils.js";
 
 export default async (req, res) => {

--- a/api/index.js
+++ b/api/index.js
@@ -1,14 +1,5 @@
-import { renderStatsCard } from "../src/cards/stats-card.js";
-import { blacklist } from "../src/common/blacklist.js";
-import {
-  clampValue,
-  CONSTANTS,
-  parseArray,
-  parseBoolean,
-  renderError,
-} from "../src/common/utils.js";
-import { fetchStats } from "../src/fetchers/stats-fetcher.js";
-import { isLocaleAvailable } from "../src/translations.js";
+import { generateStatsCard } from "../src/generators/stats-card.js";
+import { renderError } from "../src/common/utils.js";
 
 export default async (req, res) => {
   const {
@@ -39,22 +30,7 @@ export default async (req, res) => {
   } = req.query;
   res.setHeader("Content-Type", "image/svg+xml");
 
-  if (blacklist.includes(username)) {
-    return res.send(renderError("Something went wrong"));
-  }
-
-  if (locale && !isLocaleAvailable(locale)) {
-    return res.send(renderError("Something went wrong", "Language not found"));
-  }
-
   try {
-    const stats = await fetchStats(
-      username,
-      parseBoolean(count_private),
-      parseBoolean(include_all_commits),
-      parseArray(exclude_repo),
-    );
-
     const cacheSeconds = clampValue(
       parseInt(cache_seconds || CONSTANTS.FOUR_HOURS, 10),
       CONSTANTS.FOUR_HOURS,
@@ -68,30 +44,33 @@ export default async (req, res) => {
       }, s-maxage=${cacheSeconds}, stale-while-revalidate=${CONSTANTS.ONE_DAY}`,
     );
 
-    return res.send(
-      renderStatsCard(stats, {
-        hide: parseArray(hide),
-        show_icons: parseBoolean(show_icons),
-        hide_title: parseBoolean(hide_title),
-        hide_border: parseBoolean(hide_border),
-        card_width: parseInt(card_width, 10),
-        hide_rank: parseBoolean(hide_rank),
-        include_all_commits: parseBoolean(include_all_commits),
-        line_height,
-        title_color,
-        ring_color,
-        icon_color,
-        text_color,
-        text_bold: parseBoolean(text_bold),
-        bg_color,
-        theme,
-        custom_title,
-        border_radius,
-        border_color,
-        locale: locale ? locale.toLowerCase() : null,
-        disable_animations: parseBoolean(disable_animations),
-      }),
-    );
+    const card = await generateStatsCard({
+      username,
+      hide,
+      hide_title,
+      hide_border,
+      card_width,
+      hide_rank,
+      show_icons,
+      count_private,
+      include_all_commits,
+      line_height,
+      title_color,
+      ring_color,
+      icon_color,
+      text_color,
+      text_bold,
+      bg_color,
+      theme,
+      exclude_repo,
+      custom_title,
+      locale,
+      disable_animations,
+      border_radius,
+      border_color,
+    });
+
+    return res.send(card);
   } catch (err) {
     res.setHeader("Cache-Control", `no-cache, no-store, must-revalidate`); // Don't cache error responses.
     return res.send(renderError(err.message, err.secondaryMessage));

--- a/api/pin.js
+++ b/api/pin.js
@@ -1,4 +1,4 @@
-import { generateRepoCard } from "../src/generators/repo.js";
+import generateRepoCard from "../src/generators/repo.js";
 import { renderError } from "../src/common/utils.js";
 
 export default async (req, res) => {

--- a/api/pin.js
+++ b/api/pin.js
@@ -1,13 +1,5 @@
-import { renderRepoCard } from "../src/cards/repo-card.js";
-import { blacklist } from "../src/common/blacklist.js";
-import {
-  clampValue,
-  CONSTANTS,
-  parseBoolean,
-  renderError,
-} from "../src/common/utils.js";
-import { fetchRepo } from "../src/fetchers/repo-fetcher.js";
-import { isLocaleAvailable } from "../src/translations.js";
+import { generateRepoCard } from "../src/generators/repo.js";
+import { renderError } from "../src/common/utils.js";
 
 export default async (req, res) => {
   const {
@@ -28,35 +20,12 @@ export default async (req, res) => {
 
   res.setHeader("Content-Type", "image/svg+xml");
 
-  if (blacklist.includes(username)) {
-    return res.send(renderError("Something went wrong"));
-  }
-
-  if (locale && !isLocaleAvailable(locale)) {
-    return res.send(renderError("Something went wrong", "Language not found"));
-  }
-
   try {
-    const repoData = await fetchRepo(username, repo);
-
     let cacheSeconds = clampValue(
       parseInt(cache_seconds || CONSTANTS.FOUR_HOURS, 10),
       CONSTANTS.FOUR_HOURS,
       CONSTANTS.ONE_DAY,
     );
-
-    /*
-      if star count & fork count is over 1k then we are kFormating the text
-      and if both are zero we are not showing the stats
-      so we can just make the cache longer, since there is no need to frequent updates
-    */
-    const stars = repoData.starCount;
-    const forks = repoData.forkCount;
-    const isBothOver1K = stars > 1000 && forks > 1000;
-    const isBothUnder1 = stars < 1 && forks < 1;
-    if (!cache_seconds && (isBothOver1K || isBothUnder1)) {
-      cacheSeconds = CONSTANTS.FOUR_HOURS;
-    }
 
     res.setHeader(
       "Cache-Control",
@@ -65,20 +34,22 @@ export default async (req, res) => {
       }, s-maxage=${cacheSeconds}, stale-while-revalidate=${CONSTANTS.ONE_DAY}`,
     );
 
-    return res.send(
-      renderRepoCard(repoData, {
-        hide_border: parseBoolean(hide_border),
-        title_color,
-        icon_color,
-        text_color,
-        bg_color,
-        theme,
-        border_radius,
-        border_color,
-        show_owner: parseBoolean(show_owner),
-        locale: locale ? locale.toLowerCase() : null,
-      }),
-    );
+    const card = await generateRepoCard({
+      username,
+      repo,
+      hide_border,
+      title_color,
+      icon_color,
+      text_color,
+      bg_color,
+      theme,
+      show_owner,
+      locale,
+      border_radius,
+      border_color,
+    });
+
+    return res.send(card);
   } catch (err) {
     res.setHeader("Cache-Control", `no-cache, no-store, must-revalidate`); // Don't cache error responses.
     return res.send(renderError(err.message, err.secondaryMessage));

--- a/api/top-langs.js
+++ b/api/top-langs.js
@@ -1,14 +1,5 @@
-import { renderTopLanguages } from "../src/cards/top-languages-card.js";
-import { blacklist } from "../src/common/blacklist.js";
-import {
-  clampValue,
-  CONSTANTS,
-  parseArray,
-  parseBoolean,
-  renderError,
-} from "../src/common/utils.js";
-import { fetchTopLanguages } from "../src/fetchers/top-languages-fetcher.js";
-import { isLocaleAvailable } from "../src/translations.js";
+import { generateTopLanguagesCard } from "../src/generators/top-langs.js";
+import { renderError } from "../src/common/utils.js";
 
 export default async (req, res) => {
   const {
@@ -33,20 +24,7 @@ export default async (req, res) => {
   } = req.query;
   res.setHeader("Content-Type", "image/svg+xml");
 
-  if (blacklist.includes(username)) {
-    return res.send(renderError("Something went wrong"));
-  }
-
-  if (locale && !isLocaleAvailable(locale)) {
-    return res.send(renderError("Something went wrong", "Locale not found"));
-  }
-
   try {
-    const topLangs = await fetchTopLanguages(
-      username,
-      parseArray(exclude_repo),
-    );
-
     const cacheSeconds = clampValue(
       parseInt(cache_seconds || CONSTANTS.FOUR_HOURS, 10),
       CONSTANTS.FOUR_HOURS,
@@ -60,25 +38,27 @@ export default async (req, res) => {
       }, s-maxage=${cacheSeconds}, stale-while-revalidate=${CONSTANTS.ONE_DAY}`,
     );
 
-    return res.send(
-      renderTopLanguages(topLangs, {
-        custom_title,
-        hide_title: parseBoolean(hide_title),
-        hide_border: parseBoolean(hide_border),
-        card_width: parseInt(card_width, 10),
-        hide: parseArray(hide),
-        title_color,
-        text_color,
-        bg_color,
-        theme,
-        layout,
-        langs_count,
-        border_radius,
-        border_color,
-        locale: locale ? locale.toLowerCase() : null,
-        disable_animations: parseBoolean(disable_animations),
-      }),
-    );
+    const card = await generateTopLanguagesCard({
+      username,
+      hide,
+      hide_title,
+      hide_border,
+      card_width,
+      title_color,
+      text_color,
+      bg_color,
+      theme,
+      layout,
+      langs_count,
+      exclude_repo,
+      custom_title,
+      locale,
+      border_radius,
+      border_color,
+      disable_animations,
+    });
+
+    return res.send(card);
   } catch (err) {
     res.setHeader("Cache-Control", `no-cache, no-store, must-revalidate`); // Don't cache error responses.
     return res.send(renderError(err.message, err.secondaryMessage));

--- a/api/top-langs.js
+++ b/api/top-langs.js
@@ -1,4 +1,4 @@
-import { generateTopLanguagesCard } from "../src/generators/top-langs.js";
+import generateTopLanguagesCard from "../src/generators/top-langs.js";
 import { renderError } from "../src/common/utils.js";
 
 export default async (req, res) => {

--- a/api/wakatime.js
+++ b/api/wakatime.js
@@ -1,4 +1,4 @@
-import { generateWakatimeCard } from "../src/generators/wakatime.js";
+import generateWakatimeCard from "../src/generators/wakatime.js";
 import { renderError } from "../src/common/utils.js";
 
 export default async (req, res) => {

--- a/api/wakatime.js
+++ b/api/wakatime.js
@@ -1,13 +1,5 @@
-import { renderWakatimeCard } from "../src/cards/wakatime-card.js";
-import {
-  clampValue,
-  CONSTANTS,
-  parseArray,
-  parseBoolean,
-  renderError,
-} from "../src/common/utils.js";
-import { fetchWakatimeStats } from "../src/fetchers/wakatime-fetcher.js";
-import { isLocaleAvailable } from "../src/translations.js";
+import { generateWakatimeCard } from "../src/generators/wakatime.js";
+import { renderError } from "../src/common/utils.js";
 
 export default async (req, res) => {
   const {
@@ -35,13 +27,7 @@ export default async (req, res) => {
 
   res.setHeader("Content-Type", "image/svg+xml");
 
-  if (locale && !isLocaleAvailable(locale)) {
-    return res.send(renderError("Something went wrong", "Language not found"));
-  }
-
   try {
-    const stats = await fetchWakatimeStats({ username, api_domain, range });
-
     let cacheSeconds = clampValue(
       parseInt(cache_seconds || CONSTANTS.FOUR_HOURS, 10),
       CONSTANTS.FOUR_HOURS,
@@ -59,26 +45,29 @@ export default async (req, res) => {
       }, s-maxage=${cacheSeconds}, stale-while-revalidate=${CONSTANTS.ONE_DAY}`,
     );
 
-    return res.send(
-      renderWakatimeCard(stats, {
-        custom_title,
-        hide_title: parseBoolean(hide_title),
-        hide_border: parseBoolean(hide_border),
-        hide: parseArray(hide),
-        line_height,
-        title_color,
-        icon_color,
-        text_color,
-        bg_color,
-        theme,
-        hide_progress,
-        border_radius,
-        border_color,
-        locale: locale ? locale.toLowerCase() : null,
-        layout,
-        langs_count,
-      }),
-    );
+    const card = await generateWakatimeCard({
+      username,
+      title_color,
+      icon_color,
+      hide_border,
+      line_height,
+      text_color,
+      bg_color,
+      theme,
+      hide_title,
+      hide_progress,
+      custom_title,
+      locale,
+      layout,
+      langs_count,
+      hide,
+      api_domain,
+      range,
+      border_radius,
+      border_color,
+    });
+
+    return res.send(card);
   } catch (err) {
     res.setHeader("Cache-Control", `no-cache, no-store, must-revalidate`); // Don't cache error responses.
     return res.send(renderError(err.message, err.secondaryMessage));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "github-readme-stats",
+  "name": "@zo-bro-23/github-readme-stats",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "github-readme-stats",
+      "name": "@zo-bro-23/github-readme-stats",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
@@ -25,7 +25,7 @@
         "axios-mock-adapter": "^1.18.1",
         "color-contrast-checker": "^2.1.0",
         "hjson": "^3.2.2",
-        "husky": "^8.0.0",
+        "husky": "^8.0.3",
         "jest": "^29.0.3",
         "jest-environment-jsdom": "^29.0.3",
         "js-yaml": "^4.1.0",
@@ -2693,9 +2693,9 @@
       }
     },
     "node_modules/husky": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
-      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
       "dev": true,
       "bin": {
         "husky": "lib/bin.js"
@@ -7722,9 +7722,9 @@
       "dev": true
     },
     "husky": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
-      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
+      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
       "dev": true
     },
     "iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "github-readme-stats",
-  "version": "1.0.0",
+  "name": "@zo-bro-23/github-readme-stats-test",
+  "version": "1.0.5",
   "description": "Dynamically generate stats for your GitHub readme",
   "keywords": [
     "github-readme-stats",
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/anuraghazra/github-readme-stats.git"
+    "url": "git+https://github.com/anuraghazra/github-readme-stats.git"
   },
   "scripts": {
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js --coverage",
@@ -42,7 +42,7 @@
     "axios-mock-adapter": "^1.18.1",
     "color-contrast-checker": "^2.1.0",
     "hjson": "^3.2.2",
-    "husky": "^8.0.0",
+    "husky": "^8.0.3",
     "jest": "^29.0.3",
     "jest-environment-jsdom": "^29.0.3",
     "js-yaml": "^4.1.0",
@@ -61,5 +61,12 @@
   },
   "lint-staged": {
     "*.{js,css,md}": "prettier --write"
+  },
+  "directories": {
+    "doc": "docs",
+    "test": "tests"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/src/common/blacklist.js
+++ b/src/common/blacklist.js
@@ -1,4 +1,9 @@
-const blacklist = ["renovate-bot", "technote-space", "sw-yx"];
+const blacklist = [
+  "renovate-bot",
+  "technote-space",
+  "sw-yx",
+  "blacklistedUser", // For testing purposes
+];
 
 export { blacklist };
 export default blacklist;

--- a/src/generators/index.js
+++ b/src/generators/index.js
@@ -1,0 +1,4 @@
+export { default as generateStatsCard } from "./stats.js";
+export { default as generateTopLanguagesCard } from "./top-langs.js";
+export { default as generateWakatimeCard } from "./wakatime.js";
+export { default as generateRepoCard } from "./repo.js";

--- a/src/generators/repo.js
+++ b/src/generators/repo.js
@@ -1,0 +1,54 @@
+import { renderRepoCard } from "../cards/repo-card.js";
+import { blacklist } from "../common/blacklist.js";
+import {
+  clampValue,
+  CONSTANTS,
+  parseBoolean,
+  renderError,
+} from "../common/utils.js";
+import { fetchRepo } from "../fetchers/repo-fetcher.js";
+import { isLocaleAvailable } from "../translations.js";
+
+export default async (options) => {
+  const {
+    username,
+    repo,
+    hide_border,
+    title_color,
+    icon_color,
+    text_color,
+    bg_color,
+    theme,
+    show_owner,
+    locale,
+    border_radius,
+    border_color,
+  } = options;
+
+  if (blacklist.includes(username)) {
+    return renderError("Something went wrong");
+  }
+
+  if (locale && !isLocaleAvailable(locale)) {
+    return renderError("Something went wrong", "Language not found");
+  }
+
+  try {
+    const repoData = await fetchRepo(username, repo);
+
+    return renderRepoCard(repoData, {
+      hide_border: parseBoolean(hide_border),
+      title_color,
+      icon_color,
+      text_color,
+      bg_color,
+      theme,
+      border_radius,
+      border_color,
+      show_owner: parseBoolean(show_owner),
+      locale: locale ? locale.toLowerCase() : null,
+    });
+  } catch (err) {
+    return renderError(err.message, err.secondaryMessage);
+  }
+};

--- a/src/generators/stats.js
+++ b/src/generators/stats.js
@@ -1,0 +1,75 @@
+import { renderStatsCard } from "../cards/stats-card.js";
+import { blacklist } from "../common/blacklist.js";
+import { parseArray, parseBoolean, renderError } from "../common/utils.js";
+import { fetchStats } from "../fetchers/stats-fetcher.js";
+import { isLocaleAvailable } from "../translations.js";
+
+export default async (options) => {
+  const {
+    username,
+    hide,
+    hide_title,
+    hide_border,
+    card_width,
+    hide_rank,
+    show_icons,
+    count_private,
+    include_all_commits,
+    line_height,
+    title_color,
+    ring_color,
+    icon_color,
+    text_color,
+    text_bold,
+    bg_color,
+    theme,
+    exclude_repo,
+    custom_title,
+    locale,
+    disable_animations,
+    border_radius,
+    border_color,
+  } = options;
+
+  if (blacklist.includes(username)) {
+    return renderError("Something went wrong");
+  }
+
+  if (locale && !isLocaleAvailable(locale)) {
+    return renderError("Something went wrong", "Language not found");
+  }
+
+  try {
+    const stats = await fetchStats(
+      username,
+      parseBoolean(count_private),
+      parseBoolean(include_all_commits),
+      parseArray(exclude_repo),
+    );
+
+    return renderStatsCard(stats, {
+      hide: parseArray(hide),
+      show_icons: parseBoolean(show_icons),
+      hide_title: parseBoolean(hide_title),
+      hide_border: parseBoolean(hide_border),
+      card_width: parseInt(card_width, 10),
+      hide_rank: parseBoolean(hide_rank),
+      include_all_commits: parseBoolean(include_all_commits),
+      line_height,
+      title_color,
+      ring_color,
+      icon_color,
+      text_color,
+      text_bold: parseBoolean(text_bold),
+      bg_color,
+      theme,
+      custom_title,
+      border_radius,
+      border_color,
+      locale: locale ? locale.toLowerCase() : null,
+      disable_animations: parseBoolean(disable_animations),
+    });
+  } catch (err) {
+    return renderError(err.message, err.secondaryMessage);
+  }
+};

--- a/src/generators/top-langs.js
+++ b/src/generators/top-langs.js
@@ -1,0 +1,68 @@
+import { renderTopLanguages } from "../cards/top-languages-card.js";
+import { blacklist } from "../common/blacklist.js";
+import {
+  clampValue,
+  CONSTANTS,
+  parseArray,
+  parseBoolean,
+  renderError,
+} from "../common/utils.js";
+import { fetchTopLanguages } from "../fetchers/top-languages-fetcher.js";
+import { isLocaleAvailable } from "../translations.js";
+
+export default async (options) => {
+  const {
+    username,
+    hide,
+    hide_title,
+    hide_border,
+    card_width,
+    title_color,
+    text_color,
+    bg_color,
+    theme,
+    layout,
+    langs_count,
+    exclude_repo,
+    custom_title,
+    locale,
+    border_radius,
+    border_color,
+    disable_animations,
+  } = options;
+
+  if (blacklist.includes(username)) {
+    return renderError("Something went wrong");
+  }
+
+  if (locale && !isLocaleAvailable(locale)) {
+    return renderError("Something went wrong", "Locale not found");
+  }
+
+  try {
+    const topLangs = await fetchTopLanguages(
+      username,
+      parseArray(exclude_repo),
+    );
+
+    return renderTopLanguages(topLangs, {
+      custom_title,
+      hide_title: parseBoolean(hide_title),
+      hide_border: parseBoolean(hide_border),
+      card_width: parseInt(card_width, 10),
+      hide: parseArray(hide),
+      title_color,
+      text_color,
+      bg_color,
+      theme,
+      layout,
+      langs_count,
+      border_radius,
+      border_color,
+      locale: locale ? locale.toLowerCase() : null,
+      disable_animations: parseBoolean(disable_animations),
+    });
+  } catch (err) {
+    return renderError(err.message, err.secondaryMessage);
+  }
+};

--- a/src/generators/wakatime.js
+++ b/src/generators/wakatime.js
@@ -1,0 +1,63 @@
+import { renderWakatimeCard } from "../cards/wakatime-card.js";
+import {
+  clampValue,
+  CONSTANTS,
+  parseArray,
+  parseBoolean,
+  renderError,
+} from "../common/utils.js";
+import { fetchWakatimeStats } from "../fetchers/wakatime-fetcher.js";
+import { isLocaleAvailable } from "../translations.js";
+
+export default async (options) => {
+  const {
+    username,
+    title_color,
+    icon_color,
+    hide_border,
+    line_height,
+    text_color,
+    bg_color,
+    theme,
+    hide_title,
+    hide_progress,
+    custom_title,
+    locale,
+    layout,
+    langs_count,
+    hide,
+    api_domain,
+    range,
+    border_radius,
+    border_color,
+  } = options;
+
+  if (locale && !isLocaleAvailable(locale)) {
+    return renderError("Something went wrong", "Language not found");
+  }
+
+  try {
+    const stats = await fetchWakatimeStats({ username, api_domain, range });
+
+    return renderWakatimeCard(stats, {
+      custom_title,
+      hide_title: parseBoolean(hide_title),
+      hide_border: parseBoolean(hide_border),
+      hide: parseArray(hide),
+      line_height,
+      title_color,
+      icon_color,
+      text_color,
+      bg_color,
+      theme,
+      hide_progress,
+      border_radius,
+      border_color,
+      locale: locale ? locale.toLowerCase() : null,
+      layout,
+      langs_count,
+    });
+  } catch (err) {
+    return renderError(err.message, err.secondaryMessage);
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,2 @@
-export * from "./common/index.js";
 export * from "./cards/index.js";
-export { getStyles, getAnimations } from "./getStyles.js";
+export * from "./generators/index.js";


### PR DESCRIPTION
The path towards #2179; releases GRS as an NPM module.

**Note: Currently the NPM module only supports ESM, meaning that CJS users who try to do `require()` will get an error. We should consider using `babel` to automatically convert ESM to CJS before releasing to NPM.**

Things are currently working on my end, and I've published a test package [@zo-bro-23/github-readme-stats-test](https://www.npmjs.com/package/@zo-bro-23/github-readme-stats-test). This is only a draft though, and let's work on more features (such as automatic releases with GH Actions) and fix issues with the current code.