### PR TITLE
Feature Request: Add custom languages

### DIFF
--- a/api/top-langs.js
+++ b/api/top-langs.js
@@ -32,6 +32,7 @@ export default async (req, res) => {
     border_color,
     disable_animations,
     hide_progress,
+    lang,
   } = req.query;
   res.setHeader("Content-Type", "image/svg+xml");
 
@@ -62,12 +63,37 @@ export default async (req, res) => {
   }
 
   try {
-    const topLangs = await fetchTopLanguages(
-      username,
-      parseArray(exclude_repo),
-      size_weight,
-      count_weight,
-    );
+    // Check if `lang` parameter is provided
+    let topLangs;
+    if (lang) {
+      // If lang is provided, split the string into an array
+      const customLangs = lang.split(",");
+      // Map custom languages to a format similar to the fetched language data
+      topLangs = customLangs.reduce((acc, curr) => {
+        acc[curr] = {
+          name: curr,
+          color: "#000000", // Assign a default color (you can customize this later)
+          size: 1, // Default size
+          count: 1, // Default count
+        };
+        return acc;
+      }, {});
+    } else {
+      // Fetch the actual top languages if no custom languages are provided
+      topLangs = await fetchTopLanguages(
+        username,
+        parseArray(exclude_repo),
+        size_weight,
+        count_weight,
+      );
+    }
+
+    // const topLangs = await fetchTopLanguages(
+    //   username,
+    //   parseArray(exclude_repo),
+    //   size_weight,
+    //   count_weight,
+    // );
 
     let cacheSeconds = parseInt(
       cache_seconds || CONSTANTS.TOP_LANGS_CACHE_SECONDS,

--- a/readme.md
+++ b/readme.md
@@ -552,6 +552,13 @@ You can use the `&langs_count=` option to increase or decrease the number of lan
 ![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=anuraghazra&langs_count=8)
 ```
 
+### Show Custom Languages
+You can now specify custom languages to be displayed using the `&lang=` query parameter. The custom languages will override the automatically fetched top languages. The value should be a comma-separated list of language names. Note that the languages provided in the list will be shown with default settings for color, size, and count.
+
+```md
+![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=anuraghazra&lang=python,java,react,javascript,nextjs)
+```
+
 ### Compact Language Card Layout
 
 You can use the `&layout=compact` option to change the card design.


### PR DESCRIPTION
Feature Request #3969 

### Show Custom Languages
You can now specify custom languages to be displayed using the `&lang=` query parameter. The custom languages will override the automatically fetched top languages. The value should be a comma-separated list of language names. Note that the languages provided in the list will be shown with default settings for color, size, and count.

```md
![Top Langs](https://github-readme-stats.vercel.app/api/top-langs/?username=anuraghazra&lang=python,java,react,javascript,nextjs)
```
