### PR TITLE
add percentile rank icon

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,5 @@
 {
     "markdown.extension.toc.levels": "1..3",
     "editor.formatOnSave": true,
-    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.defaultFormatter": "esbenp.prettier-vscode" 
 }

--- a/readme.md
+++ b/readme.md
@@ -304,7 +304,7 @@ You can provide multiple comma-separated values in the bg\_color option to rende
 *   `hide_title` - *(boolean)*. Default: `false`.
 *   `card_width` - Set the card's width manually *(number)*. Default: `500px  (approx.)`.
 *   `hide_rank` - *(boolean)* hides the rank and automatically resizes the card width. Default: `false`.
-*   `rank_icon` - Shows alternative rank icon (i.e. `github`, `progress` or `default`). Default: `default`.
+*   `rank_icon` - Shows alternative rank icon (i.e. `github`, `percentile` or `progress`, `default`). Default: `default`.
 *   `show_icons` - *(boolean)*. Default: `false`.
 *   `include_all_commits` - Count total commits instead of just the current year commits *(boolean)*. Default: `false`.
 *   `line_height` - Sets the line height between text *(number)*. Default: `25`.
@@ -556,6 +556,10 @@ Change the `?username=` value to your [Wakatime](https://wakatime.com) username.
 *   Shows rank progress instead of rank level
 
 ![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra\&rank_icon=progress)
+
+*   Shows user rank percentile instead of rank level
+
+![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra\&rank_icon=percentile)
 
 *   Customize Border Color
 

--- a/readme.md
+++ b/readme.md
@@ -304,7 +304,7 @@ You can provide multiple comma-separated values in the bg\_color option to rende
 *   `hide_title` - *(boolean)*. Default: `false`.
 *   `card_width` - Set the card's width manually *(number)*. Default: `500px  (approx.)`.
 *   `hide_rank` - *(boolean)* hides the rank and automatically resizes the card width. Default: `false`.
-*   `rank_icon` - Shows alternative rank icon (i.e. `github`, `percentile`, or `default`). Default: `default`.
+*   `rank_icon` - Shows alternative rank icon (i.e. `github`, `percentile` or `default`). Default: `default`.
 *   `show_icons` - *(boolean)*. Default: `false`.
 *   `include_all_commits` - Count total commits instead of just the current year commits *(boolean)*. Default: `false`.
 *   `line_height` - Sets the line height between text *(number)*. Default: `25`.

--- a/readme.md
+++ b/readme.md
@@ -83,38 +83,38 @@ Please visit [this link](https://give.do/fundraisers/stand-beside-the-victims-of
 
 # Features <!-- omit in toc -->
 
-*   [GitHub Stats Card](#github-stats-card)
-    *   [Hiding individual stats](#hiding-individual-stats)
-    *   [Showing additional individual stats](#showing-additional-individual-stats)
-    *   [Showing icons](#showing-icons)
-    *   [Themes](#themes)
-    *   [Customization](#customization)
-*   [GitHub Extra Pins](#github-extra-pins)
-    *   [Usage](#usage)
-    *   [Demo](#demo)
-*   [Top Languages Card](#top-languages-card)
-    *   [Usage](#usage-1)
-    *   [Language stats algorithm](#language-stats-algorithm)
-    *   [Exclude individual repositories](#exclude-individual-repositories)
-    *   [Hide individual languages](#hide-individual-languages)
-    *   [Show more languages](#show-more-languages)
-    *   [Compact Language Card Layout](#compact-language-card-layout)
-    *   [Donut Chart Language Card Layout](#donut-chart-language-card-layout)
-    *   [Donut Vertical Chart Language Card Layout](#donut-vertical-chart-language-card-layout)
-    *   [Pie Chart Language Card Layout](#pie-chart-language-card-layout)
-    *   [Hide Progress Bars](#hide-progress-bars)
-    *   [Demo](#demo-1)
-*   [Wakatime Stats Card](#wakatime-stats-card)
-    *   [Demo](#demo-2)
-*   [All Demos](#all-demos)
-    *   [Quick Tip (Align The Repo Cards)](#quick-tip-align-the-repo-cards)
-*   [Deploy on your own](#deploy-on-your-own)
-    *   [On Vercel](#on-vercel)
-        *   [:film\_projector: Check Out Step By Step Video Tutorial By @codeSTACKr](#film_projector-check-out-step-by-step-video-tutorial-by-codestackr)
-    *   [On other platforms](#on-other-platforms)
-    *   [Disable rate limit protections](#disable-rate-limit-protections)
-    *   [Keep your fork up to date](#keep-your-fork-up-to-date)
-*   [:sparkling\_heart: Support the project](#sparkling_heart-support-the-project)
+- [GitHub Stats Card](#github-stats-card)
+    - [Hiding individual stats](#hiding-individual-stats)
+    - [Showing additional individual stats](#showing-additional-individual-stats)
+    - [Showing icons](#showing-icons)
+    - [Themes](#themes)
+    - [Customization](#customization)
+- [GitHub Extra Pins](#github-extra-pins)
+    - [Usage](#usage)
+    - [Demo](#demo)
+- [Top Languages Card](#top-languages-card)
+    - [Usage](#usage-1)
+    - [Language stats algorithm](#language-stats-algorithm)
+    - [Exclude individual repositories](#exclude-individual-repositories)
+    - [Hide individual languages](#hide-individual-languages)
+    - [Show more languages](#show-more-languages)
+    - [Compact Language Card Layout](#compact-language-card-layout)
+    - [Donut Chart Language Card Layout](#donut-chart-language-card-layout)
+    - [Donut Vertical Chart Language Card Layout](#donut-vertical-chart-language-card-layout)
+    - [Pie Chart Language Card Layout](#pie-chart-language-card-layout)
+    - [Hide Progress Bars](#hide-progress-bars)
+    - [Demo](#demo-1)
+- [Wakatime Stats Card](#wakatime-stats-card)
+    - [Demo](#demo-2)
+- [All Demos](#all-demos)
+  - [Quick Tip (Align The Repo Cards)](#quick-tip-align-the-repo-cards)
+- [Deploy on your own](#deploy-on-your-own)
+  - [On Vercel](#on-vercel)
+    - [:film\_projector: Check Out Step By Step Video Tutorial By @codeSTACKr](#film_projector-check-out-step-by-step-video-tutorial-by-codestackr)
+  - [On other platforms](#on-other-platforms)
+  - [Disable rate limit protections](#disable-rate-limit-protections)
+  - [Keep your fork up to date](#keep-your-fork-up-to-date)
+- [:sparkling\_heart: Support the project](#sparkling_heart-support-the-project)
 
 # Important Notice <!-- omit in toc -->
 
@@ -304,7 +304,7 @@ You can provide multiple comma-separated values in the bg\_color option to rende
 *   `hide_title` - *(boolean)*. Default: `false`.
 *   `card_width` - Set the card's width manually *(number)*. Default: `500px  (approx.)`.
 *   `hide_rank` - *(boolean)* hides the rank and automatically resizes the card width. Default: `false`.
-*   `rank_icon` - Shows alternative rank icon (i.e. `github`, `percentile` or `progress`, `default`). Default: `default`.
+*   `rank_icon` - Shows alternative rank icon (i.e. `github`, `percentile`, or `default`). Default: `default`.
 *   `show_icons` - *(boolean)*. Default: `false`.
 *   `include_all_commits` - Count total commits instead of just the current year commits *(boolean)*. Default: `false`.
 *   `line_height` - Sets the line height between text *(number)*. Default: `25`.

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -328,7 +328,7 @@ const renderStatsCard = (stats = {}, options = {}) => {
         <circle class="rank-circle-rim" cx="-10" cy="8" r="40" />
         <circle class="rank-circle" cx="-10" cy="8" r="40" />
         <g class="rank-text">
-          ${rankIcon(rank_icon, rank?.level, progress)}
+          ${rankIcon(rank_icon, rank?.level, rank?.percentile)}
         </g>
       </g>`;
 

--- a/src/cards/types.d.ts
+++ b/src/cards/types.d.ts
@@ -1,5 +1,5 @@
 type ThemeNames = keyof typeof import("../../themes/index.js");
-type RankIcon = "default" | "github" | "progress" | "percentile";
+type RankIcon = "default" | "github" | "percentile";
 
 export type CommonOptions = {
   title_color: string;

--- a/src/cards/types.d.ts
+++ b/src/cards/types.d.ts
@@ -1,5 +1,5 @@
 type ThemeNames = keyof typeof import("../../themes/index.js");
-type RankIcon = "default" | "github" | "progress";
+type RankIcon = "default" | "github" | "progress" | "percentile";
 
 export type CommonOptions = {
   title_color: string;

--- a/src/common/icons.js
+++ b/src/common/icons.js
@@ -27,20 +27,14 @@ const rankIcon = (rankIcon, rankLevel, percentile) => {
           <path d="M8 0c4.42 0 8 3.58 8 8a8.013 8.013 0 0 1-5.45 7.59c-.4.08-.55-.17-.55-.38 0-.27.01-1.13.01-2.2 0-.75-.25-1.23-.54-1.48 1.78-.2 3.65-.88 3.65-3.95 0-.88-.31-1.59-.82-2.15.08-.2.36-1.02-.08-2.12 0 0-.67-.22-2.2.82-.64-.18-1.32-.27-2-.27-.68 0-1.36.09-2 .27-1.53-1.03-2.2-.82-2.2-.82-.44 1.1-.16 1.92-.08 2.12-.51.56-.82 1.28-.82 2.15 0 3.06 1.86 3.75 3.64 3.95-.23.2-.44.55-.51 1.07-.46.21-1.61.55-2.33-.66-.15-.24-.6-.83-1.23-.82-.67.01-.27.38.01.53.34.19.73.9.82 1.13.16.45.68 1.31 2.69.94 0 .67.01 1.3.01 1.49 0 .21-.15.45-.55.38A7.995 7.995 0 0 1 0 8c0-4.42 3.58-8 8-8Z"></path>
         </svg>
       `;
-    case "progress":
-      return `
-        <text x="-5" y="3" alignment-baseline="central" dominant-baseline="central" text-anchor="middle" data-testid="progress-rank-icon" class="rank-progress-text">
-            ${(100 - percentile).toFixed(1)}%
-        </text>
-        `;
     case "percentile":
       return `
-      <text x="-5" y="-12" alignment-baseline="central" dominant-baseline="central" text-anchor="middle" data-testid="percentile-top-header" class="rank-percentile-header">
+        <text x="-5" y="-12" alignment-baseline="central" dominant-baseline="central" text-anchor="middle" data-testid="percentile-top-header" class="rank-percentile-header">
           Top
-      </text>
-      <text x="-5" y="12" alignment-baseline="central" dominant-baseline="central" text-anchor="middle" data-testid="percentile-rank-value" class="rank-percentile-text">
-          ${percentile.toFixed(1)}%
-      </text>
+        </text>
+        <text x="-5" y="12" alignment-baseline="central" dominant-baseline="central" text-anchor="middle" data-testid="percentile-rank-value" class="rank-percentile-text">
+          ${(100 - percentile).toFixed(1)}%
+        </text>
       `;
     case "default":
     default:

--- a/src/common/icons.js
+++ b/src/common/icons.js
@@ -16,10 +16,10 @@ const icons = {
  *
  * @param {string} rankIcon - The rank icon type.
  * @param {number} rankLevel - The rank level.
- * @param {number} progress - The rank progress.
+ * @param {number} percentile - The rank percentile.
  * @returns {string} - The SVG code of the rank icon
  */
-const rankIcon = (rankIcon, rankLevel, progress) => {
+const rankIcon = (rankIcon, rankLevel, percentile) => {
   switch (rankIcon) {
     case "github":
       return `
@@ -29,8 +29,17 @@ const rankIcon = (rankIcon, rankLevel, progress) => {
       `;
     case "progress":
       return `
-      <text x="-5" y="3" alignment-baseline="central" dominant-baseline="central" text-anchor="middle" data-testid="progress-rank-icon" class="rank-progress-text">
-          ${progress.toFixed(1)}%
+        <text x="-5" y="3" alignment-baseline="central" dominant-baseline="central" text-anchor="middle" data-testid="progress-rank-icon" class="rank-progress-text">
+            ${(100 - percentile).toFixed(1)}%
+        </text>
+        `;
+    case "percentile":
+      return `
+      <text x="-5" y="-12" alignment-baseline="central" dominant-baseline="central" text-anchor="middle" data-testid="percentile-top-header" class="rank-percentile-header">
+          Top
+      </text>
+      <text x="-5" y="12" alignment-baseline="central" dominant-baseline="central" text-anchor="middle" data-testid="percentile-rank-value" class="rank-percentile-text">
+          ${percentile.toFixed(1)}%
       </text>
       `;
     case "default":

--- a/src/common/icons.js
+++ b/src/common/icons.js
@@ -33,7 +33,7 @@ const rankIcon = (rankIcon, rankLevel, percentile) => {
           Top
         </text>
         <text x="-5" y="12" alignment-baseline="central" dominant-baseline="central" text-anchor="middle" data-testid="percentile-rank-value" class="rank-percentile-text">
-          ${(100 - percentile).toFixed(1)}%
+          ${percentile.toFixed(1)}%
         </text>
       `;
     case "default":

--- a/src/getStyles.js
+++ b/src/getStyles.js
@@ -101,6 +101,12 @@ const getStyles = ({
     .rank-progress-text {
       font-size: 16px;
     }
+    .rank-percentile-header {
+      font-size: 16px;
+    }
+    .rank-percentile-text {
+      font-size: 16px;
+    }
     
     .not_bold { font-weight: 400 }
     .bold { font-weight: 700 }
@@ -130,4 +136,4 @@ const getStyles = ({
   `;
 };
 
-export { getStyles, getAnimations };
+export { getAnimations, getStyles };

--- a/src/getStyles.js
+++ b/src/getStyles.js
@@ -98,9 +98,6 @@ const getStyles = ({
       font: 800 24px 'Segoe UI', Ubuntu, Sans-Serif; fill: ${textColor};
       animation: scaleInAnimation 0.3s ease-in-out forwards;
     }
-    .rank-progress-text {
-      font-size: 16px;
-    }
     .rank-percentile-header {
       font-size: 14px;
     }

--- a/src/getStyles.js
+++ b/src/getStyles.js
@@ -102,7 +102,7 @@ const getStyles = ({
       font-size: 16px;
     }
     .rank-percentile-header {
-      font-size: 16px;
+      font-size: 14px;
     }
     .rank-percentile-text {
       font-size: 16px;

--- a/tests/__snapshots__/renderWakatimeCard.test.js.snap
+++ b/tests/__snapshots__/renderWakatimeCard.test.js.snap
@@ -42,9 +42,6 @@ exports[`Test Render Wakatime Card should render correctly with compact layout 1
       font: 800 24px 'Segoe UI', Ubuntu, Sans-Serif; fill: #434d58;
       animation: scaleInAnimation 0.3s ease-in-out forwards;
     }
-    .rank-progress-text {
-      font-size: 16px;
-    }
     .rank-percentile-header {
       font-size: 14px;
     }
@@ -230,9 +227,6 @@ exports[`Test Render Wakatime Card should render correctly with compact layout w
     .rank-text {
       font: 800 24px 'Segoe UI', Ubuntu, Sans-Serif; fill: #434d58;
       animation: scaleInAnimation 0.3s ease-in-out forwards;
-    }
-    .rank-progress-text {
-      font-size: 16px;
     }
     .rank-percentile-header {
       font-size: 14px;

--- a/tests/__snapshots__/renderWakatimeCard.test.js.snap
+++ b/tests/__snapshots__/renderWakatimeCard.test.js.snap
@@ -46,7 +46,7 @@ exports[`Test Render Wakatime Card should render correctly with compact layout 1
       font-size: 16px;
     }
     .rank-percentile-header {
-      font-size: 16px;
+      font-size: 14px;
     }
     .rank-percentile-text {
       font-size: 16px;
@@ -235,7 +235,7 @@ exports[`Test Render Wakatime Card should render correctly with compact layout w
       font-size: 16px;
     }
     .rank-percentile-header {
-      font-size: 16px;
+      font-size: 14px;
     }
     .rank-percentile-text {
       font-size: 16px;

--- a/tests/__snapshots__/renderWakatimeCard.test.js.snap
+++ b/tests/__snapshots__/renderWakatimeCard.test.js.snap
@@ -45,6 +45,12 @@ exports[`Test Render Wakatime Card should render correctly with compact layout 1
     .rank-progress-text {
       font-size: 16px;
     }
+    .rank-percentile-header {
+      font-size: 16px;
+    }
+    .rank-percentile-text {
+      font-size: 16px;
+    }
     
     .not_bold { font-weight: 400 }
     .bold { font-weight: 700 }
@@ -226,6 +232,12 @@ exports[`Test Render Wakatime Card should render correctly with compact layout w
       animation: scaleInAnimation 0.3s ease-in-out forwards;
     }
     .rank-progress-text {
+      font-size: 16px;
+    }
+    .rank-percentile-header {
+      font-size: 16px;
+    }
+    .rank-percentile-text {
       font-size: 16px;
     }
     

--- a/tests/renderStatsCard.test.js
+++ b/tests/renderStatsCard.test.js
@@ -427,4 +427,18 @@ describe("Test renderStatsCard", () => {
       queryByTestId(document.body, "progress-rank-icon").textContent.trim(),
     ).toBe((100 - stats.rank.percentile).toFixed(1) + "%");
   });
+
+  it("should show the rank percentile", () => {
+    document.body.innerHTML = renderStatsCard(stats, {
+      rank_icon: "percentile",
+    });
+    expect(queryByTestId(document.body, "percentile-top-header")).toBeDefined();
+    expect(
+      queryByTestId(document.body, "percentile-top-header").textContent.trim(),
+    ).toBe("Top");
+    expect(queryByTestId(document.body, "rank-percentile-text")).toBeDefined();
+    expect(
+      queryByTestId(document.body, "percentile-rank-value").textContent.trim(),
+    ).toBe(stats.rank.percentile.toFixed(1) + "%");
+  });
 });

--- a/tests/renderStatsCard.test.js
+++ b/tests/renderStatsCard.test.js
@@ -429,6 +429,6 @@ describe("Test renderStatsCard", () => {
     expect(queryByTestId(document.body, "rank-percentile-text")).toBeDefined();
     expect(
       queryByTestId(document.body, "percentile-rank-value").textContent.trim(),
-    ).toBe((100 - stats.rank.percentile).toFixed(1) + "%");
+    ).toBe(stats.rank.percentile.toFixed(1) + "%");
   });
 });

--- a/tests/renderStatsCard.test.js
+++ b/tests/renderStatsCard.test.js
@@ -418,16 +418,6 @@ describe("Test renderStatsCard", () => {
     expect(queryByTestId(document.body, "github-rank-icon")).toBeDefined();
   });
 
-  it("should show the progress", () => {
-    document.body.innerHTML = renderStatsCard(stats, {
-      rank_icon: "progress",
-    });
-    expect(queryByTestId(document.body, "rank-progress-text")).toBeDefined();
-    expect(
-      queryByTestId(document.body, "progress-rank-icon").textContent.trim(),
-    ).toBe((100 - stats.rank.percentile).toFixed(1) + "%");
-  });
-
   it("should show the rank percentile", () => {
     document.body.innerHTML = renderStatsCard(stats, {
       rank_icon: "percentile",
@@ -439,6 +429,6 @@ describe("Test renderStatsCard", () => {
     expect(queryByTestId(document.body, "rank-percentile-text")).toBeDefined();
     expect(
       queryByTestId(document.body, "percentile-rank-value").textContent.trim(),
-    ).toBe(stats.rank.percentile.toFixed(1) + "%");
+    ).toBe((100 - stats.rank.percentile).toFixed(1) + "%");
   });
 });


### PR DESCRIPTION
This pull request adds the `percentile` option for the `rank_icon` query variable. This option displays the rank percentile the user belongs to. See https://github.com/anuraghazra/github-readme-stats/pull/2858#issuecomment-1597529697.

```md
[![Anurag's GitHub stats](https://github-readme-stats-git-addpercentilerankicon-rickstaa.vercel.app//api?username=anuraghazra&rank_icon=percentile)](https://github.com/anuraghazra/github-readme-stats)
```

[![Anurag's GitHub stats](https://github-readme-stats-git-addpercentilerankicon-rickstaa.vercel.app//api?username=anuraghazra&rank_icon=percentile)](https://github.com/anuraghazra/github-readme-stats)

@qwerty541 let me know what you think. We can also replace the `progress` option that was merged, but maybe having both options would be nice. I'm not yet sure 🤔 .