### PR TITLE
Added new language support: Urdu (ur)

### DIFF
--- a/src/translations.js
+++ b/src/translations.js
@@ -45,6 +45,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       uz: `${encodedName}ning GitHub'dagi statistikasi`,
       vi: `Thống Kê GitHub ${encodedName}`,
       se: `GitHubstatistik för ${encodedName}`,
+      ur: `GitHub کے اعداد و شمار ${encodedName}`,
     },
     "statcard.ranktitle": {
       ar: `${encodedName} إحصائيات غيت هاب`,
@@ -76,6 +77,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       uz: `${encodedName}ning GitHub'dagi statistikasi`,
       vi: `Thống Kê GitHub ${encodedName}`,
       se: `GitHubstatistik för ${encodedName}`,
+      ur: `GitHub کے اعداد و شمار ${encodedName}`,
     },
     "statcard.totalstars": {
       ar: "مجموع النجوم",
@@ -107,6 +109,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       uz: "Yulduzchalar",
       vi: "Tổng Số Sao",
       se: "Antal intjänade stjärnor",
+      ur: "کل Stars",
     },
     "statcard.commits": {
       ar: "مجموع الحفظ",
@@ -138,6 +141,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       uz: "'Commit'lar",
       vi: "Tổng Số Cam Kết",
       se: "Totalt antal commits",
+      ur: "کل Commits",
     },
     "statcard.prs": {
       ar: "مجموع طلبات السحب",
@@ -169,6 +173,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       uz: "'Pull Request'lar",
       vi: "Tổng Số PR",
       se: "Totalt antal PR",
+      ur: "کل PRs",
     },
     "statcard.issues": {
       ar: "مجموع التحسينات",
@@ -200,6 +205,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       uz: "'Issue'lar",
       vi: "Tổng Số Vấn Đề",
       se: "Total antal issues",
+      ur: "کل Issues",
     },
     "statcard.contribs": {
       ar: "ساهم في (العام الماضي)",
@@ -231,6 +237,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       uz: "Hissa qoʻshgan (o'tgan yili)",
       vi: "Đã Đóng Góp (năm ngoái)",
       se: "Bidragit till (förra året)",
+      ur: "شراکت (پچھلے سال)",
     },
     "statcard.reviews": {
       ar: "تمت مراجعة إجمالي العلاقات العامة",
@@ -262,6 +269,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       uz: "Koʻrib chiqilgan PR-lar soni",
       vi: "Tổng Số PR Đã Xem Xét",
       se: "Totalt antal granskade PR",
+      ur: "کل PRs کا جائزہ لیا گیا",
     },
     "statcard.discussions-started": {
       ar: "مجموع بدء المناقشات",
@@ -293,6 +301,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       uz: "Boshlangan muzokaralar soni",
       vi: "Tổng Số Thảo Luận Bắt Đầu",
       se: "Totalt antal diskussioner startade",
+      ur: "کل discussions Star کیے گئے",
     },
     "statcard.discussions-answered": {
       ar: "مجموع الردود على المناقشات",
@@ -324,6 +333,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       uz: "Javob berilgan muzokaralar soni",
       vi: "Tổng Số Thảo Luận Đã Trả Lời",
       se: "Totalt antal diskussioner besvarade",
+      ur: "کل discussions جواب دیا",
     },
     "statcard.prs-merged": {
       ar: "مجموع الطلبات المدمجة",
@@ -354,6 +364,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       uz: "Birlangan PR-lar soni",
       vi: "Tổng Số PR Đã Hợp Nhất",
       se: "Totalt antal sammanfogade PR",
+      ur: "کل Marge گئے کیے PRs",
     },
     "statcard.prs-merged-percentage": {
       ar: "نسبة الطلبات المدمجة",
@@ -384,6 +395,7 @@ const statCardLocales = ({ name, apostrophe }) => {
       uz: "Birlangan PR-lar foizi",
       vi: "Tỷ Lệ PR Đã Hợp Nhất",
       se: "Procent av sammanfogade PR",
+      ur: "ہوا Merge PRs کا فیصد",
     },
   };
 };
