### PR TITLE
Show no activity error in compact layout of wakatime card

### DIFF
--- a/src/cards/wakatime-card.js
+++ b/src/cards/wakatime-card.js
@@ -267,12 +267,20 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
       <rect x="25" y="0" width="${width - 50}" height="8" fill="white" rx="5" />
       </mask>
       ${compactProgressBar}
-      ${createLanguageTextNode({
-        x: 0,
-        y: 25,
-        langs: filteredLanguages,
-        totalSize: 100,
-      }).join("")}
+      ${
+        filteredLanguages.length
+          ? createLanguageTextNode({
+              x: 0,
+              y: 25,
+              langs: filteredLanguages,
+              totalSize: 100,
+            }).join("")
+          : noCodingActivityNode({
+              // @ts-ignore
+              color: textColor,
+              text: i18n.t("wakatimecard.nocodingactivity"),
+            })
+      }
     `;
   } else {
     finalLayout = flexLayout({


### PR DESCRIPTION
Currently compact layout of wakatime card is completely empty when there are no coding activity. 

![image](https://user-images.githubusercontent.com/53787217/235322899-6768bf04-790d-492f-9ed8-a32607a34472.png)

This is how it will look like

![image](https://user-images.githubusercontent.com/53787217/235323015-01a3e874-21a8-4d22-afc3-700ffa0428e6.png)

Preview deployed there: https://github-readme-stats-arc8tv92a-qwerty541.vercel.app
