### PR TITLE
refactor: remove check for private user repository

### DIFF
--- a/src/fetchers/repo-fetcher.js
+++ b/src/fetchers/repo-fetcher.js
@@ -90,11 +90,11 @@ const fetchRepo = async (username, reponame) => {
 
   const isUser = data.organization === null && data.user;
   const isOrg = data.user === null && data.organization;
-
+  /**
   if (isUser) {
     if (!data.user.repository || data.user.repository.isPrivate) {
       throw new Error("User Repository Not found");
-    }
+    }**/
     return {
       ...data.user.repository,
       starCount: data.user.repository.stargazers.totalCount,


### PR DESCRIPTION
This commit removes the check that throws an error if the user's repository is not found or is private. This change is intended to improve the system's handling of user repositories by no longer failing when encountering private repositories.