### PR TITLE
feat: rank markings

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -37,6 +37,7 @@ export default async (req, res) => {
     number_format,
     border_color,
     rank_icon,
+    rank_markings,
     show,
   } = req.query;
   res.setHeader("Content-Type", "image/svg+xml");
@@ -117,6 +118,7 @@ export default async (req, res) => {
         locale: locale ? locale.toLowerCase() : null,
         disable_animations: parseBoolean(disable_animations),
         rank_icon,
+        rank_markings,
         show: showStats,
       }),
     );

--- a/src/cards/stats-card.js
+++ b/src/cards/stats-card.js
@@ -237,6 +237,7 @@ const renderStatsCard = (stats, options = {}) => {
     locale,
     disable_animations = false,
     rank_icon = "default",
+    rank_markings = false,
     show = [],
   } = options;
 
@@ -498,6 +499,7 @@ const renderStatsCard = (stats, options = {}) => {
   };
 
   // Conditionally rendered elements
+  console.log(rank_markings);
   const rankCircle = hide_rank
     ? ""
     : `<g data-testid="rank-circle"

--- a/src/cards/types.d.ts
+++ b/src/cards/types.d.ts
@@ -27,6 +27,7 @@ export type StatCardOptions = CommonOptions & {
   ring_color: string;
   text_bold: boolean;
   rank_icon: RankIcon;
+  rank_markings: boolean;
   show: string[];
 };
 


### PR DESCRIPTION
This PR introduces a new feature to show the upcoming rank/s markings in the circular progress, as the user can get an idea on how far is the next rank/s.

It is an optional feature.
To enable it, the API should be modified to: `&rank_markings=true`.

Closes #3872