### PR TITLE
fix: typo in `themes/README.md`

### DIFF
--- a/themes/README.md
+++ b/themes/README.md
@@ -4,7 +4,7 @@
 
 With inbuilt themes, you can customize the look of the card without doing any manual customization.
 
-Use `?theme=THEME_NAME` parameter like so:
+Use `&theme=THEME_NAME` parameter like so:
 
 ```md
 ![Anurag's GitHub stats](https://github-readme-stats.vercel.app/api?username=anuraghazra&theme=dark&show_icons=true)


### PR DESCRIPTION
`&theme=` is mistyped as `?theme=`