### PR TITLE
Edit docs : `Language Card Exclusive Options` sections for each language

### DIFF
--- a/docs/readme_cn.md
+++ b/docs/readme_cn.md
@@ -187,10 +187,17 @@ dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontr
 
 #### 语言卡片专属选项:
 
-- `hide` - 从卡片中隐藏指定语言 _(Comma seperated values)_
-- `hide_title` - _(boolean)_
-- `layout` - 提供五種佈局 `normal` & `compact` & `donut` & `donut-vertical` & `pie` 间切换
-- `card_width` - 手动设置卡片的宽度 _(number)_
+- `hide` - 从卡片中隐藏指定语言 _(逗号分隔的值)_。默认：`[] (空数组)`。
+- `hide_title` - _(boolean)_。默认：`false`。
+- `layout` - 提供五種佈局 `normal` & `compact` & `donut` & `donut-vertical` & `pie` 间切换。默认：`normal`。
+- `card_width` - 手动设置卡片的宽度 _(number)_。默认 `300`。
+- `langs_count` - 在卡片上显示更多的语言，范围在 1-20 之间 _(number)_。默认：`normal` 和 `donut` 为 `5`，其他布局为 `6`。
+- `exclude_repo` - 排除指定的仓库 _(逗号分隔的值)_。默认：`[] (空数组)`。
+- `custom_title` - 为卡片设置自定义标题 _(string)_。默认为 `Most Used Languages`。
+- `disable_animations` - 在卡片中禁用所有动画 _(boolean)_。默认：`false`。
+- `hide_progress` - 使用紧凑的布局选项，隐藏百分比并删除条形图。默认：`false`。
+- `size_weight` - 配置语言统计算法 _(number)_（请参阅[语言统计算法](#Language-stats-algorithm)），默认为 1。
+- `count_weight` - 配置语言统计算法 _(number)_（请参阅[语言统计算法](#Language-stats-algorithm)），默认为 0。
 
 > :warning: **重要:**
 > 如 [Percent Encoding](https://en.wikipedia.org/wiki/Percent-encoding) 所指定，语言名称应使用 uri 转义。

--- a/docs/readme_de.md
+++ b/docs/readme_de.md
@@ -177,10 +177,17 @@ Du kannst mehrere, mit Kommas separierte, Werte in der bg_color Option angeben, 
 
 #### Exklusive Optionen der Sprachen-Karte:
 
-- `hide` - Verbirgt die angegebenen Sprachen von der Karte _(Komma separierte Werte)_
-- `hide_title` - _(Boolean)_
-- `layout` - Wechseln Sie zwischen den fünf verfügbaren Layouts `normal` & `compact` & `donut` & `donut-vertical` & `pie`
-- `card_width` - Lege die Breite der Karte manuell fest _(Zahl)_
+- `hide` - Verbirgt die angegebenen Sprachen von der Karte _(Komma separierte Werte)_. Standard: `[] (leeres Array)`.
+- `hide_title` - _(Boolean)_. Standard: `false`.
+- `layout` - Wechseln Sie zwischen den fünf verfügbaren Layouts `normal` & `compact` & `donut` & `donut-vertical` & `pie`. Standard: `normal`.
+- `card_width` - Lege die Breite der Karte manuell fest _(number)_. Standard: `300`.
+- `langs_count` - Zeigt mehr Sprachen auf der Karte an, zwischen 1-20 _(number)_. Standard: `5` für `normal` und `donut`, `6` für andere Layouts.
+- `exclude_repo` - Schließt angegebene Repositorys aus _(Kommagetrennte Werte)_. Standard: `[] (leeres Array)`.
+- `custom_title` - Setzt einen benutzerdefinierten Titel für die Karte _(String)_. Standard: `Most Used Languages`.
+- `disable_animations` - Deaktiviert alle Animationen auf der Karte _(Boolean)_. Standard: `false`.
+- `hide_progress` - Verwendet die kompakte Layoutoption, blendet Prozentsätze aus und entfernt die Balken. Standard: `false`.
+- `size_weight` - Konfiguriert den Algorithmus für Sprachstatistiken _(number)_ (siehe [Sprachstatistikalgorithmus](#Language-stats-algorithm)), Standard: 1.
+- `count_weight` - Konfiguriert den Algorithmus für Sprachstatistiken _(number)_ (siehe [Sprachstatistikalgorithmus](#Language-stats-algorithm)), Standard: 0.
 
 > :warning: **Wichtig:**
 > Sprachennamen sollten uri-escaped sein, wie hier angegeben: [Percent Encoding](https://en.wikipedia.org/wiki/Percent-encoding)

--- a/docs/readme_es.md
+++ b/docs/readme_es.md
@@ -194,13 +194,17 @@ Puedes pasar mútliples valores separados por coma en la opción `bg_color` para
 
 #### Opciones exclusivas de la Tarjeta de Lenguajes:
 
-- `hide` - Oculta de la tarjeta los lenguajes especificados  _(valores separados por comas)_
-- `hide_title` - _(booleano)_
-- `layout` - Cambiar entre los cinco diseños disponibles `normal` & `compact` & `donut` & `donut-vertical` & `pie`
-- `card_width` - Establece el ancho de la tarjeta manualmente _(número)_
-- `langs_count` - Muestra más lenguajes en la tarjeta, entre 1-10, por defecto 5 _(número)_
-- `exclude_repo` - Excluye los repositorios especificados  _(valores separados por comas)_
-- `custom_title` - Establece un título personalizado
+- `hide` - Oculta de la tarjeta los lenguajes especificados  _(valores separados por comas)_. Por defecto: `[] (matriz vacía)`.
+- `hide_title` - _(booleano)_. Por defecto: `false`.
+- `layout` - Cambiar entre los cinco diseños disponibles `normal` & `compact` & `donut` & `donut-vertical` & `pie`. Por defecto: `normal`.
+- `card_width` - Establece el ancho de la tarjeta manualmente _(número)_. Por defecto: `300`.
+- `langs_count` - Muestra más lenguajes en la tarjeta, entre 1-20 _(número)_. Por defecto: `5` para `normal` y `donut`, `6` para otros diseños.
+- `exclude_repo` - Excluye repositorios especificados _(valores separados por comas)_. Por defecto: `[] (matriz vacía)`.
+- `custom_title` - Establece un título personalizado para la tarjeta _(cadena)_. Por defecto: `Most Used Languages`.
+- `disable_animations` - Desactiva todas las animaciones en la tarjeta _(booleano)_. Por defecto: `false`.
+- `hide_progress` - Utiliza la opción de diseño compacto, oculta los porcentajes y elimina las barras. Por defecto: `false`.
+- `size_weight` - Configura el algoritmo de estadísticas de lenguaje _(número)_ (ver [Algoritmo de estadísticas de lenguaje](#Language-stats-algorithm)), por defecto 1.
+- `count_weight` - Configura el algoritmo de estadísticas de lenguaje _(número)_ (ver [Algoritmo de estadísticas de lenguaje](#Language-stats-algorithm)), por defecto 0.
 
 > :warning: **Importante:**
 > Los nombres de los lenguajes deben estar codificados para URLs, como se especifica en [Código porciento](https://es.wikipedia.org/wiki/C%C3%B3digo_porciento)
@@ -276,7 +280,7 @@ Puedes usar el parámetro `?hide=language1,language2` para ocultar lenguajes ind
 
 ### Mostrar más lenguajes
 
-Puedes usar el paramétro `&langs_count=` para incrementar o decrementar el número de lenguajes mostrados en la tarjeta. Los valores admitidos son los números enteros entre 1 y 10 (inclusive), y el valor por defecto es 5.
+Puedes usar el paramétro `&langs_count=` para incrementar o decrementar el número de lenguajes mostrados en la tarjeta. Los valores admitidos son los números enteros entre 1 y 20 (inclusive), y el valor por defecto es 5.
 
 ```md
 [![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=anuraghazra&langs_count=8)](https://github.com/anuraghazra/github-readme-stats)

--- a/docs/readme_fr.md
+++ b/docs/readme_fr.md
@@ -174,10 +174,17 @@ Vous pouvez fournir plusieurs valeurs (suivie d'une virgule) dans l'option bg_co
 
 #### Language Card Exclusive Options:
 
--   `hide` - Masquer les langages spécifiés sur la carte _(Comma seperated values)_
--   `hide_title` - Masquer le titre _(boolean)_
--   `layout` - Alterner entre 5 mise en page `normal` & `compact` & `donut` & `donut-vertical` & `pie`
--   `card_width` - Fixer la largeur de la carte manuellement _(number)_
+-   `hide` - Masque les langages spécifiés de la carte _(valeurs séparées par des virgules)_. Par défaut: `[] (tableau vide)`.
+-   `hide_title` - _(booléen)_. Par défaut: `false`.
+-   `layout` - Alterne entre cinq mises en page disponibles `normal` & `compact` & `donut` & `donut-vertical` & `pie`. Par défaut: `normal`.
+-   `card_width` - Définit manuellement la largeur de la carte _(nombre)_. Par défaut `300`.
+-   `langs_count` - Affiche plus de langages sur la carte, entre 1-20 _(nombre)_. Par défaut: `5` pour `normal` et `donut`, `6` pour les autres mises en page.
+-   `exclude_repo` - Exclut les dépôts spécifiés _(valeurs séparées par des virgules)_. Par défaut: `[] (tableau vide)`.
+-   `custom_title` - Définit un titre personnalisé pour la carte _(chaîne)_. Par défaut `Most Used Languages`.
+-   `disable_animations` - Désactive toutes les animations dans la carte _(booléen)_. Par défaut: `false`.
+-   `hide_progress` - Utilise l'option de mise en page compacte, masque les pourcentages et supprime les barres. Par défaut: `false`.
+-   `size_weight` - Configure l'algorithme de statistiques de langage _(nombre)_ (voir [Algorithme de statistiques de langage](#Language-stats-algorithm)), par défaut 1.
+-   `count_weight` - Configure l'algorithme de statistiques de langage _(nombre)_ (voir [Algorithme de statistiques de langage](#Language-stats-algorithm)), par défaut 0.
 
 > :warning: **Important:**
 > Les noms des langages doivent être en format uri, comme spécifié dans [Percent Encoding](https://fr.wikipedia.org/wiki/Percent-encoding)

--- a/docs/readme_it.md
+++ b/docs/readme_it.md
@@ -188,10 +188,17 @@ Puoi fornire valori separati da virgola nel parametro bg_color per creare un gra
 
 #### Opzioni valide solo per le card dei linguaggi:
 
-- `hide` - Nasconde un linguaggio specifico _(valori separati da virgola)_
-- `hide_title` - Nasconde il titolo _(booleano)_
-- `layout` - Specificare il tipo di layout, `normal` (esteso), `compact` (compatto), `donut` (ciambella), `donut-vertical` (ciambella verticale) e `pie` (torta)
-- `card_width` - Specifica il valore della larghezza _(numero)_
+- `hide` - Nasconde un linguaggio specifico _(valori separati da virgola)_. Predefinito: `[] (array vuoto)`.
+- `hide_title` - Nasconde il titolo _(booleano)_. Predefinito: `false`.
+- `layout` - Specificare il tipo di layout, `normal` (esteso), `compact` (compatto), `donut` (ciambella), `donut-vertical` (ciambella verticale) e `pie` (torta). Predefinito: `normal`.
+- `card_width` - Specifica il valore della larghezza _(numero)_. Predefinito `300`.
+- `langs_count` - Mostra più lingue sulla carta, tra 1-20 _(numero)_. Predefinito: `5` per `normale` e `ciambella`, `6` per le altre disposizioni.
+- `exclude_repo` - Esclude i repository specificati _(valori separati da virgola)_. Predefinito: `[] (array vuoto)`.
+- `custom_title` - Imposta un titolo personalizzato per la carta _(stringa)_. Predefinito `Most Used Languages`.
+- `disable_animations` - Disabilita tutte le animazioni nella carta _(booleano)_. Predefinito: `false`.
+- `hide_progress` - Utilizza l'opzione di layout compatto, nasconde le percentuali e rimuove le barre. Predefinito: `false`.
+- `size_weight` - Configura l'algoritmo delle statistiche di linguaggio _(numero)_ (vedi [Algoritmo delle statistiche di linguaggio](#Language-stats-algorithm)), predefinito 1.
+- `count_weight` - Configura l'algoritmo delle statistiche di linguaggio _(numero)_ (vedi [Algoritmo delle statistiche di linguaggio](#Language-stats-algorithm)), predefinito 0.
 
 > :warning: **Importante:**
 > Per i nomi dei linguaggi, assicurati di effettuare l'encoding giusto nell'uri, come specificato in [Percent Encoding](https://en.wikipedia.org/wiki/Percent-encoding)

--- a/docs/readme_ja.md
+++ b/docs/readme_ja.md
@@ -190,13 +190,17 @@ bg_color オプションで複数のカンマ区切りの値を指定してグ�
 
 #### Language Card だけに存在するオプション
 
-- `hide` - 特定の言語を隠す _(カンマ区切りで指定)_
-- `hide_title` - _(boolean)_
-- `layout` - `normal` & `compact` & `donut` & `donut-vertical` & `pie` のいずれかのレイアウトに切り替える
-- `card_width` - カードの横幅 _(number)_
-- `langs_count` - 表示される言語の数　_(1 ~ 10, 初期値 5)_
-- `exclude_repo` - 指定されたリポジトリを除外する _(カンマ区切りで指定)_
-- `custom_title` - タイトル文字列を変更する
+- `hide` - 特定の言語を隠す _(カンマ区切りで指定)_。デフォルト：`[]（空の配列）`。
+- `hide_title` - _(boolean)_。デフォルト：`false`。
+- `layout` - `normal` & `compact` & `donut` & `donut-vertical` & `pie` のいずれかのレイアウトに切り替える。デフォルト：`normal`。
+- `card_width` - カードの横幅 _(number)_。デフォルト `300`。
+- `langs_count` - 表示される言語の数　_(1 ~ 20, 初期値 5)_。デフォルト：`通常`と`ドーナツ`では`5`、他のレイアウトでは`6`。
+- `exclude_repo` - 指定されたリポジトリを除外する _(カンマ区切りで指定)_。デフォルト：`[]（空の配列）`。
+- `custom_title` - タイトル文字列を変更する。デフォルト: `Most Used Languages`。
+- `disable_animations` - カード内のすべてのアニメーションを無効にします *(boolean)*。デフォルト：`false`。
+- `hide_progress` - コンパクトなレイアウトオプションを使用し、パーセンテージを非表示にし、バーを削除します。デフォルト：`false`。
+- `size_weight` - 言語統計アルゴリズムを設定します *(number)*（詳細は[言語統計アルゴリズム](#Language-stats-algorithm)を参照）、デフォルトは1です。
+- `count_weight` - 言語統計アルゴリズムを設定します *(number)*（詳細は[言語統計アルゴリズム](#Language-stats-algorithm)を参照）、デフォルトは0です。
 
 > :warning: **重要:**
 > [Percent Encoding](https://en.wikipedia.org/wiki/Percent-encoding) で指定されているように、プログラミング言語の名前は URL エンコードされている必要があります。

--- a/docs/readme_kr.md
+++ b/docs/readme_kr.md
@@ -208,13 +208,17 @@ dark, radical, merko, gruvbox, tokyonight, onedark, cobalt, synthwave, highcontr
 
 #### 언어 사용량 통계 카드의 표시 제한 옵션:
 
-- `hide` - 카드에서 특정 언어 제외 _(Comma-separated values)_
-- `hide_title` - 타이틀 제외 _(boolean)_
-- `layout` - 5가지 값 사용 가능, `normal` & `compact` & `donut` & `donut-vertical` & `pie` 중 표시 형태 선택
-- `card_width` - 카드 너비 직접 설정 _(number)_
-- `langs_count` - 카드에 표시할 언어의 수 (1-10 사이, 기본 값 : 5) _(number)_
-- `exclude_repo` - 통계에 제외할 저장소 지정 _(Comma-separated values)_
-- `custom_title` - 카드의 타이틀 값 설정
+- `hide` - 카드에서 특정 언어 제외 _(쉼표로 구분된 값)_. 기본값: `[] (빈 배열)`.
+- `hide_title` - 타이틀 제외 _(boolean)_. 기본값: `false`.
+- `layout` - 5가지 값 사용 가능, `normal` & `compact` & `donut` & `donut-vertical` & `pie` 중 표시 형태 선택. 기본값: `normal`.
+- `card_width` - 카드 너비 직접 설정 _(number)_. 기본값 `300`.
+- `langs_count` - 카드에 표시할 언어의 수 (1-20 사이). 기본값: `normal` 및 `donut`의 경우 `5`, 기타 레이아웃의 경우 `6`.
+- `exclude_repo` - 통계에 제외할 저장소 지정 _(쉼표로 구분된 값)_. 기본값: `[] (빈 배열)`.
+- `custom_title` - 카드의 타이틀 값 설정 _(string)_.. 기본값 `Most Used Languages`.
+- `disable_animations` - 카드의 모든 애니메이션을 비활성화 _(boolean)_. 기본값: `false`.
+- `hide_progress` - 간소화된 레이아웃 옵션을 사용하여 백분율과 막대를 제거. 기본값: `false`.
+- `size_weight` - 언어 통계 알고리즘 구성 _(number)_ (자세한 내용은 [언어 통계 알고리즘](#Language-stats-algorithm) 참조), 기본값: 1.
+- `count_weight` - 언어 통계 알고리즘 구성 _(number)_ (자세한 내용은 [언어 통계 알고리즘](#Language-stats-algorithm) 참조), 기본값: 0.
 
 ##### 경고! **매우 중요**
 >
@@ -292,7 +296,7 @@ _참고:
 
 ### 표시할 언어 수 지정하기
 
-`&langs_count=` 속성을 통해 카드에 표시할 언어의 수를 지정할 수 있어요. (1-10 사이, 기본 값 : 5)
+`&langs_count=` 속성을 통해 카드에 표시할 언어의 수를 지정할 수 있어요. (1-20 사이, 기본 값 : 5)
 
 ```md
 [![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=anuraghazra&langs_count=8)](https://github.com/anuraghazra/github-readme-stats)

--- a/docs/readme_nl.md
+++ b/docs/readme_nl.md
@@ -195,13 +195,19 @@ Je kan meerdere komma verdeelde waarden in de bg_color optie geven om een kleure
 
 #### Exclusieve opties voor Programmeertaal Kaart:
 
-- `hide` - Verbergt specifieke talen van de kaart _(komma gescheiden waardes)_
-- `hide_title` - _(boolean)_
-- `layout` - Kies uit de vijf beschikbare lay-outs `normal` & `compact` & `donut` & `donut-vertical` & `pie`
-- `card_width` - Stelt de breedte van de kaart handmatig in. _(nummer)_
-- `langs_count` - Laat meer talen op de kaart zien, waarde tussen 1-10, staat standaard op to 5 _(nummer)_
-- `exclude_repo` - Verbergt specifieke repositories _(komma gescheiden waardes)_
-- `custom_title` - Stelt een eigen titel voor de kaart in
+- `hide` - Verbergt specifieke talen van de kaart _(komma gescheiden waardes)_. Standaard: `[] (lege array)`.
+- `hide_title` - _(boolean)_. Standaard: `false`.
+- `layout` - Kies uit de vijf beschikbare lay-outs `normal` & `compact` & `donut` & `donut-vertical` & `pie`. Standaard: `normal`.
+- `card_width` - Stelt de breedte van de kaart handmatig in. _(nummer)_. Standaard `300`.
+- `langs_count` - Laat meer talen op de kaart zien, waarde tussen 1-20. Standaard: `5` voor `normal` en `donut`, `6` voor andere indelingen.
+- `exclude_repo` - Verbergt specifieke repositories _(komma gescheiden waardes)_. Standaard: `[] (lege array)`.
+- `custom_title` - Stelt een eigen titel voor de kaart in. Standaard `Most Used Languages`.
+- `disable_animations` - Schakelt alle animaties uit op de kaart *(boolean)*. Standaard: `false`.
+- `hide_progress` - Gebruikt de compacte indelingsoptie, verbergt percentages en verwijdert de balken. Standaard: `false`.
+- `size_weight` - Configureert het taalstatistieken-algoritme *(number)* (zie [Taalstatistieken-algoritme](#Language-stats-algorithm)), standaardwaarde is 1.
+- `count_weight` - Configureert het taalstatistieken-algoritme *(number)* (zie [Taalstatistieken-algoritme](#Language-stats-algorithm)), standaardwaarde is 0.
+
+Dit is een .md-document op GitHub, ik heb de tekst voor je naar het Nederlands vertaald, met uitzondering van links en variabelen.
 
 > :Waarschuwing: **Belangrijk:**
 > Namen van programmeertalen moeten worden geuri-escaped, zoals gespecificeerd in [Percent Encoding](https://en.wikipedia.org/wiki/Percent-encoding)
@@ -277,7 +283,7 @@ Je kan de `?hide=taal1,taal2` parameter gebruiken om individuele programmeer tal
 
 ### Laat meer programmeertalen zien
 
-Je kan de `&langs_count=` optie gebruiken om de hoeveelheid talen op je kaart groter en kleiner te maken. Geldige waardes zijn tussen de 1 en 10 (inclusief), en de standaard waarde is 5.
+Je kan de `&langs_count=` optie gebruiken om de hoeveelheid talen op je kaart groter en kleiner te maken. Geldige waardes zijn tussen de 1 en 20 (inclusief), en de standaard waarde is 5.
 
 ```md
 [![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=anuraghazra&langs_count=8)](https://github.com/anuraghazra/github-readme-stats)

--- a/docs/readme_np.md
+++ b/docs/readme_np.md
@@ -193,13 +193,17 @@ You can provide multiple comma-separated values in bg_color option to render a g
 
 #### भाषा कार्ड अनन्य विकल्पहरू :
 
-- `hide` - Hide the languages specified from the card _(Comma-separated values)_
-- `hide_title` - _(boolean)_
-- `layout` - Switch between five available layouts `normal` & `compact` & `donut` & `donut-vertical` & `pie`. Default: `normal`.
-- `card_width` - Set the card's width manually _(number)_
-- `langs_count` - Show more languages on the card, between 1-10, defaults to 5 _(number)_
-- `exclude_repo` - Exclude specified repositories _(Comma-separated values)_
-- `custom_title` - Sets a custom title for the card
+- `hide` - कार्डबाट दिइएका भाषाहरूलाई लुकाउँछ _(कमा-विभाजित मूल्यहरू)_। Default: `[] (खाली सरणी)`।
+- `hide_title` - _(boolean)_। Default: `false`।
+- `layout` - पाँच उपलब्ध लेआउटहरूमध्ये परिवर्तन गर्दछ `normal` & `compact` & `donut` & `donut-vertical` & `pie`। Default: `normal`।
+- `card_width` - कार्डको चौडाइलाई म्यानुअल रूपमा सेट गर्दछ _(number)_। Default `300`।
+- `langs_count` - कार्डमा अधिक भाषाहरू देखाउँछ, 1-20 को बीच _(number)_। Default: `सामान्य` र `डोनट` को लागि `5`, अन्य लेआउटहरूको लागि `6`।
+- `exclude_repo` - निर्दिष्ट रिपोजिटोरीहरूलाई बाहिर राख्दछ _(कमा-विभाजित मूल्यहरू)_। Default: `[] (खाली सरणी)`।
+- `custom_title` - कार्डको लागि विशेष शीर्षक सेट गर्दछ _(number)_। Default `Most Used Languages`।
+- `disable_animations` - कार्डमा सबै एनिमेसनलाई अक्षम गर्दछ _(boolean)_। Default: `false`।
+- `hide_progress` - संक्षिप्त लेआउट विकल्प प्रयोग गर्दछ, प्रतिशतहरूलाई लुकाउँछ, र बारहरूलाई हटाउँछ। Default: `false`।
+- `size_weight` - भाषा आँकडा एल्गोरिदमको कृयात्मक गर्दछ _(number)_ (देख्नुहोस् [भाषा आँकडा एल्गोरिदम](#Language-stats-algorithm)), Default: `1`।
+- `count_weight` - भाषा आँकडा एल्गोरिदमको कृयात्मक गर्दछ _(number)_ (देख्नुहोस् [भाषा आँकडा एल्गोरिदम](#Language-stats-algorithm)), Default: `0`।
 
 > :warning: **Important:**
 > Language names should be uri-escaped, as specified in [Percent Encoding](https://en.wikipedia.org/wiki/Percent-encoding)
@@ -273,7 +277,7 @@ You can use `?hide=language1,language2` parameter to hide individual languages.
 
 ### धेरॆ भाषाहरु हेर्नको लागि 
 
-You can use the `&langs_count=` option to increase or decrease the number of languages shown on the card. Valid values are integers between 1 and 10 (inclusive), and the default is 5.
+You can use the `&langs_count=` option to increase or decrease the number of languages shown on the card. Valid values are integers between 1 and 20 (inclusive), and the default is 5.
 
 ```md
 [![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=anuraghazra&langs_count=8)](https://github.com/anuraghazra/github-readme-stats)

--- a/docs/readme_pt-BR.md
+++ b/docs/readme_pt-BR.md
@@ -181,10 +181,19 @@ Personalize a aparência do seu `Stats Card` ou `Repo Card` da maneira que desej
 
 #### Opções exclusivas do cartão de linguagens:
 
-- `hide` - Oculta linguagens específicas _(Valores separados por vírgulas)_
-- `hide_title` - Oculta o título _(boolean)_
-- `layout` - Alternar entre os cinco layouts disponíveis `normal` & `compact` & `donut` & `donut-vertical` & `pie`
-- `card_width` - Define a largura do cartão manualmente _(number)_
+- `hide` - Oculta linguagens específicas _(Valores separados por vírgulas)_. Padrão: `[] (array vazio)`.
+- `hide_title` - Oculta o título _(boolean)_. Padrão: `false`.
+- `layout` - Alternar entre os cinco layouts disponíveis `normal` & `compact` & `donut` & `donut-vertical` & `pie`. Padrão: `normal`.
+- `card_width` - Define a largura do cartão manualmente _(number)_. Padrão `300`.
+- `langs_count` - Mostra mais idiomas no cartão, entre 1-20 *(number)*. Padrão: `5` para `normal` e `donut`, `6` para outros layouts.
+- `exclude_repo` - Exclui repositórios especificados *(valores separados por vírgulas)*. Padrão: `[] (array vazio)`.
+- `custom_title` - Define um título personalizado para o cartão *(string)*. Padrão `Most Used Languages`.
+- `disable_animations` - Desativa todas as animações no cartão *(boolean)*. Padrão: `false`.
+- `hide_progress` - Usa a opção de layout compacto, esconde as porcentagens e remove as barras. Padrão: `false`.
+- `size_weight` - Configura o algoritmo de estatísticas de idioma *(number)* (veja [Algoritmo de estatísticas de idioma](#Language-stats-algorithm)), padrão: 1.
+- `count_weight` - Configura o algoritmo de estatísticas de idioma *(number)* (veja [Algoritmo de estatísticas de idioma](#Language-stats-algorithm)), padrão: 0.
+
+É um documento .md do GitHub, por favor traduza o texto, excluindo links e nomes de variáveis, para o português.
 
 > :warning: **Importante:**
 > Nomes de linguagens devem ser uma sequência escapada de URI, como específicado em [Codificação por cento](https://pt.wikipedia.org/wiki/Codificação_por_cento)

--- a/docs/readme_tr.md
+++ b/docs/readme_tr.md
@@ -195,13 +195,17 @@ bg_color içerisinde birden fazla rengi gradient olarak göstermek için virgül
 
 #### Dil Kartları Exclusive Özellikler:
 
-- `hide` - Belirli bir dili listede gizler _(Virgül ile ayırılmış değerlerle)_
-- `hide_title` - _(boolean)_
-- `layout` - Beş uygun tasarım / düzen arasında geçiş yapın `normal` & `compact` & `donut` & `donut-vertical` & `pie`
-- `card_width` - Kartın genişliğini manuel olarak belirler _(number)_
-- `langs_count` - 1-10 arasında istediğiniz kadar dil gösterebilirsiniz. Varsayılan: 5 _(number)_
-- `exclude_repo` - Belirli repoları listeden çıkartır _(Virgül ile ayırılmış değerlerle)_
-- `custom_title` - Kart için istediğiniz bir başlığı belirler
+- `hide` - Belirli bir dili listede gizler _(Virgül ile ayırılmış değerlerle)_. Varsayılan: `[] (boş dizi)`.
+- `hide_title` - _(boolean)_. Varsayılan: `false`.
+- `layout` - Beş uygun tasarım / düzen arasında geçiş yapın `normal` & `compact` & `donut` & `donut-vertical` & `pie`. Varsayılan: `normal`.
+- `card_width` - Kartın genişliğini manuel olarak belirler _(number)_. Varsayılan `300`.
+- `langs_count` - 1-20 arasında istediğiniz kadar dil gösterebilirsiniz. Varsayılan: `normal` ve `tatlı` için `5`, diğer düzenler için `6`.
+- `exclude_repo` - Belirli repoları listeden çıkartır _(Virgül ile ayırılmış değerlerle)_. Varsayılan: `[] (boş dizi)`.
+- `custom_title` - Kart için istediğiniz bir başlığı belirler. Varsayılan `Most Used Languages`.
+- `animasyonları_devre_dışı_bırak` - Karttaki tüm animasyonları devre dışı bırakır *(boolean)*. Varsayılan: `false`.
+- `ilerlemeyi_gizle` - Kompakt düzen seçeneğini kullanır, yüzdeleri gizler ve çubukları kaldırır. Varsayılan: `false`.
+- `boyut_ağırlığı` - Dil istatistikleri algoritmasını yapılandırır *(number)* (bakınız [Dil istatistikleri algoritması](#Language-stats-algorithm)), varsayılan olarak 1.
+- `sayım_ağırlığı` - Dil istatistikleri algoritmasını yapılandırır *(number)* (bakınız [Dil istatistikleri algoritması](#Language-stats-algorithm)), varsayılan olarak 0.
 
 > :warning: **Önemli:**
 > Dİl isimleri [Percent Encoding](https://en.wikipedia.org/wiki/Percent-encoding)'te belirtildiği üzere uri-escaped olarak belirtilmelidir.
@@ -276,7 +280,7 @@ Endpoint: `api/top-langs?username=mustafacagri`
 
 ### Daha Fazla Dil Gösterin
 
-`&langs_count=` parametresini kullanarak kartınızda gösterilen dil sayısını azaltabilir ya da artırabilirsiniz. Varsayılan değeri 5, kullanılabilir sayı aralığı ise 1-10'dur.
+`&langs_count=` parametresini kullanarak kartınızda gösterilen dil sayısını azaltabilir ya da artırabilirsiniz. Varsayılan değeri 5, kullanılabilir sayı aralığı ise 1-20'dur.
 
 ```md
 [![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=mustafacagri&langs_count=8)](https://github.com/anuraghazra/github-readme-stats)

--- a/readme.md
+++ b/readme.md
@@ -472,7 +472,7 @@ You can use `&hide=language1,language2` parameter to hide individual languages.
 
 ### Show more languages
 
-You can use the `&langs_count=` option to increase or decrease the number of languages shown on the card. Valid values are integers between 1 and 10 (inclusive), and the default is 5.
+You can use the `&langs_count=` option to increase or decrease the number of languages shown on the card. Valid values are integers between 1 and 20 (inclusive), and the default is 5.
 
 ```md
 ![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=anuraghazra&langs_count=8)


### PR DESCRIPTION
- Enhance the description of options in the **Language Card Exclusive Options** section for each language document.
  - Particularly, reflect the fact that the maximum value of `langs_count` has been changed from 10 to 20.
    - Reference: https://github.com/anuraghazra/github-readme-stats/pull/2832
  - I'm not a comprehensive master of all languages, so I utilized ChatGPT for translation.
    This will be an effort akin to priming water, requiring further refinement from native speakers of each language.
    (I'm a native Korean speaker, intermediate in English and Chinese, and a beginner in German and Italian.)