### PR TITLE
refactor: remove vscode 'formatOnSave'

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
     "markdown.extension.toc.levels": "1..3",
-    "editor.formatOnSave": true
 }


### PR DESCRIPTION
This commit ensures that the `formatOnSave` variable is not set. This
needs to be done since people have different prefered formatters. With `formatOnSave`
included this will cause code to be formatted on save with different
formatters than prettier.
