### PR TITLE
Use compact layout default langs count when hide_progress param was set

### DIFF
--- a/src/cards/top-languages-card.js
+++ b/src/cards/top-languages-card.js
@@ -676,11 +676,13 @@ const noLanguagesDataNode = ({ color, text, layout }) => {
 /**
  * Get default languages count for provided card layout.
  *
- * @param {import("./types").TopLangOptions["layout"] | undefined} layout Input layout string
- * @return {number} Default languages count for input layout
+ * @param {object} props Function properties.
+ * @param {import("./types").TopLangOptions["layout"]=} props.layout Input layout string.
+ * @param {boolean=} props.hide_progress Input hide_progress parameter value.
+ * @return {number} Default languages count for input layout.
  */
-const getDefaultLanguagesCountByLayout = (layout) => {
-  if (layout === "compact") {
+const getDefaultLanguagesCountByLayout = ({ layout, hide_progress }) => {
+  if (layout === "compact" || hide_progress === true) {
     return COMPACT_LAYOUT_DEFAULT_LANGS_COUNT;
   } else if (layout === "donut") {
     return DONUT_LAYOUT_DEFAULT_LANGS_COUNT;
@@ -714,7 +716,7 @@ const renderTopLanguages = (topLangs, options = {}) => {
     layout,
     custom_title,
     locale,
-    langs_count = getDefaultLanguagesCountByLayout(layout),
+    langs_count = getDefaultLanguagesCountByLayout({ layout, hide_progress }),
     border_radius,
     border_color,
     disable_animations,

--- a/tests/renderTopLanguages.test.js
+++ b/tests/renderTopLanguages.test.js
@@ -331,12 +331,25 @@ describe("Test renderTopLanguages helper functions", () => {
   });
 
   it("getDefaultLanguagesCountByLayout", () => {
-    expect(getDefaultLanguagesCountByLayout("normal")).toStrictEqual(5);
-    expect(getDefaultLanguagesCountByLayout(undefined)).toStrictEqual(5);
-    expect(getDefaultLanguagesCountByLayout("compact")).toStrictEqual(6);
-    expect(getDefaultLanguagesCountByLayout("donut")).toStrictEqual(5);
-    expect(getDefaultLanguagesCountByLayout("donut-vertical")).toStrictEqual(6);
-    expect(getDefaultLanguagesCountByLayout("pie")).toStrictEqual(6);
+    expect(
+      getDefaultLanguagesCountByLayout({ layout: "normal" }),
+    ).toStrictEqual(5);
+    expect(getDefaultLanguagesCountByLayout({})).toStrictEqual(5);
+    expect(
+      getDefaultLanguagesCountByLayout({ layout: "compact" }),
+    ).toStrictEqual(6);
+    expect(
+      getDefaultLanguagesCountByLayout({ hide_progress: true }),
+    ).toStrictEqual(6);
+    expect(getDefaultLanguagesCountByLayout({ layout: "donut" })).toStrictEqual(
+      5,
+    );
+    expect(
+      getDefaultLanguagesCountByLayout({ layout: "donut-vertical" }),
+    ).toStrictEqual(6);
+    expect(getDefaultLanguagesCountByLayout({ layout: "pie" })).toStrictEqual(
+      6,
+    );
   });
 });
 


### PR DESCRIPTION
Specifying `hide_progress` parameter switch card layout to compact. Currently if you use `&layout=compact` it shows 6 languages by default, but if you specify `&hide_progress=true` it still shows 5. This pull request fix this behavior.

![image](https://github.com/anuraghazra/github-readme-stats/assets/53787217/358ba551-e58a-4a57-98b2-5b3755dbbb40)

![image](https://github.com/anuraghazra/github-readme-stats/assets/53787217/6a88237c-b66b-4eef-974e-3333561dbb35)
