### PR TITLE
fix: Added missing closing bracket "}" for Mayo Blue theme

### DIFF
--- a/themes/index.js
+++ b/themes/index.js
@@ -462,6 +462,11 @@ export const themes = {
     icon_color: "ffffff",
     bg_color: "35,4158d0,c850c0,ffcc70",
   },
+  mayo_blue: {
+    title_color: '334eac',
+    icon_color: "bad6eb",
+    text_color: "434d58",
+    bg_color: "fff9ef",
 };
 
 export default themes;

--- a/themes/index.js
+++ b/themes/index.js
@@ -467,6 +467,7 @@ export const themes = {
     icon_color: "bad6eb",
     text_color: "434d58",
     bg_color: "fff9ef",
+  },
 };
 
 export default themes;


### PR DESCRIPTION
I added the Mayo Blue theme on Nov 29, 2024. However, I accidentally forgot to add the closing bracket "}". This PR fixes the issue by adding the missing bracket.