### PR TITLE
fix: replace deprecated #gh-dark-mode-only fragments with <picture> element in Responsive Card Theme preview

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -234,8 +234,17 @@ You can use [GitHub's theme context](https://github.blog/changelog/2021-11-24-sp
 <details>
 <summary>:eyes: Show example</summary>
 
-[![Anurag's GitHub stats-Dark](https://github-readme-stats.vercel.app/api?username=anuraghazra\&show_icons=true\&theme=dark#gh-dark-mode-only)](https://github.com/anuraghazra/github-readme-stats#gh-dark-mode-only)
-[![Anurag's GitHub stats-Light](https://github-readme-stats.vercel.app/api?username=anuraghazra\&show_icons=true\&theme=default#gh-light-mode-only)](https://github.com/anuraghazra/github-readme-stats#gh-light-mode-only)
+<picture>
+  <source
+    srcset="https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&theme=dark"
+    media="(prefers-color-scheme: dark)"
+  />
+  <source
+    srcset="https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true"
+    media="(prefers-color-scheme: light), (prefers-color-scheme: no-preference)"
+  />
+  <img src="https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true" />
+</picture>
 
 </details>
 

--- a/readme.md
+++ b/readme.md
@@ -178,8 +178,17 @@ You can look at a preview for [all available themes](themes/README.md) or checko
 
 #### Responsive Card Theme
 
-[![Anurag's GitHub stats-Dark](https://github-readme-stats.vercel.app/api?username=anuraghazra\&show_icons=true\&theme=dark#gh-dark-mode-only)](https://github.com/anuraghazra/github-readme-stats#responsive-card-theme#gh-dark-mode-only)
-[![Anurag's GitHub stats-Light](https://github-readme-stats.vercel.app/api?username=anuraghazra\&show_icons=true\&theme=default#gh-light-mode-only)](https://github.com/anuraghazra/github-readme-stats#responsive-card-theme#gh-light-mode-only)
+<picture>
+  <source
+    srcset="https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true&theme=dark"
+    media="(prefers-color-scheme: dark)"
+  />
+  <source
+    srcset="https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true"
+    media="(prefers-color-scheme: light), (prefers-color-scheme: no-preference)"
+  />
+  <img src="https://github-readme-stats.vercel.app/api?username=anuraghazra&show_icons=true" />
+</picture>
 
 Since GitHub will re-upload the cards and serve them from their [CDN](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/about-anonymized-urls), we can not infer the browser/GitHub theme on the server side. There are, however, four methods you can use to create dynamics themes on the client side.
 


### PR DESCRIPTION
## What

Two locations in the README had broken images caused by the deprecated `#gh-dark-mode-only` / `#gh-light-mode-only` URL fragment syntax, which GitHub no longer renders:

1. The preview at the top of the **Responsive Card Theme** section (had an additional malformed double anchor in the link href, e.g. `#responsive-card-theme#gh-dark-mode-only`)
2. The live example inside the **"Use GitHub's theme context tag"** `<details>` block

## Fix

Replaced both instances with `<picture>` elements using `prefers-color-scheme` media queries — the same approach the README itself documents as the correct modern method in the **"Use GitHub's new media feature"** subsection.

The catbox.moe screenshots in the Vercel setup guide were also audited and confirmed still live (all returning HTTP 200).

## Testing

Verified locally that the `<picture>` syntax matches the working examples already present in the **"Use GitHub's new media feature"** subsection.