### PR TITLE
Docs: Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# GitHub Readme Stats Security Policies and Procedures <!-- omit in toc -->
+
+This document outlines security procedures and general policies for the
+GitHub Readme Stats project.
+
+- [Reporting a Vulnerability](#reporting-a-vulnerability)
+- [Disclosure Policy](#disclosure-policy)
+
+## Reporting a Vulnerability 
+
+The GitHub Readme Stats team and community take all security vulnerabilities
+seriously. Thank you for improving the security of our open source 
+software. We appreciate your efforts and responsible disclosure and will
+make every effort to acknowledge your contributions.
+
+Report security vulnerabilities by emailing the GitHub Readme Stats team at:
+
+```
+hazru.anurag@gmail.com
+```
+
+The lead maintainer will acknowledge your email within 24 hours, and will
+send a more detailed response within 48 hours indicating the next steps in 
+handling your report. After the initial reply to your report, the security
+team will endeavor to keep you informed of the progress towards a fix and
+full announcement, and may ask for additional information or guidance.
+
+Report security vulnerabilities in third-party modules to the person or 
+team maintaining the module.
+
+## Disclosure Policy
+
+When the security team receives a security bug report, they will assign it
+to a primary handler. This person will coordinate the fix and release
+process, involving the following steps:
+
+  * Confirm the problem.
+  * Audit code to find any potential similar problems.
+  * Prepare fixes and release them as fast as possible.


### PR DESCRIPTION
Adding basic security policy to resolve code scanning alert: https://github.com/anuraghazra/github-readme-stats/security/code-scanning/43

I used this as template: https://github.com/atomist/samples/blob/master/SECURITY.md

@rickstaa What do you think about this?