### PR TITLE
docs: improve vercel badge position

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,6 +24,9 @@
     </a>
     <br />
     <br />
+    <a href="https://vercel.com?utm\_source=github\_readme\_stats\_team\&utm\_campaign=oss">
+      <img src="./powered-by-vercel.svg"/>
+    </a>
   </p>
 
   <p align="center">
@@ -814,8 +817,6 @@ However, if you are using this project and are happy with it or just want to enc
 Thanks! :heart:
 
 ***
-
-[![https://vercel.com?utm\_source=github\_readme\_stats\_team\&utm\_campaign=oss](./powered-by-vercel.svg)](https://vercel.com?utm_source=github_readme_stats_team\&utm_campaign=oss)
 
 Contributions are welcome! <3
 

--- a/readme.md
+++ b/readme.md
@@ -818,6 +818,8 @@ Thanks! :heart:
 
 ***
 
+[![https://vercel.com?utm\_source=github\_readme\_stats\_team\&utm\_campaign=oss](./powered-by-vercel.svg)](https://vercel.com?utm_source=github_readme_stats_team\&utm_campaign=oss)
+
 Contributions are welcome! <3
 
 Made with :heart: and JavaScript.


### PR DESCRIPTION
This pull request improved the Vercel badge position since they have been a massive sponsor since GRS began.