### PR TITLE
Stats card: Reorder total reviews count position

### DIFF
--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -160,6 +160,16 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     value: totalPRs,
     id: "prs",
   };
+
+  if (show_total_reviews) {
+    STATS.reviews = {
+      icon: icons.reviews,
+      label: i18n.t("statcard.reviews"),
+      value: totalReviews,
+      id: "reviews",
+    };
+  }
+
   STATS.issues = {
     icon: icons.issues,
     label: i18n.t("statcard.issues"),
@@ -172,16 +182,6 @@ const renderStatsCard = (stats = {}, options = { hide: [] }) => {
     value: contributedTo,
     id: "contribs",
   };
-
-  // Extra stats items.
-  if (show_total_reviews) {
-    STATS.reviews = {
-      icon: icons.reviews,
-      label: i18n.t("statcard.reviews"),
-      value: totalReviews,
-      id: "reviews",
-    };
-  }
 
   const longLocales = [
     "cn",


### PR DESCRIPTION
Hey, @rickstaa! I see that you reverted this change while merging #1404. I deliberately placed the number of reviews next to the number of pull requests, because in my opinion the card looks much prettier in this way and, in general, the arrangement of these elements side by side is more logical due to their close relationship with each other. Do not you agree?