### PR TITLE
fix: split stats query to fit GitHub GraphQL per-query resource limits (RESOURCE_LIMITS_EXCEEDED)

### DIFF
--- a/src/fetchers/stats.js
+++ b/src/fetchers/stats.js
@@ -38,19 +38,27 @@ const GRAPHQL_REPOS_QUERY = `
   }
 `;
 
+// GitHub's GraphQL API enforces a per-query resource budget that the combined
+// stats query now exceeds, so contributionsCollection/counts, repositories,
+// and repositoriesContributedTo are fetched in separate requests.
+const GRAPHQL_CONTRIBUTED_TO_QUERY = `
+  query userInfo($login: String!) {
+    user(login: $login) {
+      repositoriesContributedTo(first: 1, contributionTypes: [COMMIT, ISSUE, PULL_REQUEST, REPOSITORY]) {
+        totalCount
+      }
+    }
+  }
+`;
+
 const GRAPHQL_STATS_QUERY = `
-  query userInfo($login: String!, $after: String, $includeMergedPullRequests: Boolean!, $includeDiscussions: Boolean!, $includeDiscussionsAnswers: Boolean!, $startTime: DateTime = null) {
+  query userInfo($login: String!, $includeMergedPullRequests: Boolean!, $includeDiscussions: Boolean!, $includeDiscussionsAnswers: Boolean!, $startTime: DateTime = null) {
     user(login: $login) {
       name
       login
-      commits: contributionsCollection (from: $startTime) {
+      contributions: contributionsCollection (from: $startTime) {
         totalCommitContributions,
-      }
-      reviews: contributionsCollection {
         totalPullRequestReviewContributions
-      }
-      repositoriesContributedTo(first: 1, contributionTypes: [COMMIT, ISSUE, PULL_REQUEST, REPOSITORY]) {
-        totalCount
       }
       pullRequests(first: 1) {
         totalCount
@@ -73,7 +81,6 @@ const GRAPHQL_STATS_QUERY = `
       repositoryDiscussionComments(onlyAnswers: true) @include(if: $includeDiscussionsAnswers) {
         totalCount
       }
