### PR TITLE
docs: add uptime badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -123,6 +123,8 @@ Please visit [this link](https://give.do/fundraisers/stand-beside-the-victims-of
 > [!IMPORTANT]\
 > Since the GitHub API only [allows 5k requests per hour per user account](https://docs.github.com/en/graphql/overview/resource-limitations), the public Vercel instance hosted on `https://github-readme-stats.vercel.app/api` could possibly hit the rate limiter (see [#1471](https://github.com/anuraghazra/github-readme-stats/issues/1471)). We use caching to prevent this from happening (see https://github.com/anuraghazra/github-readme-stats#common-options). You can turn off these rate limit protections by deploying [your own Vercel instance](#disable-rate-limit-protections).
 
+<img alt="Uptime Badge" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgithub-readme-stats-git-monitoring-github-readme-stats-team.vercel.app%2Fapi%2Fstatus%2Fup%3Ftype%3Dshields">
+
 # GitHub Stats Card
 
 Copy-paste this into your markdown content, and that is it. Simple!


### PR DESCRIPTION
@qwerty541, @anuraghazra, this adds a small uptime badge to the readme. So that people know when the public instance is down. This should not increase the GraphQL usage since the response is already cached every 5 minutes on Vercel's side. 