### PR TITLE
build: rename lint command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run ESLint
         run: |
-          npm run lints
+          npm run lint
 
       - name: Run Prettier
         run: |

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,5 +2,5 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npm test
-npm run lints
+npm run lint
 npx lint-staged

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "prepare": "husky install",
-    "lints": "npx eslint --max-warnings 0 \"./src/**.js\" \"./scripts/**.js\" \"./tests/**.js\" \"./api/**.js\" \"./themes/**.js\""
+    "lint": "npx eslint --max-warnings 0 \"./src/**.js\" \"./scripts/**.js\" \"./tests/**.js\" \"./api/**.js\" \"./themes/**.js\""
   },
   "author": "Anurag Hazra",
   "license": "MIT",


### PR DESCRIPTION
Small PR that changes `npm run lints` to `npm run lint`. This was done for consistency with other npm projects and the `npm run format` command.