### PR TITLE
docs: fix broken TOC links in readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -85,8 +85,8 @@
     - [Stats and top languages cards](#stats-and-top-languages-cards)
     - [Pinning repositories](#pinning-repositories)
 - [Deploy on your own](#deploy-on-your-own)
-  - [GitHub Actions (Recommended)](#github-actions-recommended)
-  - [Self-hosted (Vercel/Other) (Recommended)](#self-hosted-vercelother-recommended)
+  - [GitHub Actions (Recommended)](#github-actions)
+  - [Self-hosted (Vercel/Other) (Recommended)](#self-hosted-vercelother)
     - [First step: get your Personal Access Token (PAT)](#first-step-get-your-personal-access-token-pat)
     - [On Vercel](#on-vercel)
     - [:film\_projector: Check Out Step By Step Video Tutorial By @codeSTACKr](#film_projector-check-out-step-by-step-video-tutorial-by-codestackr)
@@ -99,7 +99,7 @@
 # Important Notices <!-- omit in toc -->
 
 > [!IMPORTANT]
-> The public Vercel instance at `https://github-readme-stats.vercel.app/api` is best-effort and can be unreliable due to rate limits and traffic spikes (see [#1471](https://github.com/anuraghazra/github-readme-stats/issues/1471)). We use caching to improve stability (see [common options](#common-options)), but for reliable cards we recommend [self-hosting](#deploy-on-your-own) (Vercel or other) or using the [GitHub Actions workflow](#github-actions-recommended) to generate cards in your [profile repository](https://docs.github.com/en/account-and-profile/how-tos/profile-customization/managing-your-profile-readme).
+> The public Vercel instance at `https://github-readme-stats.vercel.app/api` is best-effort and can be unreliable due to rate limits and traffic spikes (see [#1471](https://github.com/anuraghazra/github-readme-stats/issues/1471)). We use caching to improve stability (see [common options](#common-options)), but for reliable cards we recommend [self-hosting](#deploy-on-your-own) (Vercel or other) or using the [GitHub Actions workflow](#github-actions) to generate cards in your [profile repository](https://docs.github.com/en/account-and-profile/how-tos/profile-customization/managing-your-profile-readme).
 
 <img alt="Uptime Badge" src="https://img.shields.io/endpoint?url=https%3A%2F%2Fgithub-readme-stats-git-monitoring-github-readme-stats-team.vercel.app%2Fapi%2Fstatus%2Fup%3Ftype%3Dshields">
 


### PR DESCRIPTION
## Summary

Fixes #4802

## Problem

The table of contents and Important Notices section had broken internal links:
- TOC entry "GitHub Actions (Recommended)" linked to `#github-actions-recommended`, but the actual section header is `## GitHub Actions` (anchor: `#github-actions`)
- TOC entry "Self-hosted (Vercel/Other) (Recommended)" linked to `#self-hosted-vercelother-recommended`, but the actual section header is `## Self-hosted (Vercel/Other)` (anchor: `#self-hosted-vercelother`)
- Important Notices section also referenced the incorrect anchor

## Solution

Updated the anchor links to match the actual section headers:
- `#github-actions-recommended` → `#github-actions`
- `#self-hosted-vercelother-recommended` → `#self-hosted-vercelother`

## Changes

- Line 88: Fixed TOC link for GitHub Actions section
- Line 89: Fixed TOC link for Self-hosted section  
- Line 102: Fixed inline link in Important Notices