### PR TITLE
Fix: When user doesn't have any PR, it's Merged PRs Percentage is NAN…

### DIFF
--- a/src/fetchers/stats.js
+++ b/src/fetchers/stats.js
@@ -297,9 +297,8 @@ const fetchStats = async (
   if (include_merged_pull_requests) {
     stats.totalPRsMerged = user.mergedPullRequests.totalCount;
     stats.mergedPRsPercentage =
-    user.pullRequests.totalCount > 0
-      ? (user.mergedPullRequests.totalCount / user.pullRequests.totalCount) * 100
-      : 0;
+      (user.mergedPullRequests.totalCount / user.pullRequests.totalCount) *
+        100 || 0;
   }
   stats.totalReviews = user.reviews.totalPullRequestReviewContributions;
   stats.totalIssues = user.openIssues.totalCount + user.closedIssues.totalCount;

--- a/src/fetchers/stats.js
+++ b/src/fetchers/stats.js
@@ -297,7 +297,9 @@ const fetchStats = async (
   if (include_merged_pull_requests) {
     stats.totalPRsMerged = user.mergedPullRequests.totalCount;
     stats.mergedPRsPercentage =
-      (user.mergedPullRequests.totalCount / user.pullRequests.totalCount) * 100;
+    user.pullRequests.totalCount > 0
+      ? (user.mergedPullRequests.totalCount / user.pullRequests.totalCount) * 100
+      : 0;
   }
   stats.totalReviews = user.reviews.totalPullRequestReviewContributions;
   stats.totalIssues = user.openIssues.totalCount + user.closedIssues.totalCount;

--- a/tests/fetchStats.test.js
+++ b/tests/fetchStats.test.js
@@ -43,6 +43,16 @@ const data_stats = {
 const data_year2003 = JSON.parse(JSON.stringify(data_stats));
 data_year2003.data.user.commits.totalCommitContributions = 428;
 
+const data_without_pull_requests = {
+  data: {
+    user: {
+      ...data_stats.data.user,
+      pullRequests: { totalCount: 0 },
+      mergedPullRequests: { totalCount: 0 },
+    },
+  },
+};
+
 const data_repo = {
   data: {
     user: {
@@ -452,6 +462,39 @@ describe("Test fetchStats", () => {
       totalCommits: 428,
       totalIssues: 200,
       totalPRs: 300,
+      totalPRsMerged: 0,
+      mergedPRsPercentage: 0,
+      totalReviews: 50,
+      totalStars: 300,
+      totalDiscussionsStarted: 0,
+      totalDiscussionsAnswered: 0,
+      rank,
+    });
+  });
+
+  it("should return correct data when user don't have any pull requests", async () => {
+    mock.reset();
+    mock
+      .onPost("https://api.github.com/graphql")
+      .reply(200, data_without_pull_requests);
+    const stats = await fetchStats("anuraghazra", false, [], true);
+    const rank = calculateRank({
+      all_commits: false,
+      commits: 100,
+      prs: 0,
+      reviews: 50,
+      issues: 200,
+      repos: 5,
+      stars: 300,
+      followers: 100,
+    });
+
+    expect(stats).toStrictEqual({
+      contributedTo: 61,
+      name: "Anurag Hazra",
+      totalCommits: 100,
+      totalIssues: 200,
+      totalPRs: 0,
       totalPRsMerged: 0,
       mergedPRsPercentage: 0,
       totalReviews: 50,


### PR DESCRIPTION
Fixed an issue where merged PRs percentage could be NaN if the user has no PRs.
Fixes #4449