### PR TITLE
CI: Fix pull requests labeler workflow error

### DIFF
--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -7,7 +7,7 @@ permissions:
   checks: read
   contents: read
   deployments: read
-  issues: read
+  issues: write
   discussions: read
   packages: read
   pages: read


### PR DESCRIPTION
Error:

https://github.com/anuraghazra/github-readme-stats/actions/runs/5435984321/workflow

Edited file does not show same error:

https://github.com/anuraghazra/github-readme-stats/actions/runs/5438592304/workflow