### PR TITLE
test: fix mistaken pageInfo.endCursor keys

### DIFF
--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -43,7 +43,7 @@ const data_stats = {
         nodes: [{ stargazers: { totalCount: 100 } }],
         pageInfo: {
           hasNextPage: false,
-          cursor: "cursor",
+          endCursor: "cursor",
         },
       },
     },

--- a/tests/fetchStats.test.js
+++ b/tests/fetchStats.test.js
@@ -27,7 +27,7 @@ const data_stats = {
         ],
         pageInfo: {
           hasNextPage: true,
-          cursor: "cursor",
+          endCursor: "cursor",
         },
       },
     },
@@ -44,7 +44,7 @@ const data_repo = {
         ],
         pageInfo: {
           hasNextPage: false,
-          cursor: "cursor",
+          endCursor: "cursor",
         },
       },
     },
@@ -64,7 +64,7 @@ const data_repo_zero_stars = {
         ],
         pageInfo: {
           hasNextPage: true,
-          cursor: "cursor",
+          endCursor: "cursor",
         },
       },
     },
@@ -86,11 +86,12 @@ const mock = new MockAdapter(axios);
 
 beforeEach(() => {
   process.env.FETCH_MULTI_PAGE_STARS = "false"; // Set to `false` to fetch only one page of stars.
-  mock
-    .onPost("https://api.github.com/graphql")
-    .replyOnce(200, data_stats)
-    .onPost("https://api.github.com/graphql")
-    .replyOnce(200, data_repo);
+  mock.onPost("https://api.github.com/graphql").reply((cfg) => {
+    return [
+      200,
+      cfg.data.includes("contributionsCollection") ? data_stats : data_repo,
+    ];
+  });
 });
 
 afterEach(() => {


### PR DESCRIPTION
```
The previous mock logic was too simplistic and has been fixed in the
commit. If the mock logic had been properly implemented, then the
mistaken pageInfo.endCursor keys should have made the test case "should
fetch two pages of stars if 'FETCH_MULTI_PAGE_STARS' env variable is set
to `true`" stuck.
```

See also https://github.com/anuraghazra/github-readme-stats/pull/1691#issuecomment-1527401508