### PR TITLE
Fix #4779: top-langs fails with theme or custom colors

### DIFF
--- a/src/common/color.js
+++ b/src/common/color.js
@@ -86,7 +86,10 @@ const getCardColors = ({
   const isThemeProvided = theme !== null && theme !== undefined;
 
   // @ts-ignore
-  const selectedTheme = isThemeProvided ? themes[theme] : defaultTheme;
+  const selectedTheme = isThemeProvided
+    ? // @ts-ignore
+      (themes[theme] ?? defaultTheme)
+    : defaultTheme;
 
   const defaultBorderColor =
     "border_color" in selectedTheme

--- a/tests/color.test.js
+++ b/tests/color.test.js
@@ -55,6 +55,20 @@ describe("Test color.js", () => {
     });
   });
 
+  it("getCardColors: should fallback to default theme colors if theme is unknown", () => {
+    let colors = getCardColors({
+      theme: "this_theme_does_not_exist",
+    });
+    expect(colors).toStrictEqual({
+      titleColor: "#2f80ed",
+      textColor: "#434d58",
+      iconColor: "#4c71f2",
+      ringColor: "#2f80ed",
+      bgColor: "#fffefe",
+      borderColor: "#e4e2e2",
+    });
+  });
+
   it("getCardColors: should return ring color equal to title color if not ring color is defined", () => {
     let colors = getCardColors({
       title_color: "f00",


### PR DESCRIPTION
Fixes #4779

## Summary
This PR addresses: top-langs fails with theme or custom colors

## Changes
```
package-lock.json   | 18 ------------------
 src/common/color.js |  5 ++++-
 tests/color.test.js | 14 ++++++++++++++
 3 files changed, 18 insertions(+), 19 deletions(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).