### PR TITLE
fix: prevent TypeError crashes on network errors with safe property a…

### DIFF
--- a/src/common/retryer.js
+++ b/src/common/retryer.js
@@ -63,10 +63,9 @@ const retryer = async (fetcher, variables, retries = 0) => {
   } catch (err) {
     // prettier-ignore
     // also checking for bad credentials if any tokens gets invalidated
-    const isBadCredential = err.response.data && err.response.data.message === "Bad credentials";
+    const isBadCredential = err.response?.data?.message === "Bad credentials";
     const isAccountSuspended =
-      err.response.data &&
-      err.response.data.message === "Sorry. Your account was suspended.";
+      err.response?.data?.message === "Sorry. Your account was suspended.";
 
     if (isBadCredential || isAccountSuspended) {
       logger.log(`PAT_${retries + 1} Failed`);

--- a/src/fetchers/wakatime.js
+++ b/src/fetchers/wakatime.js
@@ -21,7 +21,8 @@ const fetchWakatimeStats = async ({ username, api_domain }) => {
 
     return data.data;
   } catch (err) {
-    if (err.response.status < 200 || err.response.status > 299) {
+    const status = err.response?.status;
+    if (status && (status < 200 || status > 299)) {
       throw new CustomError(
         `Could not resolve to a User with the login of '${username}'`,
         "WAKATIME_USER_NOT_FOUND",


### PR DESCRIPTION
Fixed #4510 
Fixed critical bug where accessing err.response.data without null checks caused TypeError crashes when network errors occurred (timeouts, DNS failures, connection refused). These errors don't have err.response property.

Changes:
- src/common/retryer.js: Use optional chaining for err.response.data access
- src/fetchers/wakatime.js: Use optional chaining for err.response.status
- tests/retryer.test.js: Add test coverage for network error scenarios

Fixes crashes with "Cannot read property 'data' of undefined" and ensures graceful error handling during network instability.