### PR TITLE
Remove redundant ask for theme screenshot from CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,6 @@ GitHub Readme Stats supports custom theming, and you can also contribute new the
 
 All you need to do is edit the [themes/index.js](./themes/index.js) file and add your theme at the end of the file.
 
-While creating the Pull request to add a new theme **don't forget to add a screenshot of how your theme looks**, you can also test how it looks using custom URL parameters like `title_color`, `icon_color`, `bg_color`, `text_color`, `border_color`
-
 > NOTE: If you are contributing your theme just because you are using it personally, then you can [customize the looks](./readme.md#customization) of your card with URL params instead.
 
 ## Any contributions you make will be under the MIT Software License


### PR DESCRIPTION
I think we no longer need this note since we have automated theme preview workflow.