### PR TITLE
docs: fix broken TOC anchor link for 'Deploy on your own' section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@
   - [Quick Tip (Align The Cards)](#quick-tip-align-the-cards)
     - [Stats and top languages cards](#stats-and-top-languages-cards)
     - [Pinning repositories](#pinning-repositories)
-- [Deploy on your own](#deploy-on-your-own)
+- [Deploy on your own](#deploy-on-your-own-recommended)
   - [GitHub Actions (Recommended)](#github-actions-recommended)
   - [Self-hosted (Vercel/Other) (Recommended)](#self-hosted-vercelother-recommended)
     - [First step: get your Personal Access Token (PAT)](#first-step-get-your-personal-access-token-pat)


### PR DESCRIPTION
## Description
Fixed a broken anchor link in the Table of Contents. The TOC entry for "Deploy on your own" was pointing to `#deploy-on-your-own`, but the actual heading ID is `#deploy-on-your-own-recommended`.

## Changes
- Updated TOC anchor from `#deploy-on-your-own` to `#deploy-on-your-own-recommended`

## Testing
- Verified the link now correctly jumps to the "Deploy on your own (Recommended)" section
- Checked that no other TOC links were affected

Fixes #4801