### PR TITLE
ci: fix id-token 'read' bug

### DIFF
--- a/.github/workflows/empty-issues-closer.yaml
+++ b/.github/workflows/empty-issues-closer.yaml
@@ -11,7 +11,7 @@ permissions:
   checks: read
   contents: read
   deployments: read
-  id-token: read
+  id-token: none
   issues: write
   discussions: read
   packages: read

--- a/.github/workflows/generate-theme-doc.yml
+++ b/.github/workflows/generate-theme-doc.yml
@@ -11,7 +11,7 @@ permissions:
   checks: read
   contents: write
   deployments: read
-  id-token: read
+  id-token: none
   issues: read
   discussions: read
   packages: read

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -7,7 +7,7 @@ permissions:
   checks: read
   contents: read
   deployments: read
-  id-token: read
+  id-token: none
   issues: read
   discussions: read
   packages: read

--- a/.github/workflows/preview-theme.yml
+++ b/.github/workflows/preview-theme.yml
@@ -12,7 +12,7 @@ permissions:
   checks: read
   contents: read
   deployments: read
-  id-token: read
+  id-token: none
   issues: read
   discussions: read
   packages: read

--- a/.github/workflows/prs-cache-clean.yml
+++ b/.github/workflows/prs-cache-clean.yml
@@ -9,7 +9,7 @@ permissions:
   checks: read
   contents: read
   deployments: read
-  id-token: read
+  id-token: none
   issues: read
   discussions: read
   packages: read

--- a/.github/workflows/stale-theme-pr-closer.yaml
+++ b/.github/workflows/stale-theme-pr-closer.yaml
@@ -8,7 +8,7 @@ permissions:
   checks: read
   contents: read
   deployments: read
-  id-token: read
+  id-token: none
   issues: read
   discussions: read
   packages: read

--- a/.github/workflows/top-issues-dashboard.yml
+++ b/.github/workflows/top-issues-dashboard.yml
@@ -9,7 +9,7 @@ permissions:
   checks: read
   contents: read
   deployments: read
-  id-token: read
+  id-token: none
   issues: write
   discussions: read
   packages: read

--- a/.github/workflows/update-langs.yaml
+++ b/.github/workflows/update-langs.yaml
@@ -8,7 +8,7 @@ permissions:
   checks: read
   contents: read
   deployments: read
-  id-token: read
+  id-token: none
   issues: read
   discussions: read
   packages: read


### PR DESCRIPTION
This PR fixes a bug that is present when the `read` option is used for the `id-token` permission (see https://github.com/github/docs/issues/26481).
