### PR TITLE
Top langs card: Remove unreachable code from fetcher and increase tests coverage

### DIFF
--- a/src/fetchers/top-languages-fetcher.js
+++ b/src/fetchers/top-languages-fetcher.js
@@ -77,12 +77,6 @@ const fetchTopLanguages = async (
 
   if (res.data.errors) {
     logger.error(res.data.errors);
-    throw Error(res.data.errors[0].message || "Could not fetch user");
-  }
-
-  // Catch GraphQL errors.
-  if (res.data.errors) {
-    logger.error(res.data.errors);
     if (res.data.errors[0].type === "NOT_FOUND") {
       throw new CustomError(
         res.data.errors[0].message || "Could not fetch user.",

--- a/tests/fetchTopLanguages.test.js
+++ b/tests/fetchTopLanguages.test.js
@@ -141,11 +141,31 @@ describe("FetchTopLanguages", () => {
     });
   });
 
-  it("should throw error", async () => {
+  it("should throw specific error when user not found", async () => {
     mock.onPost("https://api.github.com/graphql").reply(200, error);
 
     await expect(fetchTopLanguages("anuraghazra")).rejects.toThrow(
       "Could not resolve to a User with the login of 'noname'.",
+    );
+  });
+
+  it("should throw other errors with their message", async () => {
+    mock.onPost("https://api.github.com/graphql").reply(200, {
+      errors: [{ message: "Some test GraphQL error" }],
+    });
+
+    await expect(fetchTopLanguages("anuraghazra")).rejects.toThrow(
+      "Some test GraphQL error",
+    );
+  });
+
+  it("should throw error with specific message when error does not contain message property", async () => {
+    mock.onPost("https://api.github.com/graphql").reply(200, {
+      errors: [{ type: "TEST" }],
+    });
+
+    await expect(fetchTopLanguages("anuraghazra")).rejects.toThrow(
+      "Something went while trying to retrieve the language data using the GraphQL API.",
     );
   });
 });

--- a/tests/top-langs.test.js
+++ b/tests/top-langs.test.js
@@ -139,7 +139,12 @@ describe("Test /api/top-langs", () => {
     await topLangs(req, res);
 
     expect(res.setHeader).toBeCalledWith("Content-Type", "image/svg+xml");
-    expect(res.send).toBeCalledWith(renderError(error.errors[0].message));
+    expect(res.send).toBeCalledWith(
+      renderError(
+        error.errors[0].message,
+        "Make sure the provided username is not an organization",
+      ),
+    );
   });
 
   it("should render error card on incorrect layout input", async () => {


### PR DESCRIPTION
There is two error handlers inside `fetchTopLanguages` function. Having error handler on strings 78-81 makes unreachable the next more advanced error handler on strings 84-102.