### PR TITLE
Remove call to donate to give.do that has ended

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,20 +69,6 @@
 
 <p align="center">Love the project? Please consider <a href="https://www.paypal.me/anuraghazra">donating</a> to help it improve!</p>
 
-<a href="https://indiafightscorona.giveindia.org">
-  <img src="https://cfstatic.give.do/logo.png" alt="Give india logo" width="200" />
-</a>
-
-Are you considering supporting the project by donating to me? Please DO NOT!!!
-
-<img src="https://cfstatic.give.do/910ede2a-7892-43fe-8c8a-dea45e96d950.webp" alt="Picture of Coromandel Express train tragedy" width="35%">
-
-India has recently suffered one of the most devastating train accidents, and your help will be immensely valuable for the people who were affected by this tragedy.
-
-Please visit [this link](https://give.do/fundraisers/stand-beside-the-victims-of-the-coromandel-express-train-tragedy-in-odisha-donate-now) and make a small donation to help the people in need. A small donation goes a long way. :heart:
-
-</p>
-
 # Features <!-- omit in toc -->
 
 - [GitHub Stats Card](#github-stats-card)


### PR DESCRIPTION
That terrible crash was now over two years ago, and the link for the fundraiser has stopped receiving donations.    
    
I'd like to strongly thank @anuraghazra for using his platform to help others, but I think it's about time he should start collecting donations for himself again!