### PR TITLE
docs(contributing guidelines): remove duplicate license section

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,3 @@ People _love_ thorough bug reports. I'm not even kidding.
 -   A quick idea summary
 -   What & why do you want to add the specific feature
 -   Additional context like images, links to resources to implement the feature, etc.
-
-## License
-
-By contributing, you agree that your contributions will be licensed under its [MIT License](./LICENSE).


### PR DESCRIPTION
Currently we have two sections (https://github.com/anuraghazra/github-readme-stats/blob/master/CONTRIBUTING.md#any-contributions-you-make-will-be-under-the-mit-software-license and https://github.com/anuraghazra/github-readme-stats/blob/master/CONTRIBUTING.md#license) about license. i think that it is enough to have only one because both tells the same.