### PR TITLE
Unset animation name for compatibility if animation is disabled

### DIFF
--- a/src/common/Card.js
+++ b/src/common/Card.js
@@ -231,7 +231,7 @@ class Card {
           ${process.env.NODE_ENV === "test" ? "" : this.getAnimations()}
           ${
             this.animations === false
-              ? `* { animation-duration: 0s !important; animation-delay: 0s !important; }`
+              ? `* { animation-name: none !important; animation-duration: 0s !important; animation-delay: 0s !important; }`
               : ""
           }
         </style>


### PR DESCRIPTION
I discovered that the card content does not show even if `disable_animations=true` in some software([WeasyPrint](https://weasyprint.org/)) that captures the first frame.

The keyframe name should be removed in the stylesheet evaluation to disable the animation properly.