### PR TITLE
Silence vscode type error in chunkArray function

### DIFF
--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -412,9 +412,11 @@ const chunkArray = (arr, perChunk) => {
     const chunkIndex = Math.floor(index / perChunk);
 
     if (!resultArray[chunkIndex]) {
+      // @ts-ignore
       resultArray[chunkIndex] = []; // start a new chunk
     }
 
+    // @ts-ignore
     resultArray[chunkIndex].push(item);
 
     return resultArray;


### PR DESCRIPTION
Currently we are unable to fix this error since we need to set type for second argument of `.reduce()` function like `[] as Array<Array<T>>`. Otherwise it was set `never[]` by default. Can be fixed after migration on typescript.