### PR TITLE
Fix #4773: Cannot read properties of undefined (reading 'user') on gith

### DIFF
--- a/src/fetchers/stats.js
+++ b/src/fetchers/stats.js
@@ -136,6 +136,11 @@ const statsFetcher = async ({
       return res;
     }
 
+    // Bail out early if user is null (e.g. private/non-existent user without a GraphQL error).
+    if (!res.data.data?.user) {
+      return res;
+    }
+
     // Store stats data.
     const repoNodes = res.data.data.user.repositories.nodes;
     if (stats) {
@@ -281,7 +286,11 @@ const fetchStats = async (
     );
   }
 
-  const user = res.data.data.user;
+  const user = res.data.data?.user;
+
+  if (!user) {
+    throw new CustomError("Could not fetch user.", CustomError.USER_NOT_FOUND);
+  }
 
   stats.name = user.name || user.login;
 

--- a/src/fetchers/top-languages.js
+++ b/src/fetchers/top-languages.js
@@ -91,6 +91,10 @@ const fetchTopLanguages = async (
     );
   }
 
+  if (!res.data.data?.user) {
+    throw new CustomError("Could not fetch user.", CustomError.USER_NOT_FOUND);
+  }
+
   let repoNodes = res.data.data.user.repositories.nodes;
   /** @type {Record<string, boolean>} */
   let repoToHide = {};


### PR DESCRIPTION
Fixes #4773

## Summary
This PR addresses: Cannot read properties of undefined (reading 'user') on github

## Changes
```
package-lock.json             | 18 ------------------
 src/fetchers/stats.js         | 11 ++++++++++-
 src/fetchers/top-languages.js |  4 ++++
 3 files changed, 14 insertions(+), 19 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).