### PR TITLE
Add finer ranking levels

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -108,7 +108,7 @@ Change the `?username=` value to your GitHub username.
 ```
 
 > **Note**
-> Available ranks are S+ (top 1%), S (top 25%), A++ (top 45%), A+ (top 60%), and B+ (everyone). The values are calculated by using the [cumulative distribution function](https://en.wikipedia.org/wiki/Cumulative_distribution_function) using commits, contributions, issues, stars, pull requests, followers, and owned repositories. The implementation can be investigated at [src/calculateRank.js](./src/calculateRank.js).
+> Available ranks are S (top 1%), A+ (12.5%), A (25%), A- (37.5%), B+ (50%), B (62.5%), B- (75%), C+ (87.5%) and C (everyone). This ranking scheme is based on the [Japanese academic grading](https://wikipedia.org/wiki/Academic_grading_in_Japan) system. The global percentile is calculated as a weighted sum of percentiles for each statistic (number of commits, pull requests, issues, stars and followers), based on the cumulative distribution function of the [exponential](https://wikipedia.org/wiki/exponential_distribution) and the [log-normal](https://wikipedia.org/wiki/Log-normal_distribution) distributions. The implementation can be investigated at [src/calculateRank.js](./src/calculateRank.js). The circle around the rank shows 100 minus the global percentile.
 
 ### Hiding individual stats
 

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -209,9 +209,8 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     hide_rank ? 0 : 150,
   );
 
-  // the better user's score the the rank will be closer to zero so
-  // subtracting 100 to get the progress in 100%
-  const progress = 100 - rank.score;
+  // the lower the user's percentile the better
+  const progress = 100 - rank.percentile;
   const cssStyles = getStyles({
     titleColor,
     ringColor,

--- a/src/fetchers/stats-fetcher.js
+++ b/src/fetchers/stats-fetcher.js
@@ -192,7 +192,7 @@ const fetchStats = async (
     totalIssues: 0,
     totalStars: 0,
     contributedTo: 0,
-    rank: { level: "B", score: 0 },
+    rank: { level: "C", percentile: 100 },
   };
 
   let res = await statsFetcher(username);

--- a/src/fetchers/types.d.ts
+++ b/src/fetchers/types.d.ts
@@ -22,7 +22,7 @@ export type StatsData = {
   totalIssues: number;
   totalStars: number;
   contributedTo: number;
-  rank: { level: string; score: number };
+  rank: { level: string; percentile: number };
 };
 
 export type Lang = {

--- a/tests/calculateRank.test.js
+++ b/tests/calculateRank.test.js
@@ -2,7 +2,7 @@ import "@testing-library/jest-dom";
 import { calculateRank } from "../src/calculateRank.js";
 
 describe("Test calculateRank", () => {
-  it("new user gets B rank", () => {
+  it("new user gets C rank", () => {
     expect(
       calculateRank({
         all_commits: false,
@@ -13,10 +13,24 @@ describe("Test calculateRank", () => {
         stars: 0,
         followers: 0,
       }),
-    ).toStrictEqual({ level: "B", score: 100 });
+    ).toStrictEqual({ level: "C", percentile: 100 });
   });
 
-  it("average user gets A rank", () => {
+  it("beginner user gets B- rank", () => {
+    expect(
+      calculateRank({
+        all_commits: false,
+        commits: 125,
+        prs: 25,
+        issues: 10,
+        repos: 0,
+        stars: 25,
+        followers: 5,
+      }),
+    ).toStrictEqual({ level: "B-", percentile: 69.333868386557 });
+  });
+
+  it("median user gets B+ rank", () => {
     expect(
       calculateRank({
         all_commits: false,
@@ -24,13 +38,13 @@ describe("Test calculateRank", () => {
         prs: 50,
         issues: 25,
         repos: 0,
-        stars: 250,
-        followers: 25,
+        stars: 50,
+        followers: 10,
       }),
-    ).toStrictEqual({ level: "A", score: 50 });
+    ).toStrictEqual({ level: "B+", percentile: 50 });
   });
 
-  it("average user gets A rank (include_all_commits)", () => {
+  it("average user gets B+ rank (include_all_commits)", () => {
     expect(
       calculateRank({
         all_commits: true,
@@ -38,13 +52,13 @@ describe("Test calculateRank", () => {
         prs: 50,
         issues: 25,
         repos: 0,
-        stars: 250,
-        followers: 25,
+        stars: 50,
+        followers: 10,
       }),
-    ).toStrictEqual({ level: "A", score: 50 });
+    ).toStrictEqual({ level: "B+", percentile: 50 });
   });
 
-  it("more than average user gets A+ rank", () => {
+  it("advanced user gets A rank", () => {
     expect(
       calculateRank({
         all_commits: false,
@@ -52,13 +66,13 @@ describe("Test calculateRank", () => {
         prs: 100,
         issues: 50,
         repos: 0,
-        stars: 500,
-        followers: 50,
+        stars: 200,
+        followers: 40,
       }),
-    ).toStrictEqual({ level: "A+", score: 25 });
+    ).toStrictEqual({ level: "A", percentile: 22.72727272727273 });
   });
 
-  it("expert user gets S rank", () => {
+  it("expert user gets A+ rank", () => {
     expect(
       calculateRank({
         all_commits: false,
@@ -66,23 +80,23 @@ describe("Test calculateRank", () => {
         prs: 200,
         issues: 100,
         repos: 0,
-        stars: 1000,
-        followers: 100,
+        stars: 800,
+        followers: 160,
       }),
-    ).toStrictEqual({ level: "S", score: 6.25 });
+    ).toStrictEqual({ level: "A+", percentile: 6.082887700534744 });
   });
 
-  it("ezyang gets S+ rank", () => {
+  it("sindresorhus gets S rank", () => {
     expect(
       calculateRank({
         all_commits: false,
-        commits: 1000,
-        prs: 4000,
-        issues: 2000,
+        commits: 1300,
+        prs: 1500,
+        issues: 4500,
         repos: 0,
-        stars: 5000,
-        followers: 2000,
+        stars: 600000,
+        followers: 50000,
       }),
-    ).toStrictEqual({ level: "S+", score: 1.1363983154296875 });
+    ).toStrictEqual({ level: "S", percentile: 0.49947889605312934 });
   });
 });


### PR DESCRIPTION
This PR removes the S+ rank (to comply with the Japanese grading system) and adds finer ranking levels (now S, A+, A, A-, B+, B, B-, C+ and C).

I also used a different cumulative distribution function (CDF) for stars and followers. The distributions of these two stats have heavier tails (meaning that large values are more likely) than what an [exponential distribution](https://wikipedia.org/wiki/Exponential_distribution) allows. So instead I used an approximation of the [log-normal](https://wikipedia.org/wiki/Log-normal_distribution) CDF. This makes the initial ranks (C to A) more accessible, but the final rank (S) extremely hard to reach.

I also replaced the word `score` by `percentile`.