### PR TITLE
Added "Shadow" set (Red, Green, Blue, transparent BG)

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -381,6 +381,27 @@ export const themes = {
     border_color: "e9d8d4",
     bg_color: "e9d8d4",
   },
+  shadow_red: {
+    title_color: "9A0000",
+    text_color: "444",
+    icon_color: "4F0000",
+    border_color: "4F0000",
+    bg_color: "1116",
+  },
+  shadow_green: {
+    title_color: "007A00",
+    text_color: "444",
+    icon_color: "003D00",
+    border_color: "003D00",
+    bg_color: "1116",
+  },
+  shadow_blue: {
+    title_color: "00779A",
+    text_color: "444",
+    icon_color: "004450",
+    border_color: "004490",
+    bg_color: "1116",
+  },
 };
 
 export default themes;

--- a/themes/index.js
+++ b/themes/index.js
@@ -18,6 +18,27 @@ export const themes = {
     text_color: "417E87",
     bg_color: "ffffff00",
   },
+  shadow_red: {
+    title_color: "9A0000",
+    text_color: "444",
+    icon_color: "4F0000",
+    border_color: "4F0000",
+    bg_color: "ffffff00",
+  },
+  shadow_green: {
+    title_color: "007A00",
+    text_color: "444",
+    icon_color: "003D00",
+    border_color: "003D00",
+    bg_color: "ffffff00",
+  },
+  shadow_blue: {
+    title_color: "00779A",
+    text_color: "444",
+    icon_color: "004450",
+    border_color: "004490",
+    bg_color: "ffffff00",
+  },
   dark: {
     title_color: "fff",
     icon_color: "79ff97",
@@ -380,27 +401,6 @@ export const themes = {
     icon_color: "B71F36",
     border_color: "e9d8d4",
     bg_color: "e9d8d4",
-  },
-  shadow_red: {
-    title_color: "9A0000",
-    text_color: "444",
-    icon_color: "4F0000",
-    border_color: "4F0000",
-    bg_color: "ffffff00",
-  },
-  shadow_green: {
-    title_color: "007A00",
-    text_color: "444",
-    icon_color: "003D00",
-    border_color: "003D00",
-    bg_color: "ffffff00",
-  },
-  shadow_blue: {
-    title_color: "00779A",
-    text_color: "444",
-    icon_color: "004450",
-    border_color: "004490",
-    bg_color: "ffffff00",
   },
 };
 

--- a/themes/index.js
+++ b/themes/index.js
@@ -386,21 +386,21 @@ export const themes = {
     text_color: "444",
     icon_color: "4F0000",
     border_color: "4F0000",
-    bg_color: "1116",
+    bg_color: "ffffff00",
   },
   shadow_green: {
     title_color: "007A00",
     text_color: "444",
     icon_color: "003D00",
     border_color: "003D00",
-    bg_color: "1116",
+    bg_color: "ffffff00",
   },
   shadow_blue: {
     title_color: "00779A",
     text_color: "444",
     icon_color: "004450",
     border_color: "004490",
-    bg_color: "1116",
+    bg_color: "ffffff00",
   },
 };
 


### PR DESCRIPTION
3 additional themes sticking primarily to flat colors, which the exception of icons and border being slightly darker. All 3 themes also have transparent backgrounds that will show differently per-user via GiHub's own light and dark themes. Transparency should also still provide easy readability for both. Previews are below for both of GitHub's light and dark modes.

![GitHub_Stats_Shadow_Dark](https://user-images.githubusercontent.com/55290878/219923365-6140815b-742c-4b99-bf84-4daa8b5fdc54.PNG)
![GitHub_Stats_Shadow_Light](https://user-images.githubusercontent.com/55290878/219923367-44b8ec47-fbfd-4cf9-a697-2c73a2051b33.PNG)
