### PR TITLE
ci: fix top-issues action

### DIFF
--- a/.github/workflows/top-issues-dashboard.yml
+++ b/.github/workflows/top-issues-dashboard.yml
@@ -2,6 +2,7 @@ name: Update top issues dashboard
 on:
   schedule:
     - cron: "0 0 */3 * *"
+  workflow_dispatch:
 
 jobs:
   showAndLabelTopIssues:
@@ -24,6 +25,5 @@ jobs:
           top_pull_requests: true
           custom_pull_requests_label: themes
           top_custom_pull_requests_label: ":star: top themes"
-          top_custom_pull_requests_label_description:
-            The description used for the top custom pull requests.
-          top_custom_pull_requests_label_colour: #A23599
+          top_custom_pull_requests_label_description: Top themes
+          top_custom_pull_requests_label_colour: "#A23599"


### PR DESCRIPTION
@qwerty541 after your recent documentation update, I noticed that the themes were not showing up in the https://github.com/anuraghazra/github-readme-stats/issues/1935 dashboard. This PR fixes this.