### PR TITLE
docs: write permission to Actions example to avoid 403 on push

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -817,6 +817,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

When setting up the GitHub Actions workflow from the README, the job may fail when trying to push the generated SVG files back to the repository.

Example error:

```
Permission to <repo> denied to github-actions[bot]
```

This happens when the repository uses **read-only default workflow permissions**, which is now the default setting for many repositories.
In that configuration, the `GITHUB_TOKEN` does not have permission to push commits.

## Changes

The GitHub Actions example in the README now explicitly includes:

```yml id="te72bc"
permissions:
  contents: write
```

This allows the workflow to push the generated files back to the repository.

Explicitly specifying this permission makes the example work out-of-the-box even for repositories using read-only default workflow permissions.
It also makes the required permission clearer for users who are new to GitHub Actions.

The same permission is also documented in the GitHub Actions version of this project:
https://github.com/stats-organization/github-readme-stats-action#readme