### PR TITLE
Add theme light_mint

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -466,7 +466,7 @@ export const themes = {
     title_color: "00bda3",
     text_color: "b0a3e1",
     icon_color: "00c3ae",
-    border_color=b9edc3,
+    border_color: "b9edc3",
     bg_color: "dafbe1",
   },
 };

--- a/themes/index.js
+++ b/themes/index.js
@@ -462,6 +462,13 @@ export const themes = {
     icon_color: "ffffff",
     bg_color: "35,4158d0,c850c0,ffcc70",
   },
+  light_mint: {
+    title_color: "00bda3",
+    text_color: "b0a3e1",
+    icon_color: "00c3ae",
+    border_color=b9edc3,
+    bg_color: "dafbe1",
+  },
 };
 
 export default themes;

--- a/themes/index.js
+++ b/themes/index.js
@@ -463,11 +463,11 @@ export const themes = {
     bg_color: "35,4158d0,c850c0,ffcc70",
   },
   light_mint: {
-    title_color: "00bda3",
-    text_color: "b0a3e1",
-    icon_color: "00c3ae",
-    border_color: "b9edc3",
-    bg_color: "dafbe1",
+    title_color: "00A39A",
+    text_color: "9C7FD7",
+    icon_color: "00A39A",
+    border_color: "B9EDC3",
+    bg_color: "F6FEF8",
   },
 };
 


### PR DESCRIPTION
The variety of dark themes is vast, but there are almost no light colorful themes. 

After creating some personalized themes for my friends, this one was very popular so I thought maybe others love it as well.
I designed it thinking first of those who use github in light mode. But it looks good as well in dark mode.

A screenshot of the theme: 
![image](https://github.com/anuraghazra/github-readme-stats/assets/110998002/3d0de78f-003f-4a9a-a445-6a07245c5efe)


Thanks for reviewing my PR =)