### PR TITLE
Adding github default theme with transparency background

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -423,6 +423,12 @@ export const themes = {
     border_color: "85A4C0",
     bg_color: "030314",
   },
+  github_default : {
+    title_color: "ffffff",
+    icon_color: "f78166",
+    text_color: "e6edf3",
+    bg_color: "d1d1d1",
+  },
 };
 
 export default themes;


### PR DESCRIPTION
add theme "github default colors with transparency background"