### PR TITLE
ci: fix 'update-langs' ci permissions

### DIFF
--- a/.github/workflows/update-langs.yaml
+++ b/.github/workflows/update-langs.yaml
@@ -15,7 +15,7 @@ on:
 permissions:
   actions: read
   checks: read
-  contents: read
+  contents: write
   deployments: read
   issues: read
   discussions: read


### PR DESCRIPTION
The [update-langs.yaml](https://github.com/anuraghazra/github-readme-stats/blob/master/.github/workflows/update-langs.yaml) appears to lack the necessary permissions to initiate a pull request. Detailed information can be found in the [workflow run](https://github.com/anuraghazra/github-readme-stats/actions/runs/6366521987/job/17378465600). For more information on this issue, see https://github.com/anuraghazra/github-readme-stats/issues/3351.