### PR TITLE
Fix wakatime

### DIFF
--- a/src/cards/wakatime.js
+++ b/src/cards/wakatime.js
@@ -87,21 +87,24 @@ const createCompactLangNode = ({ lang, x, y, display_format }) => {
  * @returns {string[]} The language text node items.
  */
 const createLanguageTextNode = ({ langs, y, display_format }) => {
+  const halfLength = Math.ceil(langs.length / 2);
+
   return langs.map((lang, index) => {
-    if (index % 2 === 0) {
+    if (index < halfLength) {
       return createCompactLangNode({
         lang,
         x: 25,
         y: 12.5 * index + y,
         display_format,
       });
+    } else {
+      return createCompactLangNode({
+        lang,
+        x: 230,
+        y: 12.5 * (index - halfLength) + y,
+        display_format,
+      });
     }
-    return createCompactLangNode({
-      lang,
-      x: 230,
-      y: 12.5 + 12.5 * index,
-      display_format,
-    });
   });
 };
 

--- a/src/cards/wakatime.js
+++ b/src/cards/wakatime.js
@@ -84,9 +84,10 @@ const createCompactLangNode = ({ lang, x, y, display_format }) => {
  * @param {WakaTimeLang[]} args.langs The language objects.
  * @param {number} args.y The y position of the language node.
  * @param {"time" | "percent"} args.display_format The display format of the language node.
+ * @param {number} args.lineHeight The line height for spacing.
  * @returns {string[]} The language text node items.
  */
-const createLanguageTextNode = ({ langs, y, display_format }) => {
+const createLanguageTextNode = ({ langs, y, display_format, lineHeight = 25 }) => {
   const halfLength = Math.ceil(langs.length / 2);
 
   return langs.map((lang, index) => {
@@ -94,14 +95,14 @@ const createLanguageTextNode = ({ langs, y, display_format }) => {
       return createCompactLangNode({
         lang,
         x: 25,
-        y: 12.5 * index + y,
+        y: lineHeight * index + y,
         display_format,
       });
     } else {
       return createCompactLangNode({
         lang,
         x: 230,
-        y: 12.5 * (index - halfLength) + y,
+        y: lineHeight * (index - halfLength) + y,
         display_format,
       });
     }
@@ -297,7 +298,7 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
   // RENDER COMPACT LAYOUT
   if (layout === "compact") {
     width = width + 50;
-    height = 90 + Math.round(filteredLanguages.length / 2) * 25;
+    height = 90 + Math.round(filteredLanguages.length / 2) * lheight;
 
     // progressOffset holds the previous language's width and used to offset the next language
     // so that we can stack them one after another, like this: [--][----][---]
@@ -336,6 +337,7 @@ const renderWakatimeCard = (stats = {}, options = { hide: [] }) => {
               y: 25,
               langs: filteredLanguages,
               display_format,
+              lineHeight: lheight,
             }).join("")
           : noCodingActivityNode({
               // @ts-ignore


### PR DESCRIPTION
This pull request updates the layout logic for rendering the compact Wakatime card, focusing on improving the spacing and alignment of language nodes. The main changes introduce a configurable `lineHeight` parameter, ensuring better vertical spacing and more maintainable code when displaying language statistics.

**Compact layout improvements:**

* Added a `lineHeight` parameter to the `createLanguageTextNode` function, allowing dynamic adjustment of vertical spacing between language nodes.
* Updated the calculation of the card's height in the compact layout to use the new `lineHeight` variable for more accurate sizing.
* Passed the `lineHeight` value from the `renderWakatimeCard` function into `createLanguageTextNode`, ensuring consistent spacing throughout the card rendering process.
* Keep the compact layout grid order same between WakaTime and Top Languages cards.
* fixed #4432