### PR TITLE
ci: add top themes and labels to 'top issues dashboard' action

### DIFF
--- a/.github/workflows/top-issues-dashboard.yml
+++ b/.github/workflows/top-issues-dashboard.yml
@@ -15,10 +15,15 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
         with:
           filter: "1772"
-          label: false
+          label: true
           dashboard: true
           dashboard_show_total_reactions: true
           top_issues: true
           top_bugs: true
           top_features: true
           top_pull_requests: true
+          custom_pull_requests_label: themes
+          top_custom_pull_requests_label: ":star: top themes"
+          top_custom_pull_requests_label_description:
+            The description used for the top custom pull requests.
+          top_custom_pull_requests_label_colour: #A23599


### PR DESCRIPTION
This pull requests will enable the top themes feature of the https://github.com/rickstaa/top-issues-action that was released in https://github.com/rickstaa/top-issues-action/releases/tag/v1.3.0. It also enables top issues labelling.