### PR TITLE
Add one_dark

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -374,6 +374,13 @@ export const themes = {
     border_color: "170F0C",
     bg_color: "170F0C",
   },
+  one_dark: {
+    title_color: "E06C75",
+    text_color: "E5C07B",
+    icon_color: "BC78C0",
+    border_color: "3B4048",
+    bg_color: "23272E",
+  },
 };
 
 export default themes;


### PR DESCRIPTION
Colors were got from One Dark Pro Theme in the VSCode extention. Please add it to list in oreder to use it in my profile.