### PR TITLE
Add vscode settings for yzhang.markdown-all-in-one extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ vercel_token
 # IDE
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
 *.code-workspace
 
 .vercel

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "markdown.extension.toc.levels": "1..3",
+    "editor.formatOnSave": true
+}


### PR DESCRIPTION
I think it's better to keep this settings inside repository configs instead of some pull request comment. I also added there `editor.formatOnSave` config which i found very useful for myself.