-      ${GRAPHQL_REPOS_FIELD}
     }
   }
 `;
@@ -81,15 +88,52 @@ const GRAPHQL_STATS_QUERY = `
 /**
  * Stats fetcher object.
  *
- * @param {object & { after: string | null }} variables Fetcher variables.
+ * @param {object} variables Fetcher variables.
  * @param {string} token GitHub token.
  * @returns {Promise<import('axios').AxiosResponse>} Axios response.
  */
 const fetcher = (variables, token) => {
-  const query = variables.after ? GRAPHQL_REPOS_QUERY : GRAPHQL_STATS_QUERY;
   return request(
     {
-      query,
+      query: GRAPHQL_STATS_QUERY,
+      variables,
+    },
+    {
+      Authorization: `bearer ${token}`,
+    },
+  );
+};
+
+/**
+ * Repositories fetcher object.
+ *
+ * @param {object & { after: string | null }} variables Fetcher variables.
+ * @param {string} token GitHub token.
+ * @returns {Promise<import('axios').AxiosResponse>} Axios response.
+ */
+const reposFetcher = (variables, token) => {
+  return request(
+    {
+      query: GRAPHQL_REPOS_QUERY,
+      variables,
+    },
+    {
+      Authorization: `bearer ${token}`,
+    },
+  );
+};
+
+/**
+ * Contributed-to fetcher object.
+ *
+ * @param {object} variables Fetcher variables.
+ * @param {string} token GitHub token.
+ * @returns {Promise<import('axios').AxiosResponse>} Axios response.
+ */
+const contributedToFetcher = (variables, token) => {
+  return request(
+    {
+      query: GRAPHQL_CONTRIBUTED_TO_QUERY,
       variables,
     },
     {
@@ -118,30 +162,37 @@ const statsFetcher = async ({
   includeDiscussionsAnswers,
   startTime,
 }) => {
-  let stats;
+  const stats = await retryer(fetcher, {
+    login: username,
+    includeMergedPullRequests,
+    includeDiscussions,
+    includeDiscussionsAnswers,
+    startTime,
+  });
+  if (stats.data.errors) {
+    return stats;
+  }
+
+  let repositories = null;
   let hasNextPage = true;
   let endCursor = null;
   while (hasNextPage) {
-    const variables = {
+    const res = await retryer(reposFetcher, {
       login: username,
       first: 100,
       after: endCursor,
-      includeMergedPullRequests,
-      includeDiscussions,
-      includeDiscussionsAnswers,
-      startTime,
-    };
-    let res = await retryer(fetcher, variables);
+    });
     if (res.data.errors) {
       return res;
     }
 
-    // Store stats data.
-    const repoNodes = res.data.data.user.repositories.nodes;
-    if (stats) {
-      stats.data.data.user.repositories.nodes.push(...repoNodes);
+    // Store repositories data.
+    const repoPage = res.data.data.user.repositories;
+    const repoNodes = repoPage.nodes;
+    if (repositories) {
+      repositories.nodes.push(...repoNodes);
     } else {
-      stats = res;
+      repositories = repoPage;
     }
 
     // Disable multi page fetching on public Vercel instance due to rate limits.
@@ -151,9 +202,19 @@ const statsFetcher = async ({
     hasNextPage =
       process.env.FETCH_MULTI_PAGE_STARS === "true" &&
       repoNodes.length === repoNodesWithStars.length &&
-      res.data.data.user.repositories.pageInfo.hasNextPage;
-    endCursor = res.data.data.user.repositories.pageInfo.endCursor;
+      repoPage.pageInfo.hasNextPage;
+    endCursor = repoPage.pageInfo.endCursor;
   }
+  stats.data.data.user.repositories = repositories;
+
+  const contributedToRes = await retryer(contributedToFetcher, {
+    login: username,
+  });
+  if (contributedToRes.data.errors) {
+    return contributedToRes;
+  }
+  stats.data.data.user.repositoriesContributedTo =
+    contributedToRes.data.data.user.repositoriesContributedTo;
 
   return stats;
 };
@@ -289,7 +350,7 @@ const fetchStats = async (
   if (include_all_commits) {
     stats.totalCommits = await totalCommitsFetcher(username);
   } else {
-    stats.totalCommits = user.commits.totalCommitContributions;
+    stats.totalCommits = user.contributions.totalCommitContributions;
   }
 
   stats.totalPRs = user.pullRequests.totalCount;
@@ -299,7 +360,7 @@ const fetchStats = async (
       (user.mergedPullRequests.totalCount / user.pullRequests.totalCount) *
         100 || 0;
   }
-  stats.totalReviews = user.reviews.totalPullRequestReviewContributions;
+  stats.totalReviews = user.contributions.totalPullRequestReviewContributions;
   stats.totalIssues = user.openIssues.totalCount + user.closedIssues.totalCount;
   if (include_discussions) {
     stats.totalDiscussionsStarted = user.repositoryDiscussions.totalCount;

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -50,10 +50,8 @@ const data_stats = {
     user: {
       name: stats.name,
       repositoriesContributedTo: { totalCount: stats.contributedTo },
-      commits: {
+      contributions: {
         totalCommitContributions: stats.totalCommits,
-      },
-      reviews: {
         totalPullRequestReviewContributions: stats.totalReviews,
       },
       pullRequests: { totalCount: stats.totalPRs },
@@ -102,7 +100,7 @@ const faker = (query, data) => {
     setHeader: jest.fn(),
     send: jest.fn(),
   };
-  mock.onPost("https://api.github.com/graphql").replyOnce(200, data);
+  mock.onPost("https://api.github.com/graphql").reply(200, data);
 
   return { req, res };
 };

--- a/tests/bench/api.bench.js
+++ b/tests/bench/api.bench.js
@@ -24,10 +24,8 @@ const data_stats = {
     user: {
       name: stats.name,
       repositoriesContributedTo: { totalCount: stats.contributedTo },
-      commits: {
+      contributions: {
         totalCommitContributions: stats.totalCommits,
-      },
-      reviews: {
         totalPullRequestReviewContributions: stats.totalReviews,
       },
       pullRequests: { totalCount: stats.totalPRs },

--- a/tests/fetchStats.test.js
+++ b/tests/fetchStats.test.js
@@ -10,11 +10,8 @@ const data_stats = {
   data: {
     user: {
       name: "Anurag Hazra",
-      repositoriesContributedTo: { totalCount: 61 },
-      commits: {
+      contributions: {
         totalCommitContributions: 100,
-      },
-      reviews: {
         totalPullRequestReviewContributions: 50,
       },
       pullRequests: { totalCount: 300 },
@@ -24,6 +21,16 @@ const data_stats = {
       followers: { totalCount: 100 },
       repositoryDiscussions: { totalCount: 10 },
       repositoryDiscussionComments: { totalCount: 40 },
+    },
+  },
+};
+
+const data_year2003 = JSON.parse(JSON.stringify(data_stats));
+data_year2003.data.user.contributions.totalCommitContributions = 428;
+
+const data_repo_page1 = {
+  data: {
+    user: {
       repositories: {
         totalCount: 5,
         nodes: [
@@ -40,8 +47,13 @@ const data_stats = {
   },
 };
 
-const data_year2003 = JSON.parse(JSON.stringify(data_stats));
-data_year2003.data.user.commits.totalCommitContributions = 428;
+const data_contributed_to = {
+  data: {
+    user: {
+      repositoriesContributedTo: { totalCount: 61 },
+    },
+  },
+};
 
 const data_without_pull_requests = {
   data: {
@@ -49,6 +61,8 @@ const data_without_pull_requests = {
       ...data_stats.data.user,
       pullRequests: { totalCount: 0 },
       mergedPullRequests: { totalCount: 0 },
+      repositories: data_repo_page1.data.user.repositories,
+      repositoriesContributedTo: { totalCount: 61 },
     },
   },
 };
@@ -74,6 +88,7 @@ const data_repo_zero_stars = {
   data: {
     user: {
       repositories: {
+        totalCount: 5,
         nodes: [
           { name: "test-repo-1", stargazers: { totalCount: 100 } },
           { name: "test-repo-2", stargazers: { totalCount: 100 } },
@@ -108,17 +123,20 @@ beforeEach(() => {
   mock.onPost("https://api.github.com/graphql").reply((cfg) => {
     let req = JSON.parse(cfg.data);
 
-    if (
-      req.variables &&
-      req.variables.startTime &&
-      req.variables.startTime.startsWith("2003")
-    ) {
-      return [200, data_year2003];
+    if (req.query.includes("repositoriesContributedTo")) {
+      return [200, data_contributed_to];
     }
-    return [
-      200,
-      req.query.includes("totalCommitContributions") ? data_stats : data_repo,
-    ];
+    if (req.query.includes("totalCommitContributions")) {
+      if (
+        req.variables &&
+        req.variables.startTime &&
+        req.variables.startTime.startsWith("2003")
+      ) {
+        return [200, data_year2003];
+      }
+      return [200, data_stats];
+    }
+    return [200, req.variables.after ? data_repo : data_repo_page1];
   });
 });
 
@@ -162,7 +180,9 @@ describe("Test fetchStats", () => {
       .onPost("https://api.github.com/graphql")
       .replyOnce(200, data_stats)
       .onPost("https://api.github.com/graphql")
-      .replyOnce(200, data_repo_zero_stars);
+      .replyOnce(200, data_repo_zero_stars)
+      .onPost("https://api.github.com/graphql")
+      .replyOnce(200, data_contributed_to);
 
     let stats = await fetchStats("anuraghazra");
     const rank = calculateRank({
@@ -235,7 +255,7 @@ describe("Test fetchStats", () => {
   });
 
   it("should throw specific error when include_all_commits true and invalid username", async () => {
-    expect(fetchStats("asdf///---", true)).rejects.toThrow(
+    await expect(fetchStats("asdf///---", true)).rejects.toThrow(
       new Error("Invalid username provided."),
     );
   });
@@ -245,7 +265,7 @@ describe("Test fetchStats", () => {
       .onGet("https://api.github.com/search/commits?q=author:anuraghazra")
       .reply(200, { error: "Some test error message" });
 
-    expect(fetchStats("anuraghazra", true)).rejects.toThrow(
+    await expect(fetchStats("anuraghazra", true)).rejects.toThrow(
       new Error("Could not fetch total commits."),
     );
   });


### PR DESCRIPTION
## Problem

Since around mid-July 2026, stats card requests fail with:

> Something went wrong! file an issue at https://tiny.one/readme-stats
> Resource limits for this query exceeded. / OK

GitHub's GraphQL API now enforces a much tighter **per-query resource budget**, and `GRAPHQL_STATS_QUERY` exceeds it — including on current `master`, where the two aliased `contributionsCollection` selections alone are enough to blow the budget. Every `/api` render fails, on any instance running this code (the PAT is fine; `/api/status/pat-info` reports the token valid with plenty of quota).

One red herring worth documenting: the GraphQL error `path` points at whichever field happens to exhaust the budget, which makes it look field-specific. Probing GitHub's API with isolated queries shows the limit is cumulative:

| Query composition | Result |
|---|---|
| single `contributionsCollection { totalCommitContributions totalPullRequestReviewContributions }` | ✅ |
| two aliased `contributionsCollection` selections (current `master`) | ❌ `RESOURCE_LIMITS_EXCEEDED` at the second alias |
| merged collection + `repositories(first: 100, …)` | ✅ |
| merged collection + `repositoriesContributedTo` | ❌ |
| merged collection + repositories + PR/issue/follower counts | ❌ (budget runs out mid-list, at `repositories.nodes[51].name`) |

## Fix

- Merge the `commits:` / `reviews:` aliases into a single `contributions: contributionsCollection` selection.
- Split the stats fetch into three requests, each comfortably within the budget:
  1. contribution + count stats (`GRAPHQL_STATS_QUERY`, no repositories field),
  2. repositories via the existing paginated `GRAPHQL_REPOS_QUERY` (now used for the first page too),
  3. `repositoriesContributedTo` on its own.

Trade-offs / notes:

- Up to 2 extra GraphQL requests per uncached render (each is cheap point-wise).
- When `commits_year` is set, `totalPullRequestReviewContributions` is now scoped to the same `from:` window as commits, since both live in one collection; previously reviews were always all-time.

## Tests

- Fixtures now mirror the per-query API responses; the mock router in `fetchStats.test.js` dispatches on query content.
- `faker()` in `api.test.js` used `replyOnce`, which only served the first of the (now three) GraphQL calls — switched to `reply`.
- Added missing `await` on two `expect(...).rejects` assertions in `fetchStats.test.js`. These were pre-existing floating assertions; the multi-request flow exposed them because `afterEach`'s `mock.reset()` raced the still-running fetch.

`npm test`: 27 suites / 242 tests pass. `npm run lint` and `prettier --check` clean.

Verified live on my self-hosted Vercel instance — cards render again with correct numbers.

I'm aware of #4902 (development has moved to github-stats-extended); submitting anyway because the many self-hosted instances of this repo are currently hard-broken by this GitHub-side change, and this patch may help anyone who lands here from the error message.

## Disclosure

This investigation and patch were produced by **Claude Fable 5** (Anthropic's AI model) running in Claude Code, at the request of and supervised by @nightt5879. Happy to adjust anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
