### PR TITLE
fix: Fix Card Click Behavior for Pinned Repos and Gists #3955 

### DIFF
--- a/src/cards/gist-card.js
+++ b/src/cards/gist-card.js
@@ -137,15 +137,16 @@ const renderGistCard = (gistData, options = {}) => {
   `);
   card.setHideBorder(hide_border);
 
-  return card.render(`
-    <text class="description" x="25" y="-5">
+  return ` <a href="https://github.com/${nameWithOwner}" target="_blank" rel="noopener noreferrer">
+    ${card.render(`
+      <text class="description" x="25" y="-5">
         ${descriptionSvg}
-    </text>
-
-    <g transform="translate(30, ${height - 75})">
+      </text>
+      <g transform="translate(30, ${height - 75})">
         ${starAndForkCount}
-    </g>
-  `);
+      </g>
+    `)}
+  </a>`;
 };
 
 export { renderGistCard, HEADER_MAX_LENGTH };

--- a/src/cards/repo-card.js
+++ b/src/cards/repo-card.js
@@ -169,25 +169,29 @@ const renderRepoCard = (repo, options = {}) => {
     .badge rect { opacity: 0.2 }
   `);
 
-  return card.render(`
-    ${
-      isTemplate
-        ? // @ts-ignore
-          getBadgeSVG(i18n.t("repocard.template"), colors.textColor)
-        : isArchived
-          ? // @ts-ignore
-            getBadgeSVG(i18n.t("repocard.archived"), colors.textColor)
-          : ""
-    }
+  return `
+   <a href="https://github.com/${nameWithOwner}" target="_blank" rel="noopener noreferrer">
+      ${card.render(`
+        ${
+          isTemplate
+            ? // @ts-ignore
+              getBadgeSVG(i18n.t("repocard.template"), colors.textColor)
+            : isArchived
+              ? // @ts-ignore
+                getBadgeSVG(i18n.t("repocard.archived"), colors.textColor)
+              : ""
+        }
 
-    <text class="description" x="25" y="-5">
-      ${descriptionSvg}
-    </text>
+        <text class="description" x="25" y="-5">
+          ${descriptionSvg}
+        </text>
 
-    <g transform="translate(30, ${height - 75})">
-      ${starAndForkCount}
-    </g>
-  `);
+        <g transform="translate(30, ${height - 75})">
+          ${starAndForkCount}
+        </g>
+      `)}
+    </a>
+  `;
 };
 
 export { renderRepoCard };

--- a/src/cards/repo-card.js
+++ b/src/cards/repo-card.js
@@ -169,8 +169,9 @@ const renderRepoCard = (repo, options = {}) => {
     .badge rect { opacity: 0.2 }
   `);
 
+  // by wrapping card.render into <a> tag - Incorrect formatting of repo card description Fixes
   return `
-   <a href="https://github.com/${nameWithOwner}" target="_blank" rel="noopener noreferrer">
+   <a href="https://github.com/${nameWithOwner}" target="_blank" rel="noopener noreferrer">  
       ${card.render(`
         ${
           isTemplate


### PR DESCRIPTION
### **Description**

This pull request addresses an issue with the click behavior of the cards for pinned repositories and gists. Previously, clicking on a card resulted in the user being directed to a URL that displayed an image of the card rather than the intended repository or gist page. This behavior made the pinned cards unusable as a replacement for the native pins, which should allow users to navigate directly to the relevant GitHub pages.

### **Changes Made -**

Wrapped the card rendering code in an anchor (<a>) tag, enabling users to click on the card and be redirected to the corresponding repository or gist page.
The implementation ensures that the link opens in a new tab while maintaining security best practices by using rel="noopener noreferrer"

```
<a href="https://github.com/${nameWithOwner}" target="_blank" rel="noopener noreferrer">
 // This anchor tag links to the GitHub repository or gist for the card
  ${card.render(`...`)}
  `)}
</a>
```
### **Expected Behavior-**

With this change, clicking on a card for a repository or gist now properly directs users to the respective page on GitHub. This enhances usability and aligns with the expected functionality of native pinned repositories.

I appreciate your consideration of this pull request, and I look forward to any feedback you may have!