### PR TITLE
fix: count reviewed PRs across all time

### DIFF
--- a/src/fetchers/stats.js
+++ b/src/fetchers/stats.js
@@ -39,7 +39,7 @@ const GRAPHQL_REPOS_QUERY = `
 `;
 
 const GRAPHQL_STATS_QUERY = `
-  query userInfo($login: String!, $after: String, $includeMergedPullRequests: Boolean!, $includeDiscussions: Boolean!, $includeDiscussionsAnswers: Boolean!, $startTime: DateTime = null) {
+  query userInfo($login: String!, $after: String, $includeMergedPullRequests: Boolean!, $includeDiscussions: Boolean!, $includeDiscussionsAnswers: Boolean!, $reviewedPullRequestsQuery: String!, $startTime: DateTime = null) {
     user(login: $login) {
       name
       login
@@ -48,6 +48,9 @@ const GRAPHQL_STATS_QUERY = `
       }
       reviews: contributionsCollection {
         totalPullRequestReviewContributions
+      }
+      reviewedPullRequests: search(query: $reviewedPullRequestsQuery, type: ISSUE) {
+        issueCount
       }
       repositoriesContributedTo(first: 1, contributionTypes: [COMMIT, ISSUE, PULL_REQUEST, REPOSITORY]) {
         totalCount
@@ -129,6 +132,7 @@ const statsFetcher = async ({
       includeMergedPullRequests,
       includeDiscussions,
       includeDiscussionsAnswers,
+      reviewedPullRequestsQuery: `type:pr reviewed-by:${username}`,
       startTime,
     };
     let res = await retryer(fetcher, variables);
@@ -299,7 +303,7 @@ const fetchStats = async (
       (user.mergedPullRequests.totalCount / user.pullRequests.totalCount) *
         100 || 0;
   }
-  stats.totalReviews = user.reviews.totalPullRequestReviewContributions;
+  stats.totalReviews = user.reviewedPullRequests.issueCount;
   stats.totalIssues = user.openIssues.totalCount + user.closedIssues.totalCount;
   if (include_discussions) {
     stats.totalDiscussionsStarted = user.repositoryDiscussions.totalCount;

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -56,6 +56,9 @@ const data_stats = {
       reviews: {
         totalPullRequestReviewContributions: stats.totalReviews,
       },
+      reviewedPullRequests: {
+        issueCount: stats.totalReviews,
+      },
       pullRequests: { totalCount: stats.totalPRs },
       mergedPullRequests: { totalCount: stats.totalPRsMerged },
       openIssues: { totalCount: stats.totalIssues },

--- a/tests/fetchStats.test.js
+++ b/tests/fetchStats.test.js
@@ -17,6 +17,9 @@ const data_stats = {
       reviews: {
         totalPullRequestReviewContributions: 50,
       },
+      reviewedPullRequests: {
+        issueCount: 50,
+      },
       pullRequests: { totalCount: 300 },
       mergedPullRequests: { totalCount: 240 },
       openIssues: { totalCount: 100 },
@@ -42,6 +45,10 @@ const data_stats = {
 
 const data_year2003 = JSON.parse(JSON.stringify(data_stats));
 data_year2003.data.user.commits.totalCommitContributions = 428;
+
+const data_all_time_reviews = JSON.parse(JSON.stringify(data_stats));
+data_all_time_reviews.data.user.reviews.totalPullRequestReviewContributions = 2;
+data_all_time_reviews.data.user.reviewedPullRequests.issueCount = 22;
 
 const data_without_pull_requests = {
   data: {
@@ -154,6 +161,17 @@ describe("Test fetchStats", () => {
       totalDiscussionsAnswered: 0,
       rank,
     });
+  });
+
+  it("should use the all-time reviewed pull request count", async () => {
+    mock.reset();
+    mock
+      .onPost("https://api.github.com/graphql")
+      .reply(200, data_all_time_reviews);
+
+    let stats = await fetchStats("Andrej123456789");
+
+    expect(stats.totalReviews).toBe(22);
   });
 
   it("should stop fetching when there are repos with zero stars", async () => {


### PR DESCRIPTION
## What changed

Fixes #4874.

The stats fetcher now uses a GitHub search count for `type:pr reviewed-by:<username>` so the `Total PRs Reviewed` value is not limited to the default one-year `contributionsCollection` window. The existing contribution collection field remains in the query fixture only for compatibility context, but the displayed stats use the all-time search count.

## Verification

- `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/fetchStats.test.js -t "all-time reviewed pull request count" --runInBand`
- `node --experimental-vm-modules node_modules/jest/bin/jest.js tests/fetchStats.test.js tests/api.test.js --runInBand`
- `npx eslint --max-warnings 0 src/fetchers/stats.js tests/fetchStats.test.js tests/api.test.js`
- `npx prettier --check src/fetchers/stats.js tests/fetchStats.test.js tests/api.test.js`
- `git diff --check`
- `nvm exec 22 npm test -- --runInBand`
