### PR TITLE
fix(stats card): fetch total commits from the current year only

### DIFF
--- a/src/fetchers/stats-fetcher.js
+++ b/src/fetchers/stats-fetcher.js
@@ -40,11 +40,11 @@ const GRAPHQL_REPOS_QUERY = `
 `;
 
 const GRAPHQL_STATS_QUERY = `
-  query userInfo($login: String!, $after: String, $includeMergedPullRequests: Boolean!, $includeDiscussions: Boolean!, $includeDiscussionsAnswers: Boolean!) {
+  query userInfo($login: String!, $from: DateTime, $after: String, $includeMergedPullRequests: Boolean!, $includeDiscussions: Boolean!, $includeDiscussionsAnswers: Boolean!) {
     user(login: $login) {
       name
       login
-      contributionsCollection {
+      contributionsCollection(from: $from) {
         totalCommitContributions,
         totalPullRequestReviewContributions
       }
@@ -122,10 +122,13 @@ const statsFetcher = async ({
   let stats;
   let hasNextPage = true;
   let endCursor = null;
+  const currentYear = new Date().getFullYear();
+  const from = `${currentYear}-01-01T00:00:00Z`;
   while (hasNextPage) {
     const variables = {
       login: username,
       first: 100,
+      from,
       after: endCursor,
       includeMergedPullRequests,
       includeDiscussions,


### PR DESCRIPTION
Hello, I am a student currently studying and I have made efforts to solve the following problem:


This PR addresses the issue highlighted in #3656, where the need for fetching only the current year's total commits was discussed. Previously, our stats card functionality did not provide an option to limit the commit count to the current year only. This limitation was not aligned with the specific needs of some users who wanted to display only the recent contributions within their READMEs.

Changes Made:

This PR introduces an option to fetch only the current year's commits, addressing issue #3656. It allows users to more effectively showcase their recent contributions.