### PR TITLE
Fix typo in themes/README.md

### DIFF
--- a/themes/README.md
+++ b/themes/README.md
@@ -12,7 +12,7 @@ Use `?theme=THEME_NAME` parameter like so:
 
 ## Stats
 
-> These themes works with all five our cards: Stats Card, Repo Card, Gist Card, Top languages Card and WakaTime Card.
+> These themes works with all five of our cards: Stats Card, Repo Card, Gist Card, Top languages Card and WakaTime Card.
 
 | | | |
 | :--: | :--: | :--: |


### PR DESCRIPTION
There was a typo in [themes](https://github.com/anuraghazra/github-readme-stats/blob/master/themes)/[README.md](https://github.com/anuraghazra/github-readme-stats/blob/master/themes/README.md), so I fixed it! (Missing 'of')