### PR TITLE
Add yzhang.markdown-all-in-one to recommended workspace extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "yzhang.markdown-all-in-one"
+    ]
+}


### PR DESCRIPTION
I think that we should add this extension to recommended for workspace since we use it for readme formatting.