### PR TITLE
allow usage of .env file for PAT tokens

### DIFF
--- a/express.js
+++ b/express.js
@@ -1,12 +1,11 @@
+import "dotenv/config";
 import statsCard from "./api/index.js";
 import repoCard from "./api/pin.js";
 import langCard from "./api/top-langs.js";
 import wakatimeCard from "./api/wakatime.js";
 import gistCard from "./api/gist.js";
 import express from "express";
-import dotenv from "dotenv";
 
-dotenv.config();
 const app = express();
 app.listen(process.env.port || 9000);
 


### PR DESCRIPTION
This fixes where PAT tokens aren't loaded fast enough for `retrier` to see them if using a .env file.

This is aimed for when you want to deploy this project for your self and not use vercel.