### PR TITLE
Updated the custom error there was a Typo.

### DIFF
--- a/src/fetchers/stats-fetcher.js
+++ b/src/fetchers/stats-fetcher.js
@@ -213,7 +213,7 @@ const fetchStats = async (
       );
     }
     throw new CustomError(
-      "Something went while trying to retrieve the stats data using the GraphQL API.",
+      "Something went wrong while trying to retrieve the stats data using the GraphQL API.",
       CustomError.GRAPHQL_ERROR,
     );
   }


### PR DESCRIPTION
"Something went while trying to retrieve the stats data using the GraphQL API." -> "Something went wrong while trying to retrieve the stats data using the GraphQL API."