### PR TITLE
feat: setup Crowdin integration

### DIFF
--- a/.github/workflows/localization.yml
+++ b/.github/workflows/localization.yml
@@ -1,0 +1,43 @@
+# This workflow will run Crowdin Action that will upload new texts to Crowdin, download the newest translations and create a PR
+# For more information see: https://github.com/crowdin/github-action
+
+name: Crowdin Sync
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - 'readme.md'
+      - 'docs/*'
+
+jobs:
+  synchronize-with-crowdin:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: crowdin action
+        uses: crowdin/github-action@v1
+        with:
+          # Upload sources to Crowdin
+          upload_sources: true
+          # Upload translations to Crowdin, only use true at initial run
+          upload_translations: true
+          # Download translations from Crowdin
+          download_translations: true
+          # To the specified branch
+          localization_branch_name: l10n_crowdin_translations
+          # Create pull request after pushing to branch
+          create_pull_request: true
+          pull_request_title: 'New Crowdin Translations'
+          pull_request_body: 'New Crowdin translations by [Crowdin GH Action](https://github.com/crowdin/github-action)'
+          pull_request_base_branch_name: 'master'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,20 @@
+"project_id_env": "CROWDIN_PROJECT_ID"
+"api_token_env": "CROWDIN_PERSONAL_TOKEN"
+"base_path": "."
+
+"preserve_hierarchy": true
+
+"files": [
+  {
+    "source": "readme.md",
+    "translation": "docs/readme_%two_letters_code%.md",
+    "languages_mapping": {
+      "two_letters_code": {
+        "pt-BR": "pt-BR",
+        "zh-CN": "cn",
+        "ne-NP": "np",
+        "ko": "kr"
+      }
+    }
+  }
+]


### PR DESCRIPTION
Hey everyone 👋 

According to the discussion in #2053, I'm suggesting an automated solution for the Readme translation based on integration with Crowdin via GH Actions.

In this PR:
- `.github/workflows/localization.yml` - GH Workflows that trigger by pushes to the `master` branch. This workflow uses the [crowdin/github-action](https://github.com/crowdin/github-action) to synchronize localization files (`readme.md`, `docs/*.md`) between the Crowdin Project and GitHub repo.
- `crowdin.yml` - a configuration file for Crowdin synchronization.

Here is the Crowdin **Demo project** - [github-readme-stats-demo](https://crowdin.com/project/github-readme-stats-demo).

In this demo, the existing translations were uploaded to the Crowdin project by the GH Action, and the rest strings were automatically Pre-Translated using the Crowdin NMT machine translation engine (there is a possibility to connect **any MT engine** for that).

In addition, this workflow can be extended to localize all the project texts.

**Example of PR** created by the Action - [#1](https://github.com/andrii-bodnar/github-readme-stats/pull/1/commits/21492f6103cabeed109ff894e35a2a3d8454205f) (Don't worry about the diffs - it's just updated the translation files to the actual state. Crowdin tries to keep the original file structure as much as possible. The next PRs will include the new translations only).

In this integration, there is still a possibility to suggest translations by the community. These translations will be synchronized from Crowdin to the Repo automatically. By the way, Crowdin provides an easy and comfortable **preview** of files for translators. This makes the translation process extremely straightforward.

![image](https://user-images.githubusercontent.com/29282228/215723986-2e1c5ce7-586c-42e5-9f4c-788407ba695b.png)

