### PR TITLE
Add auto-labelling for documentation updates

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,4 @@
 themes: themes/index.js
 doc-translation: docs/*
 card-i18n: src/translations.js
+documentation: readme.md


### PR DESCRIPTION
Auto labels PRs as `documentation` if they change `readme.md`. Might also label bigger PRs where new features are added, but would be useful to keep track of which PRs change the documentation. @rickstaa what do you think?