### PR TITLE
test(rank): cover the three previously-untested rank tiers (A-, B, C+)

### DIFF
--- a/tests/calculateRank.test.js
+++ b/tests/calculateRank.test.js
@@ -93,6 +93,51 @@ describe("Test calculateRank", () => {
     ).toStrictEqual({ level: "A+", percentile: 5.575988339442828 });
   });
 
+  it("rising user gets A- rank", () => {
+    expect(
+      calculateRank({
+        all_commits: false,
+        commits: 350,
+        prs: 75,
+        issues: 35,
+        reviews: 15,
+        repos: 0,
+        stars: 100,
+        followers: 25,
+      }),
+    ).toStrictEqual({ level: "A-", percentile: 31.850162395318826 });
+  });
+
+  it("casual user gets B rank", () => {
+    expect(
+      calculateRank({
+        all_commits: false,
+        commits: 150,
+        prs: 30,
+        issues: 15,
+        reviews: 8,
+        repos: 0,
+        stars: 40,
+        followers: 7,
+      }),
+    ).toStrictEqual({ level: "B", percentile: 56.92901040548792 });
+  });
+
+  it("occasional user gets C+ rank", () => {
+    expect(
+      calculateRank({
+        all_commits: false,
+        commits: 50,
+        prs: 10,
+        issues: 5,
+        reviews: 2,
+        repos: 0,
+        stars: 8,
+        followers: 2,
+      }),
+    ).toStrictEqual({ level: "C+", percentile: 83.37427145982537 });
+  });
+
   it("sindresorhus gets S rank", () => {
     expect(
       calculateRank({


### PR DESCRIPTION
## Summary

\`calculateRank\` returns one of nine levels — **S, A+, A, A-, B+, B, B-, C+, C** — but \`tests/calculateRank.test.js\` previously exercised only six (S, A+, A, B+, B-, C). **A-, B, and C+ had no test at all**, so any boundary regression in those bands would have gone unnoticed.

This PR adds three cases, one per missing band, matching the style of the existing tests (\`toStrictEqual\` on \`{ level, percentile }\`):

| Added test | Target level | Band | Percentile |
|---|---|---|---|
| \`rising user gets A- rank\` | A- | 25–37.5 | 31.85 |
| \`casual user gets B rank\` | B | 50–62.5 | 56.93 |
| \`occasional user gets C+ rank\` | C+ | 75–87.5 | 83.37 |

Inputs were picked so each percentile lands comfortably inside its band (≥1 percentile point from either threshold), to minimise flakiness from Node-version floating-point drift.

## Verification

\`\`\`
$ node --experimental-vm-modules node_modules/jest/bin/jest.js \\
    tests/calculateRank.test.js \\
    --testNamePattern 'A- rank|B rank|C\\+ rank'

Tests:   3 passed, 10 total
\`\`\`

Prettier clean: \`prettier --check tests/calculateRank.test.js\` passes.

## Heads-up (not addressed here)

While preparing this PR I noticed the pre-existing \`beginner user gets B- rank\` test is fragile across Node versions — on Node 25 it produces percentile \`65.02918514848257\` where the test expects \`65.02918514848255\` (2 ULPs drift). Happy to file that separately if you want a follow-up PR using \`toBeCloseTo\`; deliberately left out of this PR to keep scope tight.

## Scope

- No source changes.
- Single file: \`tests/calculateRank.test.js\`.
- Conventional commit type \`test:\` per repo convention.