### PR TITLE
fix: use repository stargazerCount

### DIFF
--- a/src/fetchers/repo.js
+++ b/src/fetchers/repo.js
@@ -21,9 +21,7 @@ const fetcher = (variables, token) => {
         isPrivate
         isArchived
         isTemplate
-        stargazers {
-          totalCount
-        }
+        stargazerCount
         description
         primaryLanguage {
           color
@@ -94,7 +92,7 @@ const fetchRepo = async (username, reponame) => {
     }
     return {
       ...data.user.repository,
-      starCount: data.user.repository.stargazers.totalCount,
+      starCount: data.user.repository.stargazerCount,
     };
   }
 
@@ -107,7 +105,7 @@ const fetchRepo = async (username, reponame) => {
     }
     return {
       ...data.organization.repository,
-      starCount: data.organization.repository.stargazers.totalCount,
+      starCount: data.organization.repository.stargazerCount,
     };
   }
 

--- a/src/fetchers/stats.js
+++ b/src/fetchers/stats.js
@@ -19,9 +19,7 @@ const GRAPHQL_REPOS_FIELD = `
     totalCount
     nodes {
       name
-      stargazers {
-        totalCount
-      }
+      stargazerCount
     }
     pageInfo {
       hasNextPage
@@ -146,7 +144,7 @@ const statsFetcher = async ({
 
     // Disable multi page fetching on public Vercel instance due to rate limits.
     const repoNodesWithStars = repoNodes.filter(
-      (node) => node.stargazers.totalCount !== 0,
+      (node) => node.stargazerCount !== 0,
     );
     hasNextPage =
       process.env.FETCH_MULTI_PAGE_STARS === "true" &&
@@ -319,7 +317,7 @@ const fetchStats = async (
       return !repoToHide.has(data.name);
     })
     .reduce((prev, curr) => {
-      return prev + curr.stargazers.totalCount;
+      return prev + curr.stargazerCount;
     }, 0);
 
   stats.rank = calculateRank({

--- a/src/fetchers/types.d.ts
+++ b/src/fetchers/types.d.ts
@@ -13,7 +13,7 @@ export type RepositoryData = {
   isPrivate: boolean;
   isArchived: boolean;
   isTemplate: boolean;
-  stargazers: { totalCount: number };
+  stargazerCount: number;
   description: string;
   primaryLanguage: {
     color: string;

--- a/tests/api.test.js
+++ b/tests/api.test.js
@@ -67,7 +67,7 @@ const data_stats = {
       },
       repositories: {
         totalCount: 1,
-        nodes: [{ stargazers: { totalCount: 100 } }],
+        nodes: [{ stargazerCount: 100 }],
         pageInfo: {
           hasNextPage: false,
           endCursor: "cursor",

--- a/tests/bench/api.bench.js
+++ b/tests/bench/api.bench.js
@@ -41,7 +41,7 @@ const data_stats = {
       },
       repositories: {
         totalCount: 1,
-        nodes: [{ stargazers: { totalCount: 100 } }],
+        nodes: [{ stargazerCount: 100 }],
         pageInfo: {
           hasNextPage: false,
           endCursor: "cursor",

--- a/tests/bench/pin.bench.js
+++ b/tests/bench/pin.bench.js
@@ -8,9 +8,7 @@ const data_repo = {
   repository: {
     username: "anuraghazra",
     name: "convoychat",
-    stargazers: {
-      totalCount: 38000,
-    },
+    stargazerCount: 38000,
     description: "Help us take over the world! React + TS + GraphQL Chat App",
     primaryLanguage: {
       color: "#2b7489",

--- a/tests/e2e/e2e.test.js
+++ b/tests/e2e/e2e.test.js
@@ -72,9 +72,7 @@ const REPOSITORY_DATA = {
   isPrivate: false,
   isArchived: false,
   isTemplate: false,
-  stargazers: {
-    totalCount: 1,
-  },
+  stargazerCount: 1,
   description: "Simple cra test repo.",
   primaryLanguage: {
     color: "#f1e05a",

--- a/tests/fetchRepo.test.js
+++ b/tests/fetchRepo.test.js
@@ -7,7 +7,7 @@ import { fetchRepo } from "../src/fetchers/repo.js";
 const data_repo = {
   repository: {
     name: "convoychat",
-    stargazers: { totalCount: 38000 },
+    stargazerCount: 38000,
     description: "Help us take over the world! React + TS + GraphQL Chat App",
     primaryLanguage: {
       color: "#2b7489",
@@ -46,7 +46,7 @@ describe("Test fetchRepo", () => {
 
     expect(repo).toStrictEqual({
       ...data_repo.repository,
-      starCount: data_repo.repository.stargazers.totalCount,
+      starCount: data_repo.repository.stargazerCount,
     });
   });
 
@@ -56,7 +56,7 @@ describe("Test fetchRepo", () => {
     let repo = await fetchRepo("anuraghazra", "convoychat");
     expect(repo).toStrictEqual({
       ...data_repo.repository,
-      starCount: data_repo.repository.stargazers.totalCount,
+      starCount: data_repo.repository.stargazerCount,
     });
   });
 

--- a/tests/fetchStats.test.js
+++ b/tests/fetchStats.test.js
@@ -27,9 +27,9 @@ const data_stats = {
       repositories: {
         totalCount: 5,
         nodes: [
-          { name: "test-repo-1", stargazers: { totalCount: 100 } },
-          { name: "test-repo-2", stargazers: { totalCount: 100 } },
-          { name: "test-repo-3", stargazers: { totalCount: 100 } },
+          { name: "test-repo-1", stargazerCount: 100 },
+          { name: "test-repo-2", stargazerCount: 100 },
+          { name: "test-repo-3", stargazerCount: 100 },
         ],
         pageInfo: {
           hasNextPage: true,
@@ -58,8 +58,8 @@ const data_repo = {
     user: {
       repositories: {
         nodes: [
-          { name: "test-repo-4", stargazers: { totalCount: 50 } },
-          { name: "test-repo-5", stargazers: { totalCount: 50 } },
+          { name: "test-repo-4", stargazerCount: 50 },
+          { name: "test-repo-5", stargazerCount: 50 },
         ],
         pageInfo: {
           hasNextPage: false,
@@ -75,11 +75,11 @@ const data_repo_zero_stars = {
     user: {
       repositories: {
         nodes: [
-          { name: "test-repo-1", stargazers: { totalCount: 100 } },
-          { name: "test-repo-2", stargazers: { totalCount: 100 } },
-          { name: "test-repo-3", stargazers: { totalCount: 100 } },
-          { name: "test-repo-4", stargazers: { totalCount: 0 } },
-          { name: "test-repo-5", stargazers: { totalCount: 0 } },
+          { name: "test-repo-1", stargazerCount: 100 },
+          { name: "test-repo-2", stargazerCount: 100 },
+          { name: "test-repo-3", stargazerCount: 100 },
+          { name: "test-repo-4", stargazerCount: 0 },
+          { name: "test-repo-5", stargazerCount: 0 },
         ],
         pageInfo: {
           hasNextPage: true,

--- a/tests/pin.test.js
+++ b/tests/pin.test.js
@@ -13,9 +13,7 @@ const data_repo = {
   repository: {
     username: "anuraghazra",
     name: "convoychat",
-    stargazers: {
-      totalCount: 38000,
-    },
+    stargazerCount: 38000,
     description: "Help us take over the world! React + TS + GraphQL Chat App",
     primaryLanguage: {
       color: "#2b7489",
@@ -61,7 +59,7 @@ describe("Test /api/pin", () => {
       // @ts-ignore
       renderRepoCard({
         ...data_repo.repository,
-        starCount: data_repo.repository.stargazers.totalCount,
+        starCount: data_repo.repository.stargazerCount,
       }),
     );
   });
@@ -92,7 +90,7 @@ describe("Test /api/pin", () => {
         // @ts-ignore
         {
           ...data_repo.repository,
-          starCount: data_repo.repository.stargazers.totalCount,
+          starCount: data_repo.repository.stargazerCount,
         },
         { ...req.query },
       ),


### PR DESCRIPTION
Replaces repository stargazers { totalCount } GraphQL selections with the scalar stargazerCount to avoid GitHub GraphQL FORBIDDEN errors on stargazers connections.

Updates runtime reads, fetcher types, mocks, and related tests.

Tests:
- npm test -- --runTestsByPath tests/fetchStats.test.js tests/fetchRepo.test.js tests/api.test.js tests/pin.test.js