### PR TITLE
added user profile option to rankIcon

### DIFF
--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -394,7 +394,7 @@ const renderStatsCard = (stats, options = {}) => {
         <circle class="rank-circle-rim" cx="-10" cy="8" r="40" />
         <circle class="rank-circle" cx="-10" cy="8" r="40" />
         <g class="rank-text">
-          ${rankIcon(rank_icon, rank?.level, rank?.percentile)}
+          ${rankIcon(name, rank_icon, rank?.level, rank?.percentile)}
         </g>
       </g>`;
 

--- a/src/common/icons.js
+++ b/src/common/icons.js
@@ -17,13 +17,20 @@ const icons = {
 /**
  * Get rank icon
  *
+ * @param {string} username - The username for the GitHub Account
  * @param {string} rankIcon - The rank icon type.
  * @param {string} rankLevel - The rank level.
  * @param {number} percentile - The rank percentile.
  * @returns {string} - The SVG code of the rank icon
  */
-const rankIcon = (rankIcon, rankLevel, percentile) => {
+const rankIcon = (username, rankIcon, rankLevel, percentile) => {
   switch (rankIcon) {
+    case "profile":
+      return `
+        <svg>
+          <image href="https://avatars.githubusercontent.com/${username}" x="0" y="0" height="66" width="66" />
+        </svg>
+      `;
     case "github":
       return `
         <svg x="-38" y="-30" height="66" width="66" aria-hidden="true" viewBox="0 0 16 16" version="1.1" data-view-component="true" data-testid="github-rank-icon">


### PR DESCRIPTION
- Adds the option for a users GitHub profile picture to be used as a rank icon
- I'm unable to test if this works, please feel free to clone this and update me with the results

closes #3128 