### PR TITLE
Progress bar background color #3307 option added

### DIFF
--- a/api/top-langs.js
+++ b/api/top-langs.js
@@ -33,6 +33,7 @@ export default async (req, res) => {
     border_color,
     disable_animations,
     hide_progress,
+    prog_bg_color,
   } = req.query;
   res.setHeader("Content-Type", "image/svg+xml");
 
@@ -88,6 +89,7 @@ export default async (req, res) => {
         title_color,
         text_color,
         bg_color,
+        prog_bg_color,
         theme,
         layout,
         langs_count,


### PR DESCRIPTION
## Added the optionality for changing the background color for top programmers Language.
For Ex:https://github-readme-stats.vercel.app/api/top-langs/?username=Le0X8&size_weight=0.5&count_weight=0.5&langs_count=8&theme=transparent&border_radius=0&hide_border=true&title_color=108c92&text_color=0c686c&prog_bg_color=222222.