### PR TITLE
fix: fallback to default theme when invalid theme name is provided

### DIFF
--- a/src/common/color.js
+++ b/src/common/color.js
@@ -86,7 +86,8 @@ const getCardColors = ({
   const isThemeProvided = theme !== null && theme !== undefined;
 
   // @ts-ignore
-  const selectedTheme = isThemeProvided ? themes[theme] : defaultTheme;
+  const selectedTheme =
+    isThemeProvided && themes[theme] ? themes[theme] : defaultTheme;
 
   const defaultBorderColor =
     "border_color" in selectedTheme

--- a/tests/color.test.js
+++ b/tests/color.test.js
@@ -55,6 +55,21 @@ describe("Test color.js", () => {
     });
   });
 
+  it("getCardColors: should fallback to default theme if invalid theme is provided", () => {
+    let colors = getCardColors({
+      theme: "invalid_theme_name",
+    });
+    // Should not throw and should use default theme colors
+    expect(colors).toStrictEqual({
+      titleColor: "#2f80ed",
+      textColor: "#434d58",
+      ringColor: "#2f80ed",
+      iconColor: "#4c71f2",
+      bgColor: "#fffefe",
+      borderColor: "#e4e2e2",
+    });
+  });
+
   it("getCardColors: should return ring color equal to title color if not ring color is defined", () => {
     let colors = getCardColors({
       title_color: "f00",


### PR DESCRIPTION
## Summary

Fix `TypeError: Cannot use 'in' operator to search for 'border_color' in undefined` crash that occurs when an invalid or misspelled theme name is provided.

## Root cause

In `getCardColors()`, the code checks if a `theme` parameter was provided but not whether it maps to an actual theme in the `themes` object:

```js
// Before: themes["invalid_name"] returns undefined
const selectedTheme = isThemeProvided ? themes[theme] : defaultTheme;

// Then crashes here:
"border_color" in selectedTheme  // TypeError: cannot use 'in' on undefined
```

## Fix

Add a truthy check on `themes[theme]` so unrecognized theme names fall back to the default theme:

```js
const selectedTheme =
    isThemeProvided && themes[theme] ? themes[theme] : defaultTheme;
```

## Test

Added test case verifying that an invalid theme name returns default theme colors without throwing.

All existing color tests pass. Note: the pre-existing `calculateRank` test failure (floating-point precision mismatch) is unrelated to this change.

Fixes #4779