### PR TITLE
feat: Add shadow themes (Orange, Purple, and Brown)

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -444,6 +444,27 @@ export const themes = {
     border_color: "e1bc29",
     bg_color: "2b2d40",
   },
+  shadow_orange: {
+    title_color: "B85502",
+    text_color: "444",
+    icon_color: "834400",
+    border_color: "834400",
+    bg_color: "ffffff00",
+  },
+  shadow_purple: {
+    title_color: "6f42c1",
+    text_color: "444",
+    icon_color: "570182",
+    border_color: "570182",
+    bg_color: "ffffff00",
+  },
+  shadow_brown: {
+    title_color: "5D6642",
+    text_color: "444",
+    icon_color: "4E5336",
+    border_color: "4E5336",
+    bg_color: "ffffff00",
+  },
 };
 
 export default themes;


### PR DESCRIPTION
## Description

Add shadow themes (Orange, Purple, and Brown)

## Screenshots
* Shadow_orange link:
```markdown
https://github-readme-stats-git-shadow-themes-fkstreakstats.vercel.app/api?username=anuraghazra&theme=shadow_orange&show_icons=true
```
* Shadow_purple link:
```markdown
https://github-readme-stats-git-shadow-themes-fkstreakstats.vercel.app/api?username=anuraghazra&theme=shadow_purple&show_icons=true
```
* Shadow_brown link:
```markdown
https://github-readme-stats-git-shadow-themes-fkstreakstats.vercel.app/api?username=anuraghazra&theme=shadow_brown&show_icons=true
```

|             Theme             |                                                                          Preview                                                                         |
| :---------------------------: | :------------------------------------------------------------------------------------------------------------------------------------------------------: |
|    `shadow_orange`     |  ![image](https://github-readme-stats-git-shadow-themes-fkstreakstats.vercel.app/api?username=anuraghazra&theme=shadow_orange&show_icons=true)    |
|     `shadow_purple`     |  ![image](https://github-readme-stats-git-shadow-themes-fkstreakstats.vercel.app/api?username=anuraghazra&theme=shadow_purple&show_icons=true)   |
|      `shadow_brown`      |  ![image](https://github-readme-stats-git-shadow-themes-fkstreakstats.vercel.app/api?username=anuraghazra&theme=shadow_brown&show_icons=true)   |