### PR TITLE
Fix #4765: `TypeError` when setting a non-existent theme

### DIFF
--- a/src/common/color.js
+++ b/src/common/color.js
@@ -86,7 +86,8 @@ const getCardColors = ({
   const isThemeProvided = theme !== null && theme !== undefined;
 
   // @ts-ignore
-  const selectedTheme = isThemeProvided ? themes[theme] : defaultTheme;
+  const selectedTheme =
+    (isThemeProvided ? themes[theme] : defaultTheme) || defaultTheme;
 
   const defaultBorderColor =
     "border_color" in selectedTheme

--- a/tests/color.test.js
+++ b/tests/color.test.js
@@ -55,6 +55,14 @@ describe("Test color.js", () => {
     });
   });
 
+  it("getCardColors: should fallback to default theme if theme does not exist", () => {
+    let colors = getCardColors({
+      theme: "non_existent_theme",
+    });
+    const defaultColors = getCardColors({});
+    expect(colors).toStrictEqual(defaultColors);
+  });
+
   it("getCardColors: should return ring color equal to title color if not ring color is defined", () => {
     let colors = getCardColors({
       title_color: "f00",


### PR DESCRIPTION
Fixes #4765

## Summary
This PR addresses: `TypeError` when setting a non-existent theme

## Changes
```
package-lock.json   | 18 ------------------
 src/common/color.js |  3 ++-
 tests/color.test.js |  8 ++++++++
 3 files changed, 10 insertions(+), 19 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).