### PR TITLE
fixes: Incorrect formatting of repo card description #3956

### DIFF
--- a/src/cards/gist-card.js
+++ b/src/cards/gist-card.js
@@ -137,15 +137,16 @@ const renderGistCard = (gistData, options = {}) => {
   `);
   card.setHideBorder(hide_border);
 
-  return card.render(`
-    <text class="description" x="25" y="-5">
+  return ` <a href="https://github.com/${nameWithOwner}" target="_blank" rel="noopener noreferrer">
+    ${card.render(`
+      <text class="description" x="25" y="-5">
         ${descriptionSvg}
-    </text>
-
-    <g transform="translate(30, ${height - 75})">
+      </text>
+      <g transform="translate(30, ${height - 75})">
         ${starAndForkCount}
-    </g>
-  `);
+      </g>
+    `)}
+  </a>`;
 };
 
 export { renderGistCard, HEADER_MAX_LENGTH };

--- a/src/cards/repo-card.js
+++ b/src/cards/repo-card.js
@@ -169,7 +169,7 @@ const renderRepoCard = (repo, options = {}) => {
     .badge rect { opacity: 0.2 }
   `);
 
-  // by wrapping card.render into <a> tag - Incorrect formatting of repo card description Fixes
+  // by wrapping card.render into <a> tag - fixes Incorrect formatting of repo card description Fixes #3956
   return `
    <a href="https://github.com/${nameWithOwner}" target="_blank" rel="noopener noreferrer">  
       ${card.render(`

--- a/src/cards/repo-card.js
+++ b/src/cards/repo-card.js
@@ -169,25 +169,29 @@ const renderRepoCard = (repo, options = {}) => {
     .badge rect { opacity: 0.2 }
   `);
 
-  return card.render(`
-    ${
-      isTemplate
-        ? // @ts-ignore
-          getBadgeSVG(i18n.t("repocard.template"), colors.textColor)
-        : isArchived
-          ? // @ts-ignore
-            getBadgeSVG(i18n.t("repocard.archived"), colors.textColor)
-          : ""
-    }
+  return `
+   <a href="https://github.com/${nameWithOwner}" target="_blank" rel="noopener noreferrer">
+      ${card.render(`
+        ${
+          isTemplate
+            ? // @ts-ignore
+              getBadgeSVG(i18n.t("repocard.template"), colors.textColor)
+            : isArchived
+              ? // @ts-ignore
+                getBadgeSVG(i18n.t("repocard.archived"), colors.textColor)
+              : ""
+        }
 
-    <text class="description" x="25" y="-5">
-      ${descriptionSvg}
-    </text>
+        <text class="description" x="25" y="-5">
+          ${descriptionSvg}
+        </text>
 
-    <g transform="translate(30, ${height - 75})">
-      ${starAndForkCount}
-    </g>
-  `);
+        <g transform="translate(30, ${height - 75})">
+          ${starAndForkCount}
+        </g>
+      `)}
+    </a>
+  `;
 };
 
 export { renderRepoCard };

--- a/src/cards/repo-card.js
+++ b/src/cards/repo-card.js
@@ -169,8 +169,9 @@ const renderRepoCard = (repo, options = {}) => {
     .badge rect { opacity: 0.2 }
   `);
 
+  // by wrapping card.render into <a> tag - Incorrect formatting of repo card description Fixes
   return `
-   <a href="https://github.com/${nameWithOwner}" target="_blank" rel="noopener noreferrer">
+   <a href="https://github.com/${nameWithOwner}" target="_blank" rel="noopener noreferrer">  
       ${card.render(`
         ${
           isTemplate


### PR DESCRIPTION
### **Description of the Bug**

The repository card's description width appears to be inappropriate under certain conditions, leading to an imbalance with the overall padding and layout of the card. This issue makes the card visually inconsistent, potentially affecting the user experience.

### **Expected Behavior**

The description text should maintain a more appropriate width, ensuring a larger space between the text and the card's border. This adjustment will create a more balanced and aesthetically pleasing layout for the repository card.

### **Proposed Solution**

This issue has been addressed by updating the code that generates the repository card. Specifically, the anchor tag now properly wraps the entire card content, including the badge and description. The relevant code changes are as follows:

```
<a href="https://github.com/${nameWithOwner}" target="_blank" rel="noopener noreferrer">
  // This anchor tag links to the GitHub repository or gist for the card
  ${card.render(`...`)}
</a>
```

**The modification ensures that the description does not extend too far, thus preventing overlap with the card's border.**

**Proper padding adjustments can be made in the CSS if needed, to ensure that the description aligns well within the card's layout.**

By implementing this change, the repository card's description width will be more appropriate, enhancing the overall presentation and usability of the card in the user interface.
