### PR TITLE
Fixed docstring for trimTopLanguages function

### DIFF
--- a/src/cards/top-languages-card.js
+++ b/src/cards/top-languages-card.js
@@ -163,11 +163,11 @@ const donutCenterTranslation = (totalLangs) => {
  * Trim top languages to lang_count while also hiding certain languages.
  *
  * @param {Record<string, Lang>} topLangs Top languages.
- * @param {string[]} hide Languages to hide.
  * @param {string} langs_count Number of languages to show.
- * @returns {{topLangs: Record<string, Lang>, totalSize: number}} Trimmed top languages and total size.
+ * @param {string[]=} hide Languages to hide.
+ * @returns {{ langs: Lang[], totalLanguageSize: number }} Trimmed top languages and total size.
  */
-const trimTopLanguages = (topLangs, hide, langs_count) => {
+const trimTopLanguages = (topLangs, langs_count, hide) => {
   let langs = Object.values(topLangs);
   let langsToHide = {};
   let langsCount = clampValue(parseInt(langs_count), 1, 10);
@@ -733,8 +733,8 @@ const renderTopLanguages = (topLangs, options = {}) => {
 
   const { langs, totalLanguageSize } = trimTopLanguages(
     topLangs,
-    hide,
     String(langs_count),
+    hide,
   );
 
   let width = isNaN(card_width)

--- a/tests/renderTopLanguages.test.js
+++ b/tests/renderTopLanguages.test.js
@@ -310,17 +310,15 @@ describe("Test renderTopLanguages helper functions", () => {
       langs: [langs.javascript],
       totalLanguageSize: 200,
     });
-    expect(
-      trimTopLanguages([langs.javascript, langs.HTML], 5, []),
-    ).toStrictEqual({
+    expect(trimTopLanguages([langs.javascript, langs.HTML], 5)).toStrictEqual({
       langs: [langs.javascript, langs.HTML],
       totalLanguageSize: 400,
     });
-    expect(trimTopLanguages(langs, 5, [])).toStrictEqual({
+    expect(trimTopLanguages(langs, 5)).toStrictEqual({
       langs: Object.values(langs),
       totalLanguageSize: 500,
     });
-    expect(trimTopLanguages(langs, 2, [])).toStrictEqual({
+    expect(trimTopLanguages(langs, 2)).toStrictEqual({
       langs: Object.values(langs).slice(0, 2),
       totalLanguageSize: 400,
     });

--- a/tests/renderTopLanguages.test.js
+++ b/tests/renderTopLanguages.test.js
@@ -311,20 +311,20 @@ describe("Test renderTopLanguages helper functions", () => {
       totalLanguageSize: 200,
     });
     expect(
-      trimTopLanguages([langs.javascript, langs.HTML], [], 5),
+      trimTopLanguages([langs.javascript, langs.HTML], 5, []),
     ).toStrictEqual({
       langs: [langs.javascript, langs.HTML],
       totalLanguageSize: 400,
     });
-    expect(trimTopLanguages(langs, [], 5)).toStrictEqual({
+    expect(trimTopLanguages(langs, 5, [])).toStrictEqual({
       langs: Object.values(langs),
       totalLanguageSize: 500,
     });
-    expect(trimTopLanguages(langs, [], 2)).toStrictEqual({
+    expect(trimTopLanguages(langs, 2, [])).toStrictEqual({
       langs: Object.values(langs).slice(0, 2),
       totalLanguageSize: 400,
     });
-    expect(trimTopLanguages(langs, ["javascript"], 5)).toStrictEqual({
+    expect(trimTopLanguages(langs, 5, ["javascript"])).toStrictEqual({
       langs: [langs.HTML, langs.css],
       totalLanguageSize: 300,
     });


### PR DESCRIPTION
Function arguments was reordered because optional parameter cannot be previously than non-optional.