### PR TITLE
refactor: use more clear retryer error message (2)

### DIFF
--- a/src/common/retryer.js
+++ b/src/common/retryer.js
@@ -26,7 +26,10 @@ const retryer = async (fetcher, variables, retries = 0) => {
     throw new CustomError("No GitHub API tokens found", CustomError.NO_TOKENS);
   }
   if (retries > RETRIES) {
-    throw new CustomError("Maximum retries exceeded", CustomError.MAX_RETRY);
+    throw new CustomError(
+      "Downtime due to GitHub API rate limiting",
+      CustomError.MAX_RETRY,
+    );
   }
   try {
     // try to fetch with the first token since RETRIES is 0 index i'm adding +1

--- a/src/common/utils.js
+++ b/src/common/utils.js
@@ -381,7 +381,8 @@ const CONSTANTS = {
 };
 
 const SECONDARY_ERROR_MESSAGES = {
-  MAX_RETRY: "Downtime due to GitHub API rate limiting",
+  MAX_RETRY:
+    "You can deploy own instance or wait until public will be no longer limited",
   NO_TOKENS:
     "Please add an env variable called PAT_1 with your GitHub API token in vercel",
   USER_NOT_FOUND: "Make sure the provided username is not an organization",

--- a/tests/retryer.test.js
+++ b/tests/retryer.test.js
@@ -40,12 +40,12 @@ describe("Test Retryer", () => {
     expect(res).toStrictEqual({ data: "ok" });
   });
 
-  it("retryer should throw error if maximum retries reached", async () => {
+  it("retryer should throw specific error if maximum retries reached", async () => {
     try {
       await retryer(fetcherFail, {});
     } catch (err) {
       expect(fetcherFail).toBeCalledTimes(8);
-      expect(err.message).toBe("Maximum retries exceeded");
+      expect(err.message).toBe("Downtime due to GitHub API rate limiting");
     }
   });
 });


### PR DESCRIPTION
Related to https://github.com/anuraghazra/github-readme-stats/issues/3226

I think that retryer error message can be improved one more time to contain information about how users can avoid these error. Current error message "Maximum retries exceeded" is useless since do not tell users anything. I hope this change will reduce count of duplicates of https://github.com/anuraghazra/github-readme-stats/issues/1471