### PR TITLE
Add card_height feature to repo card #3369

### DIFF
--- a/src/cards/repo-card.js
+++ b/src/cards/repo-card.js
@@ -77,6 +77,7 @@ const renderRepoCard = (repo, options = {}) => {
     border_color,
     locale,
     description_lines_count,
+    card_height,
   } = options;
 
   const lineHeight = 10;
@@ -101,9 +102,10 @@ const renderRepoCard = (repo, options = {}) => {
     .map((line) => `<tspan dy="1.2em" x="25">${encodeHTML(line)}</tspan>`)
     .join("");
 
-  const height =
-    (descriptionLinesCount > 1 ? 120 : 110) +
-    descriptionLinesCount * lineHeight;
+  const height = card_height
+    ? card_height
+    : (descriptionLinesCount > 1 ? 120 : 110) +
+      descriptionLinesCount * lineHeight;
 
   const i18n = new I18n({
     locale,

--- a/src/cards/types.d.ts
+++ b/src/cards/types.d.ts
@@ -33,6 +33,7 @@ export type StatCardOptions = CommonOptions & {
 export type RepoCardOptions = CommonOptions & {
   show_owner: boolean;
   description_lines_count: number;
+  card_height: number;
 };
 
 export type TopLangOptions = CommonOptions & {


### PR DESCRIPTION
Current State of the Code:
The renderRepoCard function dynamically calculates card height, limiting customization for users needing specific dimensions.

Proposed Solution:
Add a card_height option to allow users to specify the card height for greater flexibility and customization.

Fixes #3369