### PR TITLE
Added include_forks path parameter

### DIFF
--- a/api/top-langs.js
+++ b/api/top-langs.js
@@ -31,6 +31,7 @@ export default async (req, res) => {
     border_color,
     disable_animations,
     hide_progress,
+    include_forks,
   } = req.query;
   res.setHeader("Content-Type", "image/svg+xml");
 
@@ -46,6 +47,7 @@ export default async (req, res) => {
     const topLangs = await fetchTopLanguages(
       username,
       parseArray(exclude_repo),
+      parseBoolean(include_forks) ? null : false,
     );
 
     const cacheSeconds = clampValue(

--- a/src/fetchers/top-languages-fetcher.js
+++ b/src/fetchers/top-languages-fetcher.js
@@ -19,10 +19,10 @@ const fetcher = (variables, token) => {
   return request(
     {
       query: `
-      query userInfo($login: String!) {
+      query userInfo($login: String!, $isFork: Boolean) {
         user(login: $login) {
           # fetch only owner repos & not forks
-          repositories(ownerAffiliations: OWNER, isFork: false, first: 100) {
+          repositories(ownerAffiliations: OWNER, isFork: $isFork, first: 100) {
             nodes {
               name
               languages(first: 10, orderBy: {field: SIZE, direction: DESC}) {
@@ -54,10 +54,14 @@ const fetcher = (variables, token) => {
  * @param {string[]} exclude_repo List of repositories to exclude.
  * @returns {Promise<import("./types").TopLangData>} Top languages data.
  */
-const fetchTopLanguages = async (username, exclude_repo = []) => {
+const fetchTopLanguages = async (
+  username,
+  exclude_repo = [],
+  isFork = null,
+) => {
   if (!username) throw new MissingParamError(["username"]);
 
-  const res = await retryer(fetcher, { login: username });
+  const res = await retryer(fetcher, { login: username, isFork });
 
   if (res.data.errors) {
     logger.error(res.data.errors);


### PR DESCRIPTION
I modified the code slightly so now the `isFork` argument in the API request is variable. I added an `include_forks` path parameter, and if it's true, it passes in `isFork: null`, in which the API sends all repos, whether they're forks or not. And if the `include_forks` path parameter is missing, or is any value other than `true`, it passes in `isFork: false`, which is the current behavior. 

Note: I've read the other posts, along with the comment at https://github.com/anuraghazra/github-readme-stats/pull/1122#issuecomment-1152066225. I understand that point of view, but I think adding include_forks would be beneficial. For example:

I've worked on a few projects with a small number of contributors, but I don't own those repositories, so I need to make a fork for it to appear on my profile. I'd like those projects to appear under my top-langs image, so allowing forks would let me do that. And to address the comment I linked above, I use the exclude_repo parameter to exclude my forks with a large number of contributors. 

Suggestion? (A possible alternate solution could be to change include_forks to be like exclude_forks, where instead of passing in true or false, you pass in a list of forked repository names to include?). 