### PR TITLE
add theme nightshade_noir

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -462,6 +462,12 @@ export const themes = {
     icon_color: "ffffff",
     bg_color: "35,4158d0,c850c0,ffcc70",
   },
+  nightshade_noir: {
+    title_color: "fff",
+    icon_color: "79ff97",
+    text_color: "9f9f9f",
+    bg_color: "24211e",
+  },
 };
 
 export default themes;


### PR DESCRIPTION
I want to add Nightshade Noir because, Nightshade Noir exhibits high versatility as it seamlessly integrates with a variety of colors and styles. It can serve as the perfect backdrop to accentuate other colors or design elements, as its softness doesn't overpower other tones. 


![Nightshade Noir](https://github.com/anuraghazra/github-readme-stats/assets/112188399/436e13d4-1c93-4aa3-ba6d-bddd5df7902f)