@@ -419,6 +431,7 @@ const repoCardLocales = {
     uz: "Shablon",
     vi: "Mẫu",
     se: "Mall",
+    ur: "سانچو",
   },
   "repocard.archived": {
     ar: "محفوظ",
@@ -450,6 +463,7 @@ const repoCardLocales = {
     uz: "Arxivlangan",
     vi: "Đã Lưu Trữ",
     se: "Arkiverade",
+    ur: "محفوظ شدہ",
   },
 };
 
@@ -484,6 +498,7 @@ const langCardLocales = {
     uz: "Eng koʻp ishlatiladigan tillar",
     vi: "Ngôn Ngữ Thường Sử Dụng",
     se: "Mest använda språken",
+    ur: "زیادہ تر استعمال ہونے والی Languages",
   },
   "langcard.nodata": {
     ar: "لا توجد بيانات لغات.",
@@ -515,6 +530,7 @@ const langCardLocales = {
     uz: "Til haqida ma'lumot yo'q.",
     vi: "Không có dữ liệu ngôn ngữ.",
     se: "Inga språkdata.",
+    ur: "کوئی Languages کا ڈیٹا نہیں۔",
   },
 };
 
@@ -549,6 +565,7 @@ const wakatimeCardLocales = {
     uz: "WakaTime statistikasi",
     vi: "Thống Kê WakaTime",
     se: "WakaTime statistik",
+    ur: "WakaTime کی حالت",
   },
   "wakatimecard.lastyear": {
     ar: "العام الماضي",
@@ -580,6 +597,7 @@ const wakatimeCardLocales = {
     uz: "O'tgan yil",
     vi: "Năm ngoái",
     se: "Förra året",
+    ur: "پچھلے سال",
   },
   "wakatimecard.last7days": {
     ar: "آخر 7 أيام",
@@ -611,6 +629,7 @@ const wakatimeCardLocales = {
     uz: "O'tgan 7 kun",
     vi: "7 ngày qua",
     se: "Senaste 7 dagarna",
+    ur: "پچھلے 7 دنوں میں",
   },
   "wakatimecard.notpublic": {
     ar: "ملف المستخدم غير عام",
@@ -642,6 +661,7 @@ const wakatimeCardLocales = {
     uz: "WakaTime foydalanuvchi profili ochiq emas",
     vi: "Hồ sơ người dùng WakaTime không công khai",
     se: "WakaTime användarprofil inte offentlig",
+    ur: "WakaTime صارف پروفائل عوامی نہیں ہے",
   },
   "wakatimecard.nocodedetails": {
     ar: "المستخدم لا يشارك معلومات تفصيلية عن البرمجة",
@@ -675,6 +695,7 @@ const wakatimeCardLocales = {
     uz: "Foydalanuvchi umumiy ko`d statistikasini ochiq ravishda almashmaydi",
     vi: "Người dùng không chia sẻ thống kê mã chi tiết công khai",
     se: "Användaren delar inte offentligt detaljerad kodstatistik",
+    ur: "صارف تفصیلی کوڈ کی معلومات عوامی طور پر نہیں بانٹتا",
   },
   "wakatimecard.nocodingactivity": {
     ar: "لا يوجد نشاط برمجي لهذا الأسبوع",
@@ -706,6 +727,7 @@ const wakatimeCardLocales = {
     uz: "Bu hafta faol bo'lmadi",
     vi: "Không Có Hoạt Động Trong Tuần Này",
     se: "Ingen aktivitet denna vecka",
+    ur: "اس ہفتے کوئی کوڈنگ سرگرمی نہیں ہے",
   },
 };
 


### PR DESCRIPTION
This PR adds complete Urdu (ur) translations to the GitHub stat card localization file.

Instead of using overly literal or outdated translations (e.g., translating "Issues" to "مسائل"), this update uses a modern English-Urdu hybrid style to improve clarity and relatability for native Urdu speakers familiar with common GitHub terminology.

**✅ Key points:**

*    Translations follow a natural and intuitive structure, e.g.:
** for example:   `Total Issues` → `کل Issues` (instead of the awkward کل مسائل)

* Preserves GitHub-specific terminology that is already commonly used in English among Urdu-speaking developers.