### PR TITLE
Tests: Stats card: Add hide all stats and rank icon test

### DIFF
--- a/tests/renderStatsCard.test.js
+++ b/tests/renderStatsCard.test.js
@@ -6,6 +6,7 @@ import {
 import { cssToObject } from "@uppercod/css-to-object";
 import { renderStatsCard } from "../src/cards/stats-card.js";
 import { expect, it, describe } from "@jest/globals";
+import { CustomError } from "../src/common/utils.js";
 
 // adds special assertions like toHaveTextContent
 import "@testing-library/jest-dom";
@@ -448,5 +449,19 @@ describe("Test renderStatsCard", () => {
     expect(
       queryByTestId(document.body, "percentile-rank-value").textContent.trim(),
     ).toBe(stats.rank.percentile.toFixed(1) + "%");
+  });
+
+  it("should throw error if all stats and rank icon are hidden", () => {
+    expect(() =>
+      renderStatsCard(stats, {
+        hide: ["stars", "commits", "prs", "issues", "contribs"],
+        hide_rank: true,
+      }),
+    ).toThrow(
+      new CustomError(
+        "Could not render stats card.",
+        "Either stats or rank are required.",
+      ),
+    );
   });
 });


### PR DESCRIPTION
Covers the following lines with test:

https://app.codecov.io/gh/anuraghazra/github-readme-stats/blob/master/src%2Fcards%2Fstats-card.js#L275