### PR TITLE
Increase e2e tests timeout secs

### DIFF
--- a/tests/e2e/e2e.test.js
+++ b/tests/e2e/e2e.test.js
@@ -108,7 +108,7 @@ describe("Fetch Cards", () => {
 
     // Check if stats card from deployment matches the stats card from local.
     expect(serverStatsSvg.data).toEqual(localStatsCardSVG);
-  }, 7000);
+  }, 15000);
 
   test("retrieve language card", async () => {
     expect(VERCEL_PREVIEW_URL).toBeDefined();
@@ -133,7 +133,7 @@ describe("Fetch Cards", () => {
 
     // Check if language card from deployment matches the local language card.
     expect(severLanguageSVG.data).toEqual(localLanguageCardSVG);
-  });
+  }, 15000);
 
   test("retrieve WakaTime card", async () => {
     expect(VERCEL_PREVIEW_URL).toBeDefined();
@@ -153,7 +153,7 @@ describe("Fetch Cards", () => {
 
     // Check if WakaTime card from deployment matches the local WakaTime card.
     expect(serverWakaTimeSvg.data).toEqual(localWakaCardSVG);
-  });
+  }, 15000);
 
   test("retrieve repo card", async () => {
     expect(VERCEL_PREVIEW_URL).toBeDefined();
@@ -175,5 +175,5 @@ describe("Fetch Cards", () => {
 
     // Check if Repo card from deployment matches the local Repo card.
     expect(serverRepoSvg.data).toEqual(localRepoCardSVG);
-  });
+  }, 15000);
 });


### PR DESCRIPTION
I noticed that in last time different e2e tests failed several time due to timeout. I think we should increase default jest 5 seconds timeout (https://jestjs.io/docs/next/api#testname-fn-timeout) to prevent this errors.

Examples of failed workflows:

https://github.com/anuraghazra/github-readme-stats/actions/runs/5344257566/jobs/9688569188
https://github.com/anuraghazra/github-readme-stats/actions/runs/5344257566/jobs/9688422630
https://github.com/anuraghazra/github-readme-stats/actions/runs/5343322235/jobs/9692637166