### PR TITLE
CI: Fix warnings variable usage inside theme preview workflow

### DIFF
--- a/scripts/preview-theme.js
+++ b/scripts/preview-theme.js
@@ -451,7 +451,7 @@ export const run = async () => {
       debug("Theme preview body: Check if the theme colors are valid...");
       let invalidColors = false;
       if (!colors) {
-        warning.push("Theme colors are missing");
+        warnings.push("Theme colors are missing");
         invalidColors = true;
       } else {
         const missingKeys = REQUIRED_COLOR_PROPS.filter(


### PR DESCRIPTION
I'm currently working on eslint integration and i found a bug inside theme preview script. Related to https://github.com/anuraghazra/github-readme-stats/pull/2882#issuecomment-1606993478