### PR TITLE
feat: Add neon_palenight and neon_blurange themes

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -444,6 +444,20 @@ export const themes = {
     border_color: "e1bc29",
     bg_color: "2b2d40",
   },
+  neon_palenight: {
+    title_color: "F9DD3C",
+    text_color: "5CADC0",
+    icon_color: "E41D44",
+    border_color: "A8A8A8",
+    bg_color: "020200",
+  },
+  neon_blurange: {
+    title_color: "25FB88",
+    text_color: "C7CCFF",
+    icon_color: "FB750B",
+    border_color: "C7CCFF",
+    bg_color: "030D6B",
+  },
 };
 
 export default themes;


### PR DESCRIPTION
## Description

Add neon_palenight and neon_blurange themes

## Screenshots
* Neon_palenight link:
```markdown
https://github-readme-stats-git-neon-themes-fkstreakstats.vercel.app/api?username=anuraghazra&theme=neon_palenight&show_icons=true
```
* Neon_blurange link:
```markdown
https://github-readme-stats-git-neon-themes-fkstreakstats.vercel.app/api?username=anuraghazra&theme=neon_blurange&show_icons=true
```

|             Theme             |                                                                          Preview                                                                         |
| :---------------------------: | :------------------------------------------------------------------------------------------------------------------------------------------------------: |
|      `neon_palenight`       |  ![image](https://github-readme-stats-git-neon-themes-fkstreakstats.vercel.app/api?username=anuraghazra&theme=neon_palenight&show_icons=true)    |
|      `neon_blurange`      |  ![image](https://github-readme-stats-git-neon-themes-fkstreakstats.vercel.app/api?username=anuraghazra&theme=neon_blurange&show_icons=true)   |