### PR TITLE
test: compare rank percentiles approximately in calculateRank tests

### DIFF
--- a/tests/calculateRank.test.js
+++ b/tests/calculateRank.test.js
@@ -2,9 +2,25 @@ import { describe, expect, it } from "@jest/globals";
 import "@testing-library/jest-dom";
 import { calculateRank } from "../src/calculateRank.js";
 
+/**
+ * Assert a rank, comparing the percentile approximately.
+ *
+ * The percentile is the result of a chain of floating point operations whose
+ * last digits differ between V8 versions, so an exact comparison is brittle.
+ *
+ * @param {object} rank Rank returned by `calculateRank`.
+ * @param {string} level Expected level.
+ * @param {number} percentile Expected percentile.
+ * @returns {void}
+ */
+const expectRank = (rank, level, percentile) => {
+  expect(rank.level).toStrictEqual(level);
+  expect(rank.percentile).toBeCloseTo(percentile, 10);
+};
+
 describe("Test calculateRank", () => {
   it("new user gets C rank", () => {
-    expect(
+    expectRank(
       calculateRank({
         all_commits: false,
         commits: 0,
@@ -15,11 +31,13 @@ describe("Test calculateRank", () => {
         stars: 0,
         followers: 0,
       }),
-    ).toStrictEqual({ level: "C", percentile: 100 });
+      "C",
+      100,
+    );
   });
 
   it("beginner user gets B- rank", () => {
-    expect(
+    expectRank(
       calculateRank({
         all_commits: false,
         commits: 125,
@@ -30,11 +48,13 @@ describe("Test calculateRank", () => {
         stars: 25,
         followers: 5,
       }),
-    ).toStrictEqual({ level: "B-", percentile: 65.02918514848255 });
+      "B-",
+      65.02918514848255,
+    );
   });
 
   it("median user gets B+ rank", () => {
-    expect(
+    expectRank(
       calculateRank({
         all_commits: false,
         commits: 250,
@@ -45,11 +65,13 @@ describe("Test calculateRank", () => {
         stars: 50,
         followers: 10,
       }),
-    ).toStrictEqual({ level: "B+", percentile: 46.09375 });
+      "B+",
+      46.09375,
+    );
   });
 
   it("average user gets B+ rank (include_all_commits)", () => {
-    expect(
+    expectRank(
       calculateRank({
         all_commits: true,
         commits: 1000,
@@ -60,11 +82,13 @@ describe("Test calculateRank", () => {
         stars: 50,
         followers: 10,
       }),
-    ).toStrictEqual({ level: "B+", percentile: 46.09375 });
+      "B+",
+      46.09375,
+    );
   });
 
   it("advanced user gets A rank", () => {
-    expect(
+    expectRank(
       calculateRank({
         all_commits: false,
         commits: 500,
@@ -75,11 +99,13 @@ describe("Test calculateRank", () => {
         stars: 200,
         followers: 40,
       }),
-    ).toStrictEqual({ level: "A", percentile: 20.841471354166664 });
+      "A",
+      20.841471354166664,
+    );
   });
 
   it("expert user gets A+ rank", () => {
-    expect(
+    expectRank(
       calculateRank({
         all_commits: false,
         commits: 1000,
@@ -90,11 +116,13 @@ describe("Test calculateRank", () => {
         stars: 800,
         followers: 160,
       }),
-    ).toStrictEqual({ level: "A+", percentile: 5.575988339442828 });
+      "A+",
+      5.575988339442828,
+    );
   });
 
   it("sindresorhus gets S rank", () => {
-    expect(
+    expectRank(
       calculateRank({
         all_commits: false,
         commits: 1300,
@@ -105,6 +133,8 @@ describe("Test calculateRank", () => {
         stars: 600000,
         followers: 50000,
       }),
-    ).toStrictEqual({ level: "S", percentile: 0.4578556547153667 });
+      "S",
+      0.4578556547153667,
+    );
   });
 });


### PR DESCRIPTION
## What

`tests/calculateRank.test.js` now compares the `percentile` with `toBeCloseTo(value, 10)` instead of an exact `toStrictEqual` on the whole rank object. The `level` is still checked strictly.

## Why

The percentile is the result of a chain of floating point operations (weighted sums, `exponential_cdf`, `log_normal_cdf`) whose last digits differ between V8 versions. On Node 24 the "beginner user gets B- rank" case produces:

```
{ level: 'B-', percentile: 65.02918514848257 }   // expected 65.02918514848255
```

`src/calculateRank.js` is unchanged — the same failure reproduces on a clean `master` checkout. The other six cases happen to match exactly today, but they are equally brittle, so all seven were switched over for consistency.

## Notes for reviewers

- The ranking logic (weights, medians, CDFs) is **not** touched.
- `toBeCloseTo(x, 10)` allows a difference below `5e-11`; the observed drift is ~`1.4e-14`, so real regressions in the formula are still caught.
- Assertions go through a small `expectRank(rank, level, percentile)` helper to keep the cases readable.

Verified locally with `npm test -- tests/calculateRank.test.js` on Node v24.18.0: 7 passed, 100% coverage of `calculateRank.js`; `eslint` and `prettier --check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)