### PR TITLE
Theme restructure - Alternative to #2556

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -46,6 +46,8 @@ export default async (req, res) => {
   if (locale && !isLocaleAvailable(locale)) {
     return res.send(renderError("Something went wrong", "Language not found"));
   }
+  
+  theme = theme.replace(/-/g, "_")
 
   try {
     const stats = await fetchStats(

--- a/api/pin.js
+++ b/api/pin.js
@@ -35,6 +35,8 @@ export default async (req, res) => {
   if (locale && !isLocaleAvailable(locale)) {
     return res.send(renderError("Something went wrong", "Language not found"));
   }
+  
+  theme = theme.replace(/-/g, "_")
 
   try {
     const repoData = await fetchRepo(username, repo);

--- a/api/top-langs.js
+++ b/api/top-langs.js
@@ -41,6 +41,8 @@ export default async (req, res) => {
   if (locale && !isLocaleAvailable(locale)) {
     return res.send(renderError("Something went wrong", "Locale not found"));
   }
+  
+  theme = theme.replace(/-/g, "_")
 
   try {
     const topLangs = await fetchTopLanguages(

--- a/api/wakatime.js
+++ b/api/wakatime.js
@@ -38,6 +38,8 @@ export default async (req, res) => {
   if (locale && !isLocaleAvailable(locale)) {
     return res.send(renderError("Something went wrong", "Language not found"));
   }
+  
+  theme = theme.replace(/-/g, "_")
 
   try {
     const stats = await fetchWakatimeStats({ username, api_domain, range });


### PR DESCRIPTION
Another way to approach #2556. Instead of creating duplicate themes, we can just parse the theme parameter for hyphens and underscores. We have to update the NPM package to work with this, though.