### PR TITLE
Add card_width option to gist cards

### DIFF
--- a/api/gist.js
+++ b/api/gist.js
@@ -23,6 +23,7 @@ export default async (req, res) => {
     border_color,
     show_owner,
     hide_border,
+    card_width,
   } = req.query;
 
   res.setHeader("Content-Type", "image/svg+xml");
@@ -82,6 +83,7 @@ export default async (req, res) => {
         theme,
         border_radius,
         border_color,
+        card_width: card_width ? parseInt(card_width, 10) : undefined, // <-- new line
         locale: locale ? locale.toLowerCase() : null,
         show_owner: parseBoolean(show_owner),
         hide_border: parseBoolean(hide_border),

--- a/src/cards/gist.js
+++ b/src/cards/gist.js
@@ -54,6 +54,7 @@ const renderGistCard = (gistData, options = {}) => {
     border_color,
     show_owner = false,
     hide_border = false,
+    card_width = CARD_DEFAULT_WIDTH, // <-- new line
   } = options;
 
   // returns theme based colors with proper overrides and defaults
@@ -118,7 +119,7 @@ const renderGistCard = (gistData, options = {}) => {
         ? `${header.slice(0, HEADER_MAX_LENGTH)}...`
         : header,
     titlePrefixIcon: icons.gist,
-    width: CARD_DEFAULT_WIDTH,
+    width: card_width,
     height,
     border_radius,
     colors: {


### PR DESCRIPTION
- Added support for `card_width` in `src/cards/gist.js`.
- Integrated `card_width` in API (`api/gist.js`) so users can customize gist card width via query parameter.
- Default width remains 400px if not specified.
