### PR TITLE
refactor(stats card fetcher): improve could not fetch total commits error message

### DIFF
--- a/src/fetchers/stats-fetcher.js
+++ b/src/fetchers/stats-fetcher.js
@@ -180,7 +180,10 @@ const totalCommitsFetcher = async (username) => {
 
   const totalCount = res.data.total_count;
   if (!totalCount || isNaN(totalCount)) {
-    throw new Error("Could not fetch total commits.");
+    throw new CustomError(
+      "Could not fetch total commits.",
+      CustomError.GRAPHQL_ERROR,
+    );
   }
   return totalCount;
 };

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -301,4 +301,22 @@ describe("Test /api/", () => {
       renderError("Something went wrong", "Language not found"),
     );
   });
+
+  it("should render error card when include_all_commits true and upstream API fails", async () => {
+    mock
+      .onGet("https://api.github.com/search/commits?q=author:anuraghazra")
+      .reply(200, { error: "Some test error message" });
+
+    const { req, res } = faker(
+      { username: "anuraghazra", include_all_commits: true },
+      data_stats,
+    );
+
+    await api(req, res);
+
+    expect(res.setHeader).toBeCalledWith("Content-Type", "image/svg+xml");
+    expect(res.send).toBeCalledWith(
+      renderError("Could not fetch total commits.", "Please try again later"),
+    );
+  });
 });


### PR DESCRIPTION
@rickstaa We can also make text "file an issue at https://tiny.one/readme-stats" optional in the next pull request if your are up to approve these changes to show it only for unexpected errors to reduce count of new issues.

https://github.com/anuraghazra/github-readme-stats/blob/master/src/common/utils.js#L44